### PR TITLE
ts(vm): compute delta locally and drop Host.diff

### DIFF
--- a/packages/tf-lang-l0-ts/src/host/memory.ts
+++ b/packages/tf-lang-l0-ts/src/host/memory.ts
@@ -1,19 +1,10 @@
 import type { Host } from '../vm/index.js';
-import type { Value } from '../model/index.js';
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  try { return JSON.stringify(a) === JSON.stringify(b); } catch { return false; }
-}
 
 export const DummyHost: Host = {
   lens_project: async (state, region) => ({ region, state }),
   lens_merge: async (state, _region, sub) => ({ orig: state, sub }),
   snapshot_make: async (state) => state,
   snapshot_id: async (snap) => `id:${JSON.stringify(snap)}`,
-  diff: async (a, b) => {
-    if (deepEqual(a, b)) return null;
-    return { replace: b };
-  },
   diff_apply: async (state, delta) => {
     if (delta == null) return state;                 // identity
     if (delta && typeof delta === 'object' && 'replace' in delta) return (delta as any).replace;

--- a/packages/tf-lang-l0-ts/src/vm/interpreter.ts
+++ b/packages/tf-lang-l0-ts/src/vm/interpreter.ts
@@ -87,8 +87,12 @@ export class VM {
     }
 
     const finalState = regs[0];
-    const delta = await this.host.diff(initialState, finalState);
-    return delta ?? null;
+    // Compute delta locally to mirror Rust VM:
+    // identity => null; otherwise full replace
+    if (JSON.stringify(initialState) === JSON.stringify(finalState)) {
+      return null;
+    }
+    return { replace: finalState };
   }
 }
 

--- a/packages/tf-lang-l0-ts/src/vm/opcode.ts
+++ b/packages/tf-lang-l0-ts/src/vm/opcode.ts
@@ -7,8 +7,6 @@ export interface Host {
 
   snapshot_make(state: Value): Value | Promise<Value>;
   snapshot_id(snapshot: Value): string | Promise<string>;
-
-  diff(a: Value, b: Value): Value | null | Promise<Value | null>;
   diff_apply(state: Value, delta: Value): Value | Promise<Value>;
   diff_invert(delta: Value): Value | Promise<Value>;
 


### PR DESCRIPTION
## Summary
- compute delta in TypeScript VM without host diff, matching Rust runtime
- remove diff from Host interface and memory host implementation

## Testing
- `pnpm -C packages/tf-lang-l0-ts build` (fails: TS6059 rootDir error)
- `pnpm -C packages/tf-lang-l0-ts test` (fails: failed to load ../src/vm/index.js)
- `pnpm -C packages/tf-lang-l0-ts exec vitest run tests/vm.test.ts`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
- `pnpm -C packages/claims-core-ts build`
- `pnpm -C packages/adapter-legal-ts build`
- `node packages/adapter-legal-ts/dist/examples/ro-mini/build.js | diff -u .golden/ro-mini.out.txt -`

------
https://chatgpt.com/codex/tasks/task_e_68c0c9e152f08320ba53d898917d81c4