### PR TITLE
feat: add proof tag interfaces (B1)

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -471,3 +471,20 @@ Next suggested step:
   - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
 - Results:
   - vectors and tests passed
+## [B1] Proof tags
+- Start: 2025-09-11 22:40 UTC
+- End:   2025-09-11 22:55 UTC
+- Lessons consulted:
+  - A1–A7
+- Changes:
+  - Added proof tag interfaces in TS and Rust with exports
+  - Added unit tests demonstrating tag construction
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts build
+  - pnpm -C packages/tf-lang-l0-ts test
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml --tests
+- Results:
+  - build succeeded
+  - tests passed
+- Next suggested step:
+  - B2

--- a/.codex/LESSONS.md
+++ b/.codex/LESSONS.md
@@ -17,3 +17,4 @@
 - [A4/A5][2025-09-11] Rule: "Dummy host parity TS↔Rust (delta NF; plan/delta TF)." Guardrail: host:parity
 - [A4/A5][2025-09-11] Rule: "LENS ops restricted to dst:0; explicit opcode whitelist." Guardrail: lens:dst_only+opcode_whitelist
 - [A7][2025-09-11] Rule: "Guardrail ops must propagate errors; hosts must not swallow them." Guardrail: host:propagate_guardrail_errors
+- [B1][2025-09-11] Rule: "Proof tags dev-only and excluded from hashes." Guardrail: proof:dev_only_no_hash

--- a/.codex/polish/B1.md
+++ b/.codex/polish/B1.md
@@ -1,0 +1,3 @@
+# Polish for B1
+
+- Mirror Rust coverage by adding a TS test constructing a Transport tag.

--- a/.codex/self-plans/B1.md
+++ b/.codex/self-plans/B1.md
@@ -1,0 +1,22 @@
+# Plan for B1
+
+## Steps
+- Define proof tag interfaces in TS under `src/proof/tags.ts`.
+- Re-export tags via `src/proof/index.ts` and package root.
+- Mirror structures in Rust at `src/proof.rs` and expose module.
+- Add lightweight tests in TS and Rust that instantiate a sample tag.
+- Update journal and lessons if a general rule emerges.
+
+## Tests
+- `pnpm -C packages/tf-lang-l0-ts build`
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml --tests`
+
+## Risks
+- Type mismatches between TS and Rust structures.
+- Unused code or exports causing lints to fail.
+
+## Definition of Done
+- New tag interfaces compile in both runtimes.
+- Existing tests stay green and new tests pass.
+- Journal updated; lessons appended if needed.

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -4,5 +4,6 @@ pub mod model;
 pub mod util;
 pub mod vm;
 pub mod ops;
+pub mod proof;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/proof.rs
+++ b/packages/tf-lang-l0-rs/src/proof.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind")]
+pub enum ProofTag {
+    Witness { delta: Value, effect: Value },
+    Normalization { target: NormalizationTarget },
+    Transport { op: TransportOp, region: String },
+    Refutation { code: String, msg: Option<String> },
+    Conservativity { callee: String, expected: String, found: String },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum NormalizationTarget {
+    Delta,
+    Effect,
+    State,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TransportOp {
+    #[serde(rename = "LENS_PROJ")]
+    LensProj,
+    #[serde(rename = "LENS_MERGE")]
+    LensMerge,
+}

--- a/packages/tf-lang-l0-rs/tests/proof.rs
+++ b/packages/tf-lang-l0-rs/tests/proof.rs
@@ -1,0 +1,19 @@
+use tflang_l0::proof::{ProofTag, TransportOp};
+
+#[test]
+fn constructs_refutation_tag() {
+    let t = ProofTag::Refutation { code: "E".into(), msg: Some("x".into()) };
+    match t {
+        ProofTag::Refutation { code, .. } => assert_eq!(code, "E"),
+        _ => panic!("wrong tag"),
+    }
+}
+
+#[test]
+fn transports_region() {
+    let t = ProofTag::Transport { op: TransportOp::LensProj, region: "r0".into() };
+    match t {
+        ProofTag::Transport { region, .. } => assert_eq!(region, "r0"),
+        _ => panic!("wrong tag"),
+    }
+}

--- a/packages/tf-lang-l0-ts/src/index.ts
+++ b/packages/tf-lang-l0-ts/src/index.ts
@@ -5,3 +5,4 @@ export * as check from './check/index.js';
 export { canonicalJsonBytes } from './canon/json.js';
 export { blake3hex } from './canon/hash.js';
 export * as ops from './ops/index.js';
+export * as proof from './proof/index.js';

--- a/packages/tf-lang-l0-ts/src/proof/index.ts
+++ b/packages/tf-lang-l0-ts/src/proof/index.ts
@@ -1,0 +1,1 @@
+export * from './tags.js';

--- a/packages/tf-lang-l0-ts/src/proof/tags.ts
+++ b/packages/tf-lang-l0-ts/src/proof/tags.ts
@@ -1,0 +1,36 @@
+export interface Witness {
+  kind: 'Witness';
+  delta: unknown;
+  effect: unknown;
+}
+
+export interface Normalization {
+  kind: 'Normalization';
+  target: 'delta' | 'effect' | 'state';
+}
+
+export interface Transport {
+  kind: 'Transport';
+  op: 'LENS_PROJ' | 'LENS_MERGE';
+  region: string;
+}
+
+export interface Refutation {
+  kind: 'Refutation';
+  code: string;
+  msg?: string;
+}
+
+export interface Conservativity {
+  kind: 'Conservativity';
+  callee: string;
+  expected: string;
+  found: string;
+}
+
+export type ProofTag =
+  | Witness
+  | Normalization
+  | Transport
+  | Refutation
+  | Conservativity;

--- a/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { ProofTag } from '../src/proof/tags.js';
+
+describe('proof tags', () => {
+  it('constructs refutation tag', () => {
+    const tag: ProofTag = { kind: 'Refutation', code: 'E', msg: 'x' };
+    expect(tag.kind).toBe('Refutation');
+  });
+
+  it('constructs transport tag', () => {
+    const tag: ProofTag = { kind: 'Transport', op: 'LENS_PROJ', region: 'r0' };
+    expect(tag.op).toBe('LENS_PROJ');
+  });
+});


### PR DESCRIPTION
## Summary
- define proof tag payload shapes in TypeScript and export via package root
- mirror proof tag structures in Rust and expose new module
- add unit tests covering tag construction in both runtimes

## Testing
- `pnpm -C packages/tf-lang-l0-ts build`
- `pnpm -C packages/tf-lang-l0-ts test`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml --tests`


------
https://chatgpt.com/codex/tasks/task_e_68c351ab0d748320ae070469b98aa65c