### PR TITLE
test: add shared conformance vectors

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -200,7 +200,7 @@ Next suggested step:
     - drafted minimal bytecode programs covering core operations
 - Verification:
   - Commands run:
-    - node -e "const fs=require('fs');['tests/vectors/lens_update.json','tests/vectors/snapshot_determinism.json','tests/vectors/journal_record.json','tests/vectors/match_assert.json'].forEach(f=>JSON.parse(fs.readFileSync(f)));console.log('ok');"
+    - node -e "const fs=require('fs'), path=require('path'), dir='tests/vectors'; fs.readdirSync(dir).filter(f => f.endsWith('.json')).forEach(f => JSON.parse(fs.readFileSync(path.join(dir, f)))); console.log('ok');"
   - Results:
     - JSON parsed without error
 - Challenges / Notes:

--- a/tests/vectors/journal_record.json
+++ b/tests/vectors/journal_record.json
@@ -6,9 +6,11 @@
     "instrs": [
       { "op": "CONST", "dst": 0, "value": { "data": 1 } },
       { "op": "SNAP_MAKE", "dst": 1, "state": 0 },
+      { "op": "SNAP_ID", "dst": 1, "snapshot": 1 },
       { "op": "CONST", "dst": 2, "value": 2 },
       { "op": "LENS_MERGE", "dst": 0, "state": 0, "region": "/data", "sub": 2 },
       { "op": "SNAP_MAKE", "dst": 3, "state": 0 },
+      { "op": "SNAP_ID", "dst": 3, "snapshot": 3 },
       { "op": "CONST", "dst": 4, "value": {} },
       { "op": "CONST", "dst": 5, "value": { "replace": { "data": 2 } } },
       { "op": "JOURNAL_REC", "dst": 6, "plan": 4, "delta": 5, "snap0": 1, "snap1": 3, "meta": 4 },

--- a/tests/vectors/match_assert.json
+++ b/tests/vectors/match_assert.json
@@ -4,11 +4,11 @@
     "version": "L0",
     "regs": 6,
     "instrs": [
-      { "op": "CONST", "dst": 0, "value": { } },
+      { "op": "CONST", "dst": 0, "value": {} },
       { "op": "CONST", "dst": 1, "value": 1 },
       { "op": "CONST", "dst": 2, "value": 1 },
-      { "op": "CALL",  "dst": 3, "tf_id": "tf://eq/json@0.1", "args": [1, 2] },
-      { "op": "ASSERT","pred": 3, "msg": "not equal" },
+      { "op": "CALL", "dst": 3, "tf_id": "tf://eq/json@0.1", "args": [1, 2] },
+      { "op": "ASSERT", "pred": 3, "msg": "not equal" },
       { "op": "HALT" }
     ]
   },


### PR DESCRIPTION
## Summary
- convert snapshots to IDs before journaling
- read test vectors dynamically in journal
- normalize match_assert vector formatting

## Testing
- `node -e "const fs=require('fs'), path=require('path'), dir='tests/vectors'; fs.readdirSync(dir).filter(f => f.endsWith('.json')).forEach(f => JSON.parse(fs.readFileSync(path.join(dir, f)))); console.log('ok');"`
- `pnpm -C packages/tf-lang-l0-ts test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a8fb1b6883208491a15b94aef925