### PR TITLE
feat: add proof tag interfaces (B1)

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -471,3 +471,21 @@ Next suggested step:
   - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
 - Results:
   - vectors and tests passed
+
+## [B1] Tag interfaces
+- Start: 2025-09-11 19:00 UTC
+- End:   2025-09-11 19:20 UTC
+- Lessons consulted:
+  - A1–A3
+- Changes:
+  - Added TS and Rust proof tag type definitions and exports
+  - Added compilation tests verifying tag construction
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts build
+  - pnpm -C packages/tf-lang-l0-ts test
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - build succeeded
+  - tests passed
+- Next suggested step:
+  - B2

--- a/.codex/polish/B1.md
+++ b/.codex/polish/B1.md
@@ -1,0 +1,3 @@
+# Polish Suggestions for B1
+
+- Derive `Serialize` and `Deserialize` for Rust proof tag enums to enable JSON encoding parity with TypeScript shapes.

--- a/.codex/self-plans/B1.md
+++ b/.codex/self-plans/B1.md
@@ -1,0 +1,29 @@
+# Plan for Task B1
+
+## Steps
+1. **Define TypeScript proof tags**
+   - Create `packages/tf-lang-l0-ts/src/proof/tags.ts` exporting tag payload shapes: `Witness`, `Normalization`, `Transport`, `Refutation`, `Conservativity`.
+   - Export a `ProofTag` union and re-export tags from the package root.
+2. **Define Rust proof tags**
+   - Add `packages/tf-lang-l0-rs/src/proof.rs` with equivalent enum variants and supporting enums for normalization targets and transport ops.
+   - Expose the module via `packages/tf-lang-l0-rs/src/lib.rs`.
+3. **Add compilation tests**
+   - TS: write `packages/tf-lang-l0-ts/tests/proof.tags.test.ts` instantiating each tag shape.
+   - Rust: add `packages/tf-lang-l0-rs/tests/proof.rs` constructing each enum variant.
+4. **Documentation**
+   - Append brief `[B1]` entry to `.codex/JOURNAL.md` summarizing the addition.
+
+## Test Changes
+- `pnpm -C packages/tf-lang-l0-ts build`
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks & Rollback
+- **Type mismatches:** TS and Rust tag structures may diverge; ensure field names and discriminants match.
+- **Unused exports:** Adding new exports could affect build; confirm tree-shaking keeps runtime unaffected.
+- Rollback by removing newly added files and exports if compilation fails.
+
+## Definition of Done
+- Tag structures exist in both runtimes and are exported.
+- Tests compile and pass in TS and Rust.
+- Journal updated.

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -4,5 +4,6 @@ pub mod model;
 pub mod util;
 pub mod vm;
 pub mod ops;
+pub mod proof;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/proof.rs
+++ b/packages/tf-lang-l0-rs/src/proof.rs
@@ -1,0 +1,24 @@
+use crate::model::{Effects, Value};
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProofTag {
+    Witness { delta: Value, effect: Effects },
+    Normalization { target: NormalizationTarget },
+    Transport { op: TransportOp, region: String },
+    Refutation { code: String, msg: Option<String> },
+    Conservativity { callee: String, expected: String, found: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NormalizationTarget {
+    Delta,
+    Effect,
+    State,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransportOp {
+    LensProj,
+    LensMerge,
+}

--- a/packages/tf-lang-l0-rs/tests/proof.rs
+++ b/packages/tf-lang-l0-rs/tests/proof.rs
@@ -1,0 +1,17 @@
+use tflang_l0::proof::{ProofTag, NormalizationTarget, TransportOp};
+use tflang_l0::model::Effects;
+
+#[test]
+fn constructs_tags() {
+    let w = ProofTag::Witness { delta: serde_json::Value::Null, effect: Effects::default() };
+    let n = ProofTag::Normalization { target: NormalizationTarget::Delta };
+    let t = ProofTag::Transport { op: TransportOp::LensProj, region: "r1".to_string() };
+    let r = ProofTag::Refutation { code: "X".to_string(), msg: Some("oops".to_string()) };
+    let c = ProofTag::Conservativity {
+        callee: "f".to_string(),
+        expected: "a".to_string(),
+        found: "b".to_string(),
+    };
+    let tags = vec![w, n, t, r, c];
+    assert_eq!(tags.len(), 5);
+}

--- a/packages/tf-lang-l0-ts/src/index.ts
+++ b/packages/tf-lang-l0-ts/src/index.ts
@@ -5,3 +5,11 @@ export * as check from './check/index.js';
 export { canonicalJsonBytes } from './canon/json.js';
 export { blake3hex } from './canon/hash.js';
 export * as ops from './ops/index.js';
+export type {
+  ProofTag,
+  Witness,
+  Normalization,
+  Transport,
+  Refutation,
+  Conservativity,
+} from './proof/tags.js';

--- a/packages/tf-lang-l0-ts/src/proof/tags.ts
+++ b/packages/tf-lang-l0-ts/src/proof/tags.ts
@@ -1,0 +1,38 @@
+import type { Effects, Value } from '../model/types.js';
+
+export interface Witness {
+  kind: 'Witness';
+  delta: Value;
+  effect: Effects;
+}
+
+export interface Normalization {
+  kind: 'Normalization';
+  target: 'delta' | 'effect' | 'state';
+}
+
+export interface Transport {
+  kind: 'Transport';
+  op: 'LENS_PROJ' | 'LENS_MERGE';
+  region: string;
+}
+
+export interface Refutation {
+  kind: 'Refutation';
+  code: string;
+  msg?: string;
+}
+
+export interface Conservativity {
+  kind: 'Conservativity';
+  callee: string;
+  expected: string;
+  found: string;
+}
+
+export type ProofTag =
+  | Witness
+  | Normalization
+  | Transport
+  | Refutation
+  | Conservativity;

--- a/packages/tf-lang-l0-ts/tests/proof.tags.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof.tags.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { Effects } from '../src/model/types.js';
+import type {
+  Witness,
+  Normalization,
+  Transport,
+  Refutation,
+  Conservativity,
+  ProofTag,
+} from '../src/index.js';
+
+describe('proof tags', () => {
+  it('constructs tag shapes', () => {
+    const w: Witness = { kind: 'Witness', delta: null, effect: new Effects() };
+    const n: Normalization = { kind: 'Normalization', target: 'delta' };
+    const t: Transport = { kind: 'Transport', op: 'LENS_PROJ', region: 'r1' };
+    const r: Refutation = { kind: 'Refutation', code: 'X', msg: 'oops' };
+    const c: Conservativity = {
+      kind: 'Conservativity',
+      callee: 'f',
+      expected: 'a',
+      found: 'b',
+    };
+    const tags: ProofTag[] = [w, n, t, r, c];
+    expect(tags).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary
- define TypeScript proof tag shapes and export from kernel
- mirror proof tag enum structures in Rust
- add compilation tests and derive serde traits for future JSON support

## Testing
- `pnpm -C packages/tf-lang-l0-ts build`
- `pnpm -C packages/tf-lang-l0-ts test`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c351ab0d748320ae070469b98aa65c