### PR TITLE
feat: add proof tag interfaces (B1)

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -471,3 +471,22 @@ Next suggested step:
   - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
 - Results:
   - vectors and tests passed
+
+## [B1] Tag interfaces
+- Start: 2025-09-11 22:40 UTC
+- End:   2025-09-11 22:51 UTC
+- Lessons consulted:
+  - A1 – canonicalization baseline
+  - A2 – cross-runtime parity
+  - A3 – vector expectations
+- Changes:
+  - added proof tag interfaces in TS and Rust
+  - re-exported proof modules
+  - added unit tests for tag construction
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts test
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - tests passed
+- Next suggested step:
+  - B2

--- a/.codex/polish/B1.md
+++ b/.codex/polish/B1.md
@@ -1,0 +1,3 @@
+# Polish Suggestions for B1
+
+- Extract `NormalizationTarget` and `TransportOp` type aliases in `tags.ts` to mirror Rust enums and reuse across interfaces.

--- a/.codex/self-plans/B1.md
+++ b/.codex/self-plans/B1.md
@@ -1,0 +1,23 @@
+# B1 Plan
+
+## Steps
+1. TS: create `packages/tf-lang-l0-ts/src/proof/tags.ts` exporting interfaces `Witness`, `Normalization`, `Transport`, `Refutation`, `Conservativity`, and union `ProofTag`.
+2. TS: re-export proof tags from package root.
+3. RS: create `packages/tf-lang-l0-rs/src/proof.rs` defining matching structs/enums.
+4. RS: expose proof module in crate root.
+5. Add unit tests exercising tag constructions in TS and Rust.
+6. Run TS and Rust test suites.
+7. Update `.codex/JOURNAL.md` with B1 entry.
+
+## Tests
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks
+- Misaligned structures between TS and Rust.
+- Tests may fail if new modules not properly exported.
+
+## Definition of Done
+- Proof tag interfaces available in TS and Rust.
+- All tests pass with no runtime behavior changes.
+- Journal updated.

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -3,6 +3,7 @@ pub mod check;
 pub mod model;
 pub mod util;
 pub mod vm;
+pub mod proof;
 pub mod ops;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/proof.rs
+++ b/packages/tf-lang-l0-rs/src/proof.rs
@@ -1,0 +1,37 @@
+use serde::{Serialize, Deserialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DeltaNF {
+    None,
+    Replace { replace: Value },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct EffectNF {
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub external: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum NormalizationTarget {
+    Delta,
+    Effect,
+    State,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TransportOp {
+    LensProj,
+    LensMerge,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProofTag {
+    Witness { delta: DeltaNF, effect: EffectNF },
+    Normalization { target: NormalizationTarget },
+    Transport { op: TransportOp, region: String },
+    Refutation { code: String, msg: Option<String> },
+    Conservativity { callee: String, expected: String, found: String },
+}

--- a/packages/tf-lang-l0-rs/tests/proof.rs
+++ b/packages/tf-lang-l0-rs/tests/proof.rs
@@ -1,0 +1,15 @@
+use tflang_l0::proof::{ProofTag, DeltaNF, EffectNF, NormalizationTarget, TransportOp};
+
+#[test]
+fn constructs_tags() {
+    let w = ProofTag::Witness { delta: DeltaNF::None, effect: EffectNF::default() };
+    let n = ProofTag::Normalization { target: NormalizationTarget::Delta };
+    let t = ProofTag::Transport { op: TransportOp::LensProj, region: "/r".into() };
+    let r = ProofTag::Refutation { code: "E_X".into(), msg: None };
+    let c = ProofTag::Conservativity { callee: "c".into(), expected: "e".into(), found: "f".into() };
+    let kinds = match (&w,&n,&t,&r,&c) {
+        (ProofTag::Witness {..}, ProofTag::Normalization {..}, ProofTag::Transport {..}, ProofTag::Refutation {..}, ProofTag::Conservativity {..}) => 5,
+        _ => 0
+    };
+    assert_eq!(kinds,5);
+}

--- a/packages/tf-lang-l0-ts/src/index.ts
+++ b/packages/tf-lang-l0-ts/src/index.ts
@@ -5,3 +5,4 @@ export * as check from './check/index.js';
 export { canonicalJsonBytes } from './canon/json.js';
 export { blake3hex } from './canon/hash.js';
 export * as ops from './ops/index.js';
+export * as proof from './proof/tags.js';

--- a/packages/tf-lang-l0-ts/src/proof/tags.ts
+++ b/packages/tf-lang-l0-ts/src/proof/tags.ts
@@ -1,0 +1,13 @@
+export type DeltaNF = null | { replace: unknown };
+export interface EffectNF { read: string[]; write: string[]; external: string[] }
+
+export type NormalizationTarget = 'delta' | 'effect' | 'state';
+export type TransportOp = 'LENS_PROJ' | 'LENS_MERGE';
+
+export interface Witness { kind: 'Witness'; delta: DeltaNF; effect: EffectNF }
+export interface Normalization { kind: 'Normalization'; target: NormalizationTarget }
+export interface Transport { kind: 'Transport'; op: TransportOp; region: string }
+export interface Refutation { kind: 'Refutation'; code: string; msg?: string }
+export interface Conservativity { kind: 'Conservativity'; callee: string; expected: string; found: string }
+
+export type ProofTag = Witness | Normalization | Transport | Refutation | Conservativity;

--- a/packages/tf-lang-l0-ts/tests/proof.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { proof } from '../src/index.js';
+
+describe('proof tags', () => {
+  it('constructs tag variants', () => {
+    const w: proof.Witness = { kind: 'Witness', delta: null, effect: { read: [], write: [], external: [] } };
+    const n: proof.Normalization = { kind: 'Normalization', target: 'delta' };
+    const t: proof.Transport = { kind: 'Transport', op: 'LENS_PROJ', region: '/r' };
+    const r: proof.Refutation = { kind: 'Refutation', code: 'E_X' };
+    const c: proof.Conservativity = { kind: 'Conservativity', callee: 'c', expected: 'e', found: 'f' };
+    const kinds = [w, n, t, r, c].map(x => x.kind);
+    expect(kinds).toEqual(['Witness', 'Normalization', 'Transport', 'Refutation', 'Conservativity']);
+  });
+});


### PR DESCRIPTION
## Summary
- define proof tag interfaces and union in TypeScript
- add Rust equivalents and expose proof module
- add tests covering tag construction in both runtimes

## Testing
- `pnpm -C packages/tf-lang-l0-ts test`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c351ab0d748320ae070469b98aa65c