### PR TITLE
feat: add guardrail ops and conformance vectors

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -420,3 +420,18 @@ Next suggested step:
     - Rust tests passed and rs-report.json emitted
     - reports match
     - no startsWith('LENS_') found
+## [A7] Guardrail ops baseline
+- Start: 2025-09-11 16:30 UTC
+- End:   2025-09-11 17:15 UTC
+- Lessons consulted:
+  - A1–A6 for canonicalization, vectors, and host parity
+- Changes:
+  - Added TS/Rust implementations for dimension_eq, lens_mod, bounds, delta_bounded, saturate
+  - Extended dummy hosts and exported ops
+  - Added conformance vectors for each op
+- Verification:
+  - `pnpm -C packages/tf-lang-l0-ts test`
+  - `pnpm -C packages/tf-lang-l0-ts vectors`
+  - `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+- Next suggested step:
+  - Review for concept drift and polish

--- a/.codex/LESSONS.md
+++ b/.codex/LESSONS.md
@@ -16,3 +16,4 @@
 - [A4/A5][2025-09-11] Rule: "ptrSet validates indices; pad arrays with objects." Guardrail: ptr:set_pad_arrays
 - [A4/A5][2025-09-11] Rule: "Dummy host parity TS↔Rust (delta NF; plan/delta TF)." Guardrail: host:parity
 - [A4/A5][2025-09-11] Rule: "LENS ops restricted to dst:0; explicit opcode whitelist." Guardrail: lens:dst_only+opcode_whitelist
+- [A7][2025-09-11] Rule: "CALL args must reference registers; literals require prior CONST." Guardrail: ops:call_args_register

--- a/.codex/polish/A7.md
+++ b/.codex/polish/A7.md
@@ -1,0 +1,5 @@
+# Polish Review for A7
+
+- Validate that `bounds` ops treat `min`/`max` only as integers; reject non-integer values in both TS and Rust.
+- `correct/saturate` currently only clamps the value; add a journal note `{field, before, after, reason}` when a correction occurs.
+- `probe/delta_bounded` returns only a boolean; consider returning failure evidence `{index, delta}` to match brief.

--- a/.codex/self-plans/A7.md
+++ b/.codex/self-plans/A7.md
@@ -1,0 +1,43 @@
+# Plan for A7
+
+## Step-by-step
+1. **TypeScript ops**
+   - Create `packages/tf-lang-l0-ts/src/ops/` with files for
+     `dimension_eq.ts`, `lens_mod.ts`, `bounds.ts`,
+     `delta_bounded.ts`, `saturate.ts`, plus `index.ts`.
+   - Each function enforces integer-only semantics and mirrors
+     minimal behaviour described in brief.
+   - Update `packages/tf-lang-l0-ts/src/host/memory.ts` to dispatch
+     new `tf://...@0.1` IDs.
+   - Export ops via `packages/tf-lang-l0-ts/src/index.ts`.
+2. **Rust ops**
+   - Create `packages/tf-lang-l0-rs/src/ops/` with modules
+     `dimension_eq.rs`, `lens_mod.rs`, `bounds.rs`,
+     `delta_bounded.rs`, `saturate.rs`, and `mod.rs` re-exporting them.
+   - Expose module in `packages/tf-lang-l0-rs/src/lib.rs`.
+   - Extend `DummyHost::call_tf` in
+     `packages/tf-lang-l0-rs/tests/vectors.rs` to call these ops.
+3. **Conformance vectors**
+   - Add five JSON vector files under `tests/vectors/` exercising
+     each new TF: `assert_dimension_eq.json`, `lens_mod.json`,
+     `assert_bounds.json`, `probe_delta_bounded.json`,
+     `correct_saturate.json`.
+4. **Journal**
+   - Append short entry to `.codex/JOURNAL.md` noting the addition.
+
+## Test changes
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks & Rollback
+- **Risk:** integer checks or pointer semantics may diverge between
+  TS and Rust.
+- **Risk:** vector expectations may not match effect accounting.
+- **Rollback:** revert new ops and vectors via `git revert` or remove
+  introduced files.
+
+## Definition of Done
+- Ops implemented in TS and Rust and exported.
+- Dummy hosts dispatch new `tf://` IDs.
+- Five vectors added and all test commands above pass.

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -3,5 +3,6 @@ pub mod check;
 pub mod model;
 pub mod util;
 pub mod vm;
+pub mod ops;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/ops/bounds.rs
+++ b/packages/tf-lang-l0-rs/src/ops/bounds.rs
@@ -1,0 +1,31 @@
+use anyhow::{anyhow, bail, Result};
+use serde_json::Value;
+
+pub fn bounds(x: &Value, opts: &Value) -> Result<Value> {
+    let xi = x.as_i64().ok_or_else(|| anyhow!("x must be integer"))?;
+    let min = if let Some(v) = opts.get("min") {
+        Some(v.as_i64().ok_or_else(|| anyhow!("min must be integer"))?)
+    } else {
+        None
+    };
+    let max = if let Some(v) = opts.get("max") {
+        Some(v.as_i64().ok_or_else(|| anyhow!("max must be integer"))?)
+    } else {
+        None
+    };
+    let inclusive = opts
+        .get("inclusive")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    if let Some(m) = min {
+        if (inclusive && xi < m) || (!inclusive && xi <= m) {
+            bail!("min bound {} violated by {}", m, xi);
+        }
+    }
+    if let Some(m) = max {
+        if (inclusive && xi > m) || (!inclusive && xi >= m) {
+            bail!("max bound {} violated by {}", m, xi);
+        }
+    }
+    Ok(Value::Bool(true))
+}

--- a/packages/tf-lang-l0-rs/src/ops/delta_bounded.rs
+++ b/packages/tf-lang-l0-rs/src/ops/delta_bounded.rs
@@ -1,0 +1,19 @@
+use anyhow::{anyhow, bail, Result};
+use serde_json::{json, Value};
+
+pub fn delta_bounded(seq: &Value, bound: &Value) -> Result<Value> {
+    let arr = seq.as_array().ok_or_else(|| anyhow!("delta_bounded expects array"))?;
+    let b = bound.as_i64().ok_or_else(|| anyhow!("bound must be integer"))?;
+    if b < 0 {
+        bail!("bound must be non-negative");
+    }
+    for i in 1..arr.len() {
+        let prev = arr[i - 1].as_i64().ok_or_else(|| anyhow!("seq must contain integers"))?;
+        let cur = arr[i].as_i64().ok_or_else(|| anyhow!("seq must contain integers"))?;
+        let diff = cur - prev;
+        if diff.abs() > b {
+            return Ok(json!({ "index": i, "delta": diff }));
+        }
+    }
+    Ok(Value::Bool(true))
+}

--- a/packages/tf-lang-l0-rs/src/ops/dimension_eq.rs
+++ b/packages/tf-lang-l0-rs/src/ops/dimension_eq.rs
@@ -1,0 +1,15 @@
+use anyhow::{bail, Result};
+use serde_json::Value;
+
+pub fn dimension_eq(a: &Value, b: &Value) -> Result<Value> {
+    match (a, b) {
+        (Value::Array(aa), Value::Array(bb)) => {
+            if aa.len() == bb.len() {
+                Ok(Value::Bool(true))
+            } else {
+                bail!("dimension mismatch: {} vs {}", aa.len(), bb.len());
+            }
+        }
+        _ => bail!("dimension_eq expects arrays"),
+    }
+}

--- a/packages/tf-lang-l0-rs/src/ops/lens_mod.rs
+++ b/packages/tf-lang-l0-rs/src/ops/lens_mod.rs
@@ -1,0 +1,15 @@
+use anyhow::{anyhow, bail, Result};
+use serde_json::Value;
+
+pub fn lens_mod(x: &Value, m: &Value) -> Result<Value> {
+    let xi = x.as_i64().ok_or_else(|| anyhow!("x must be integer"))?;
+    let mi = m.as_i64().ok_or_else(|| anyhow!("mod must be integer"))?;
+    if mi <= 0 {
+        bail!("mod must be >0");
+    }
+    let mut r = xi % mi;
+    if r < 0 {
+        r += mi;
+    }
+    Ok(Value::Number(r.into()))
+}

--- a/packages/tf-lang-l0-rs/src/ops/mod.rs
+++ b/packages/tf-lang-l0-rs/src/ops/mod.rs
@@ -1,0 +1,5 @@
+pub mod dimension_eq;
+pub mod lens_mod;
+pub mod bounds;
+pub mod delta_bounded;
+pub mod saturate;

--- a/packages/tf-lang-l0-rs/src/ops/saturate.rs
+++ b/packages/tf-lang-l0-rs/src/ops/saturate.rs
@@ -1,0 +1,29 @@
+use anyhow::{anyhow, bail, Result};
+use serde_json::{json, Value};
+
+pub fn saturate(x: &Value, min: &Value, max: &Value, field: &Value) -> Result<Value> {
+    let xi = x.as_i64().ok_or_else(|| anyhow!("x must be integer"))?;
+    let minv = min.as_i64().ok_or_else(|| anyhow!("min must be integer"))?;
+    let maxv = max.as_i64().ok_or_else(|| anyhow!("max must be integer"))?;
+    if minv > maxv {
+        bail!("min greater than max");
+    }
+    let mut r = xi;
+    if r < minv {
+        r = minv;
+    }
+    if r > maxv {
+        r = maxv;
+    }
+    let note = if r == xi {
+        Value::Null
+    } else {
+        json!({
+            "field": field.clone(),
+            "before": xi,
+            "after": r,
+            "reason": "saturate"
+        })
+    };
+    Ok(json!({ "tag": "sat", "values": [r, note] }))
+}

--- a/packages/tf-lang-l0-rs/tests/vectors.rs
+++ b/packages/tf-lang-l0-rs/tests/vectors.rs
@@ -10,6 +10,7 @@ use tflang_l0::canon::{blake3_hex, canonical_json_bytes};
 use tflang_l0::model::{Instr, Program};
 use tflang_l0::vm::interpreter::VM;
 use tflang_l0::vm::opcode::Host;
+use tflang_l0::ops;
 
 // Basic host used in unit tests
 struct DummyHost;
@@ -80,6 +81,33 @@ impl Host for DummyHost {
                 } else {
                     Ok(json!({ "replace": rhs }))
                 }
+            }
+            "tf://assert/dimension_eq@0.1" => {
+                let a = args.get(0).cloned().unwrap_or(Value::Null);
+                let b = args.get(1).cloned().unwrap_or(Value::Null);
+                ops::dimension_eq::dimension_eq(&a, &b)
+            }
+            "tf://lens/mod@0.1" => {
+                let x = args.get(0).cloned().unwrap_or(Value::Null);
+                let m = args.get(1).cloned().unwrap_or(Value::Null);
+                ops::lens_mod::lens_mod(&x, &m)
+            }
+            "tf://assert/bounds@0.1" => {
+                let x = args.get(0).cloned().unwrap_or(Value::Null);
+                let o = args.get(1).cloned().unwrap_or(Value::Null);
+                ops::bounds::bounds(&x, &o)
+            }
+            "tf://probe/delta_bounded@0.1" => {
+                let s = args.get(0).cloned().unwrap_or(Value::Null);
+                let b = args.get(1).cloned().unwrap_or(Value::Null);
+                ops::delta_bounded::delta_bounded(&s, &b)
+            }
+            "tf://correct/saturate@0.1" => {
+                let x = args.get(0).cloned().unwrap_or(Value::Null);
+                let min = args.get(1).cloned().unwrap_or(Value::Null);
+                let max = args.get(2).cloned().unwrap_or(Value::Null);
+                let field = args.get(3).cloned().unwrap_or(Value::Null);
+                ops::saturate::saturate(&x, &min, &max, &field)
             }
             _ => Ok(Value::Null),
         }

--- a/packages/tf-lang-l0-ts/src/host/memory.ts
+++ b/packages/tf-lang-l0-ts/src/host/memory.ts
@@ -1,6 +1,7 @@
 import type { Host } from '../vm/index.js';
 import { canonicalJsonBytes } from '../canon/json.js';
 import { blake3hex } from '../canon/hash.js';
+import { dimensionEq, lensMod, bounds, deltaBounded, saturate } from '../ops/index.js';
 
 export const DummyHost: Host = {
   lens_project: async (state, region) => ({ region, state }),
@@ -36,6 +37,21 @@ export const DummyHost: Host = {
       const a = canonicalJsonBytes(args[0]);
       const b = canonicalJsonBytes(args[1]);
       return Buffer.from(a).equals(Buffer.from(b));
+    }
+    if (id === 'tf://assert/dimension_eq@0.1') {
+      return dimensionEq(args[0], args[1]);
+    }
+    if (id === 'tf://lens/mod@0.1') {
+      return lensMod(args[0], args[1]);
+    }
+    if (id === 'tf://assert/bounds@0.1') {
+      return bounds(args[0], args[1]);
+    }
+    if (id === 'tf://probe/delta_bounded@0.1') {
+      return deltaBounded(args[0], args[1]);
+    }
+    if (id === 'tf://correct/saturate@0.1') {
+      return saturate(args[0], args[1], args[2], args[3]);
     }
     return null;
   },

--- a/packages/tf-lang-l0-ts/src/index.ts
+++ b/packages/tf-lang-l0-ts/src/index.ts
@@ -2,5 +2,6 @@
 export * as model from './model/index.js';
 export * as vm from './vm/index.js';
 export * as check from './check/index.js';
+export * as ops from './ops/index.js';
 export { canonicalJsonBytes } from './canon/json.js';
 export { blake3hex } from './canon/hash.js';

--- a/packages/tf-lang-l0-ts/src/ops/bounds.ts
+++ b/packages/tf-lang-l0-ts/src/ops/bounds.ts
@@ -1,0 +1,25 @@
+export function bounds(x: any, opts: any): boolean {
+  if (typeof x !== 'number' || !Number.isInteger(x)) {
+    throw new Error('x must be integer');
+  }
+  const min = opts?.min;
+  if (min !== undefined && (typeof min !== 'number' || !Number.isInteger(min))) {
+    throw new Error('min must be integer');
+  }
+  const max = opts?.max;
+  if (max !== undefined && (typeof max !== 'number' || !Number.isInteger(max))) {
+    throw new Error('max must be integer');
+  }
+  const inclusive = opts?.inclusive !== false;
+  if (typeof min === 'number') {
+    if (inclusive ? x < min : x <= min) {
+      throw new Error(`min bound ${min} violated by ${x}`);
+    }
+  }
+  if (typeof max === 'number') {
+    if (inclusive ? x > max : x >= max) {
+      throw new Error(`max bound ${max} violated by ${x}`);
+    }
+  }
+  return true;
+}

--- a/packages/tf-lang-l0-ts/src/ops/delta_bounded.ts
+++ b/packages/tf-lang-l0-ts/src/ops/delta_bounded.ts
@@ -1,0 +1,18 @@
+export function deltaBounded(seq: any, bound: any): boolean {
+  if (!Array.isArray(seq)) throw new Error('delta_bounded expects array');
+  if (typeof bound !== 'number' || !Number.isInteger(bound) || bound < 0) {
+    throw new Error('bound must be non-negative integer');
+  }
+  for (let i = 1; i < seq.length; i++) {
+    const prev = seq[i - 1];
+    const cur = seq[i];
+    if (!Number.isInteger(prev) || !Number.isInteger(cur)) {
+      throw new Error('seq must contain integers');
+    }
+    const diff = cur - prev;
+    if (Math.abs(diff) > bound) {
+      return { index: i, delta: diff };
+    }
+  }
+  return true;
+}

--- a/packages/tf-lang-l0-ts/src/ops/dimension_eq.ts
+++ b/packages/tf-lang-l0-ts/src/ops/dimension_eq.ts
@@ -1,0 +1,9 @@
+export function dimensionEq(a: any, b: any): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    throw new Error('dimension_eq expects arrays');
+  }
+  if (a.length !== b.length) {
+    throw new Error(`dimension mismatch: ${a.length} vs ${b.length}`);
+  }
+  return true;
+}

--- a/packages/tf-lang-l0-ts/src/ops/index.ts
+++ b/packages/tf-lang-l0-ts/src/ops/index.ts
@@ -1,0 +1,5 @@
+export { dimensionEq } from './dimension_eq.js';
+export { lensMod } from './lens_mod.js';
+export { bounds } from './bounds.js';
+export { deltaBounded } from './delta_bounded.js';
+export { saturate } from './saturate.js';

--- a/packages/tf-lang-l0-ts/src/ops/lens_mod.ts
+++ b/packages/tf-lang-l0-ts/src/ops/lens_mod.ts
@@ -1,0 +1,11 @@
+export function lensMod(x: any, m: any): number {
+  if (typeof x !== 'number' || !Number.isInteger(x)) {
+    throw new Error('x must be integer');
+  }
+  if (typeof m !== 'number' || !Number.isInteger(m)) {
+    throw new Error('mod must be integer');
+  }
+  if (m <= 0) throw new Error('mod must be >0');
+  const r = ((x % m) + m) % m;
+  return r;
+}

--- a/packages/tf-lang-l0-ts/src/ops/saturate.ts
+++ b/packages/tf-lang-l0-ts/src/ops/saturate.ts
@@ -1,0 +1,17 @@
+export function saturate(x: any, min: any, max: any, field = '') {
+  if (typeof x !== 'number' || !Number.isInteger(x)) {
+    throw new Error('x must be integer');
+  }
+  if (typeof min !== 'number' || !Number.isInteger(min)) {
+    throw new Error('min must be integer');
+  }
+  if (typeof max !== 'number' || !Number.isInteger(max)) {
+    throw new Error('max must be integer');
+  }
+  if (min > max) throw new Error('min > max');
+  let v = x;
+  if (v < min) v = min;
+  if (v > max) v = max;
+  const journal = v === x ? null : { field, before: x, after: v, reason: 'saturate' };
+  return { tag: 'sat', values: [v, journal] };
+}

--- a/tests/vectors/assert_bounds.json
+++ b/tests/vectors/assert_bounds.json
@@ -1,0 +1,19 @@
+{
+  "name": "assert bounds on integer",
+  "bytecode": {
+    "version": "L0",
+    "regs": 5,
+    "instrs": [
+      { "op": "CONST", "dst": 0, "value": {} },
+      { "op": "CONST", "dst": 1, "value": 5 },
+      { "op": "CONST", "dst": 2, "value": { "min": 0, "max": 10 } },
+      { "op": "CALL", "dst": 3, "tf_id": "tf://assert/bounds@0.1", "args": [1,2] },
+      { "op": "HALT" }
+    ]
+  },
+  "inputs": {},
+  "expected": {
+    "delta": null,
+    "effect": { "read": [], "write": [], "external": ["tf://assert/bounds@0.1"] }
+  }
+}

--- a/tests/vectors/assert_dimension_eq.json
+++ b/tests/vectors/assert_dimension_eq.json
@@ -1,0 +1,19 @@
+{
+  "name": "assert dimension equality",
+  "bytecode": {
+    "version": "L0",
+    "regs": 5,
+    "instrs": [
+      { "op": "CONST", "dst": 0, "value": {} },
+      { "op": "CONST", "dst": 1, "value": [1,2] },
+      { "op": "CONST", "dst": 2, "value": ["a","b"] },
+      { "op": "CALL", "dst": 3, "tf_id": "tf://assert/dimension_eq@0.1", "args": [1,2] },
+      { "op": "HALT" }
+    ]
+  },
+  "inputs": {},
+  "expected": {
+    "delta": null,
+    "effect": { "read": [], "write": [], "external": ["tf://assert/dimension_eq@0.1"] }
+  }
+}

--- a/tests/vectors/correct_saturate.json
+++ b/tests/vectors/correct_saturate.json
@@ -1,0 +1,23 @@
+{
+  "name": "saturate value into bounds",
+  "bytecode": {
+    "version": "L0",
+    "regs": 7,
+    "instrs": [
+      { "op": "CONST", "dst": 0, "value": { "x": 10 } },
+      { "op": "CONST", "dst": 1, "value": 10 },
+      { "op": "CONST", "dst": 2, "value": 0 },
+      { "op": "CONST", "dst": 3, "value": 5 },
+      { "op": "CONST", "dst": 6, "value": "/x" },
+      { "op": "CALL", "dst": 4, "tf_id": "tf://correct/saturate@0.1", "args": [1,2,3,6] },
+      { "op": "UNPACK", "src": 4, "tag": "sat", "dsts": [4,5] },
+      { "op": "LENS_MERGE", "dst": 0, "state": 0, "region": "/x", "sub": 4 },
+      { "op": "HALT" }
+    ]
+  },
+  "inputs": {},
+  "expected": {
+    "delta": { "replace": { "x": 5 } },
+    "effect": { "read": ["/x"], "write": ["/x"], "external": ["tf://correct/saturate@0.1"] }
+  }
+}

--- a/tests/vectors/lens_mod.json
+++ b/tests/vectors/lens_mod.json
@@ -1,0 +1,20 @@
+{
+  "name": "mod lens clamp into range",
+  "bytecode": {
+    "version": "L0",
+    "regs": 5,
+    "instrs": [
+      { "op": "CONST", "dst": 0, "value": { "x": 5 } },
+      { "op": "CONST", "dst": 1, "value": 5 },
+      { "op": "CONST", "dst": 2, "value": 3 },
+      { "op": "CALL", "dst": 3, "tf_id": "tf://lens/mod@0.1", "args": [1,2] },
+      { "op": "LENS_MERGE", "dst": 0, "state": 0, "region": "/x", "sub": 3 },
+      { "op": "HALT" }
+    ]
+  },
+  "inputs": {},
+  "expected": {
+    "delta": { "replace": { "x": 2 } },
+    "effect": { "read": ["/x"], "write": ["/x"], "external": ["tf://lens/mod@0.1"] }
+  }
+}

--- a/tests/vectors/probe_delta_bounded.json
+++ b/tests/vectors/probe_delta_bounded.json
@@ -1,0 +1,19 @@
+{
+  "name": "probe delta bounded sequence",
+  "bytecode": {
+    "version": "L0",
+    "regs": 6,
+    "instrs": [
+      { "op": "CONST", "dst": 0, "value": {} },
+      { "op": "CONST", "dst": 1, "value": [0,1,2] },
+      { "op": "CONST", "dst": 2, "value": 1 },
+      { "op": "CALL", "dst": 3, "tf_id": "tf://probe/delta_bounded@0.1", "args": [1,2] },
+      { "op": "HALT" }
+    ]
+  },
+  "inputs": {},
+  "expected": {
+    "delta": null,
+    "effect": { "read": [], "write": [], "external": ["tf://probe/delta_bounded@0.1"] }
+  }
+}


### PR DESCRIPTION
## Summary
- add baseline guardrail ops (dimension_eq, lens_mod, bounds, delta_bounded, saturate) in TS and Rust
- wire up dummy hosts and export ops
- add conformance vectors for new transforms

## Testing
- `pnpm -C packages/tf-lang-l0-ts test`
- `pnpm -C packages/tf-lang-l0-ts vectors`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c32c519b9c8320815f5a1103be14ee