### PR TITLE
feat: emit proof tags in dev mode

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -500,3 +500,17 @@ Next suggested step:
   - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
 - Results:
   - tests and vectors passed
+## [B2] Minimal proof tag emissions
+- Start: 2025-09-11 23:05 UTC
+- End:   2025-09-11 23:25 UTC
+- Changes:
+  - added DEV_PROOFS-gated tag sink and VM emissions in TS and Rust
+  - covered transport, witness, refutation, and conservativity tags with tests
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts test
+  - pnpm -C packages/tf-lang-l0-ts vectors
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - tests and vectors passed
+- Next suggested step:
+  - none

--- a/.codex/LESSONS.md
+++ b/.codex/LESSONS.md
@@ -18,3 +18,4 @@
 - [A4/A5][2025-09-11] Rule: "LENS ops restricted to dst:0; explicit opcode whitelist." Guardrail: lens:dst_only+opcode_whitelist
 - [A7][2025-09-11] Rule: "Guardrail ops must propagate errors; hosts must not swallow them." Guardrail: host:propagate_guardrail_errors
 - [B1][2025-09-11] Rule: "Proof tags are inert and excluded from hashes." Guardrail: proof:tag_inert
+- [B2][2025-09-11] Rule: "Proof tags emit only when DEV_PROOFS=1." Guardrail: proof:dev_flag

--- a/.codex/polish/B2.md
+++ b/.codex/polish/B2.md
@@ -1,0 +1,3 @@
+# Polish for B2
+- Re-export proof sink helpers from `packages/tf-lang-l0-ts/src/proof/tags.ts` or `index.ts` so downstream code can access emit/take via the package root.
+- In Rust VM conservativity tag, use `e.to_string()` instead of `format!("{e}")` for simplicity.

--- a/.codex/self-plans/B2.md
+++ b/.codex/self-plans/B2.md
@@ -1,0 +1,29 @@
+# Plan for B2
+
+## Steps
+1. Add proof tag sink to TS and Rust runtime modules that collects tags only when `DEV_PROOFS=1`.
+2. Emit proof tags from VM interpreters:
+   - Witness + Normalization at run end using final delta/effect.
+   - Transport on `LENS_PROJ`/`LENS_MERGE`.
+   - Refutation before `ASSERT` failure.
+   - Conservativity when `CALL` boundary errors.
+3. Expose helper to retrieve and clear collected tags for tests.
+4. Write unit tests in TS and Rust verifying:
+   - Tags appear with `DEV_PROOFS=1` and include witness, transport, refutation, and conservativity cases.
+   - No tags emitted when flag unset.
+5. Update LESSONS and append to JOURNAL.
+
+## Tests
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks
+- Global sinks causing cross-test contamination if not cleared.
+- Environment gating logic may differ across runtimes.
+- Error shapes for conservativity may be oversimplified.
+
+## Definition of Done
+- VM emits specified proof tags only when `DEV_PROOFS=1`.
+- Unit tests cover presence/absence and error cases for TS and Rust.
+- LESSONS and JOURNAL updated, working tree clean.

--- a/packages/tf-lang-l0-rs/Cargo.lock
+++ b/packages/tf-lang-l0-rs/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +174,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "once_cell",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/packages/tf-lang-l0-rs/Cargo.toml
+++ b/packages/tf-lang-l0-rs/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 blake3 = "1.5"
+once_cell = "1"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/packages/tf-lang-l0-rs/src/proof.rs
+++ b/packages/tf-lang-l0-rs/src/proof.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Replace {
@@ -41,4 +43,16 @@ pub enum ProofTag {
     Transport { op: TransportOp, region: String },
     Refutation { code: String, msg: Option<String> },
     Conservativity { callee: String, expected: String, found: String },
+}
+
+static TAGS: Lazy<Mutex<Vec<ProofTag>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+pub fn emit(tag: ProofTag) {
+    if std::env::var("DEV_PROOFS").ok().as_deref() == Some("1") {
+        TAGS.lock().unwrap().push(tag);
+    }
+}
+
+pub fn take() -> Vec<ProofTag> {
+    TAGS.lock().unwrap().drain(..).collect()
 }

--- a/packages/tf-lang-l0-rs/tests/proof.rs
+++ b/packages/tf-lang-l0-rs/tests/proof.rs
@@ -1,5 +1,11 @@
 use serde_json::{json, Value};
-use tflang_l0::proof::{Delta, Effect, NormalizationTarget, Replace, ProofTag, TransportOp};
+use tflang_l0::proof::{self, Delta, Effect, NormalizationTarget, Replace, ProofTag, TransportOp};
+use tflang_l0::vm::interpreter::VM;
+use tflang_l0::vm::opcode::Host;
+use tflang_l0::model::bytecode::{Program, Instr};
+use tflang_l0::model::{World, JournalEntry};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
 
 #[test]
 fn proof_tag_shapes() {
@@ -25,4 +31,89 @@ fn serde_roundtrip_normalization() {
     let n = ProofTag::Normalization { target: NormalizationTarget::Delta };
     let v = serde_json::to_value(&n).unwrap();
     assert_eq!(v, json!({"kind":"Normalization","target":"delta"}));
+}
+
+struct StubHost;
+
+impl Host for StubHost {
+    fn lens_project(&self, state: &Value, _region: &str) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn lens_merge(&self, state: &Value, _region: &str, _sub: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn snapshot_make(&self, state: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn snapshot_id(&self, _snapshot: &Value) -> anyhow::Result<String> { Ok(String::new()) }
+    fn diff_apply(&self, state: &Value, _delta: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn diff_invert(&self, delta: &Value) -> anyhow::Result<Value> { Ok(delta.clone()) }
+    fn journal_record(&self, _plan: &Value, _delta: &Value, _s0: &str, _s1: &str, _meta: &Value) -> anyhow::Result<JournalEntry> { Ok(JournalEntry(Value::Null)) }
+    fn journal_rewind(&self, _world: &World, _entry: &JournalEntry) -> anyhow::Result<World> { Ok(World(Value::Null)) }
+    fn call_tf(&self, _tf_id: &str, _args: &[Value]) -> anyhow::Result<Value> { Ok(Value::Null) }
+}
+
+struct FailHost;
+
+impl Host for FailHost {
+    fn lens_project(&self, state: &Value, _region: &str) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn lens_merge(&self, state: &Value, _region: &str, _sub: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn snapshot_make(&self, state: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn snapshot_id(&self, _snapshot: &Value) -> anyhow::Result<String> { Ok(String::new()) }
+    fn diff_apply(&self, state: &Value, _delta: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn diff_invert(&self, delta: &Value) -> anyhow::Result<Value> { Ok(delta.clone()) }
+    fn journal_record(&self, _plan: &Value, _delta: &Value, _s0: &str, _s1: &str, _meta: &Value) -> anyhow::Result<JournalEntry> { Ok(JournalEntry(Value::Null)) }
+    fn journal_rewind(&self, _world: &World, _entry: &JournalEntry) -> anyhow::Result<World> { Ok(World(Value::Null)) }
+    fn call_tf(&self, tf_id: &str, _args: &[Value]) -> anyhow::Result<Value> { anyhow::bail!("fail {tf_id}") }
+}
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn emits_tags_with_flag() {
+    let _g = TEST_MUTEX.lock().unwrap();
+    std::env::set_var("DEV_PROOFS", "1");
+    let host = StubHost;
+    let vm = VM { host: &host };
+    let prog = Program { version: "0.1".into(), regs: 2, instrs: vec![
+        Instr::Const { dst: 0, value: json!({}) },
+        Instr::LensProj { dst: 1, state: 0, region: "/r".into() },
+    ]};
+    vm.run(&prog).unwrap();
+    let tags = proof::take();
+    assert!(tags.iter().any(|t| matches!(t, ProofTag::Transport { .. })));
+    assert!(tags.iter().any(|t| matches!(t, ProofTag::Witness { .. })));
+    std::env::remove_var("DEV_PROOFS");
+}
+
+#[test]
+fn no_tags_without_flag() {
+    let _g = TEST_MUTEX.lock().unwrap();
+    std::env::remove_var("DEV_PROOFS");
+    let host = StubHost;
+    let vm = VM { host: &host };
+    let prog = Program { version: "0.1".into(), regs: 1, instrs: vec![
+        Instr::Const { dst: 0, value: Value::Null },
+    ]};
+    vm.run(&prog).unwrap();
+    assert!(proof::take().is_empty());
+}
+
+#[test]
+fn refutation_and_conservativity() {
+    let _g = TEST_MUTEX.lock().unwrap();
+    std::env::set_var("DEV_PROOFS", "1");
+    let host = StubHost;
+    let vm = VM { host: &host };
+    let prog = Program { version: "0.1".into(), regs: 1, instrs: vec![
+        Instr::Const { dst: 0, value: json!(false) },
+        Instr::Assert { pred: 0, msg: "oops".into() },
+    ]};
+    assert!(vm.run(&prog).is_err());
+    let tags = proof::take();
+    assert!(tags.iter().any(|t| matches!(t, ProofTag::Refutation { code, .. } if code == "ASSERT")));
+
+    let fail = FailHost;
+    let vm2 = VM { host: &fail };
+    let prog2 = Program { version: "0.1".into(), regs: 1, instrs: vec![
+        Instr::Call { dst: 0, tf_id: "x".into(), args: vec![] },
+    ]};
+    assert!(vm2.run(&prog2).is_err());
+    let tags2 = proof::take();
+    assert!(tags2.iter().any(|t| matches!(t, ProofTag::Conservativity { callee, .. } if callee == "x")));
+    std::env::remove_var("DEV_PROOFS");
 }

--- a/packages/tf-lang-l0-ts/src/index.ts
+++ b/packages/tf-lang-l0-ts/src/index.ts
@@ -5,4 +5,4 @@ export * as check from './check/index.js';
 export { canonicalJsonBytes } from './canon/json.js';
 export { blake3hex } from './canon/hash.js';
 export * as ops from './ops/index.js';
-export * as proof from './proof/tags.js';
+export * as proof from './proof/index.js';

--- a/packages/tf-lang-l0-ts/src/proof/index.ts
+++ b/packages/tf-lang-l0-ts/src/proof/index.ts
@@ -1,0 +1,2 @@
+export * from './tags.js';
+export * from './sink.js';

--- a/packages/tf-lang-l0-ts/src/proof/sink.ts
+++ b/packages/tf-lang-l0-ts/src/proof/sink.ts
@@ -1,0 +1,13 @@
+import type { ProofTag } from './tags.js';
+
+const tags: ProofTag[] = [];
+
+export function emit(tag: ProofTag): void {
+  if (process.env.DEV_PROOFS === '1') tags.push(tag);
+}
+
+export function take(): ProofTag[] {
+  const out = tags.slice();
+  tags.length = 0;
+  return out;
+}

--- a/packages/tf-lang-l0-ts/src/vm/interpreter.ts
+++ b/packages/tf-lang-l0-ts/src/vm/interpreter.ts
@@ -2,6 +2,7 @@ import type { Program } from '../model/bytecode.js';
 import type { Host } from './opcode.js';
 import type { Value, World, JournalEntry } from '../model/types.js';
 import { canonicalJsonBytes, blake3hex } from '../canon/index.js';
+import { emit } from '../proof/sink.js';
 
 export class VM {
   constructor(public host: Host) {}
@@ -41,8 +42,16 @@ export class VM {
         }
         case 'SNAP_MAKE': regs[ins.dst] = await this.host.snapshot_make(this.get(regs, ins.state)); break;
         case 'SNAP_ID': regs[ins.dst] = await this.host.snapshot_id(this.get(regs, ins.snapshot)); break;
-        case 'LENS_PROJ': regs[ins.dst] = await this.host.lens_project(this.get(regs, ins.state), ins.region); break;
-        case 'LENS_MERGE': regs[ins.dst] = await this.host.lens_merge(this.get(regs, ins.state), ins.region, this.get(regs, ins.sub)); break;
+        case 'LENS_PROJ': {
+          regs[ins.dst] = await this.host.lens_project(this.get(regs, ins.state), ins.region);
+          emit({ kind: 'Transport', op: 'LENS_PROJ', region: ins.region });
+          break;
+        }
+        case 'LENS_MERGE': {
+          regs[ins.dst] = await this.host.lens_merge(this.get(regs, ins.state), ins.region, this.get(regs, ins.sub));
+          emit({ kind: 'Transport', op: 'LENS_MERGE', region: ins.region });
+          break;
+        }
         case 'PLAN_SIM': {
           const res: any = await this.host.call_tf("tf://plan/simulate@0.1", [this.get(regs, ins.world), this.get(regs, ins.plan)]);
           regs[ins.dst_delta] = res?.delta ?? null;
@@ -67,12 +76,21 @@ export class VM {
         }
         case 'CALL': {
           const args = ins.args.map(a => this.get(regs, a));
-          regs[ins.dst] = await this.host.call_tf(ins.tf_id, args);
+          try {
+            regs[ins.dst] = await this.host.call_tf(ins.tf_id, args);
+          } catch (e: any) {
+            const msg = e && typeof e === 'object' && 'message' in e ? String((e as any).message) : String(e);
+            emit({ kind: 'Conservativity', callee: ins.tf_id, expected: '', found: msg });
+            throw e;
+          }
           break;
         }
         case 'ASSERT': {
           const v = this.get(regs, ins.pred);
-          if (v !== true) throw new Error(`ASSERT failed: ${ins.msg}`);
+          if (v !== true) {
+            emit({ kind: 'Refutation', code: 'ASSERT', msg: ins.msg });
+            throw new Error(`ASSERT failed: ${ins.msg}`);
+          }
           break;
         }
         default: {
@@ -92,9 +110,17 @@ export class VM {
     const a = canonicalJsonBytes(initialState);
     const b = canonicalJsonBytes(finalState);
     if (Buffer.from(a).equals(Buffer.from(b))) {
-      return null;
+      const delta = null;
+      emit({ kind: 'Witness', delta, effect: { read: [], write: [], external: [] } });
+      emit({ kind: 'Normalization', target: 'delta' });
+      emit({ kind: 'Normalization', target: 'effect' });
+      return delta;
     }
-    return { replace: finalState };
+    const delta = { replace: finalState };
+    emit({ kind: 'Witness', delta, effect: { read: [], write: [], external: [] } });
+    emit({ kind: 'Normalization', target: 'delta' });
+    emit({ kind: 'Normalization', target: 'effect' });
+    return delta;
   }
 }
 

--- a/packages/tf-lang-l0-ts/tests/dev-proofs.test.ts
+++ b/packages/tf-lang-l0-ts/tests/dev-proofs.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { VM } from '../src/vm/interpreter.js';
+import type { Program } from '../src/model/bytecode.js';
+import type { Host } from '../src/vm/opcode.js';
+import { take } from '../src/proof/sink.js';
+
+function stubHost(overrides: Partial<Host> = {}): Host {
+  return {
+    lens_project: (s) => s,
+    lens_merge: (s) => s,
+    snapshot_make: (s) => s,
+    snapshot_id: () => '',
+    diff_apply: (s) => s,
+    diff_invert: (d) => d,
+    journal_record: () => ({ value: null }),
+    journal_rewind: () => ({ value: null }),
+    call_tf: () => null,
+    ...overrides,
+  } as Host;
+}
+
+describe('dev proofs', () => {
+  it('emits tags when DEV_PROOFS=1', async () => {
+    process.env.DEV_PROOFS = '1';
+    const host = stubHost();
+    const vm = new VM(host);
+    const prog: Program = { regs: 2, instrs: [
+      { op: 'CONST', dst: 0, value: {} },
+      { op: 'LENS_PROJ', dst: 1, state: 0, region: '/r' },
+    ]};
+    await vm.run(prog);
+    const tags = take();
+    expect(tags.some(t => t.kind === 'Transport')).toBe(true);
+    expect(tags.some(t => t.kind === 'Witness')).toBe(true);
+    delete process.env.DEV_PROOFS;
+  });
+
+  it('no tags when DEV_PROOFS unset', async () => {
+    delete process.env.DEV_PROOFS;
+    const host = stubHost();
+    const vm = new VM(host);
+    const prog: Program = { regs: 1, instrs: [{ op: 'CONST', dst: 0, value: null }] };
+    await vm.run(prog);
+    expect(take()).toEqual([]);
+  });
+
+  it('refutation tag on ASSERT failure', async () => {
+    process.env.DEV_PROOFS = '1';
+    const host = stubHost();
+    const vm = new VM(host);
+    const prog: Program = { regs: 1, instrs: [
+      { op: 'CONST', dst: 0, value: false },
+      { op: 'ASSERT', pred: 0, msg: 'oops' },
+    ]};
+    await expect(vm.run(prog)).rejects.toThrow('ASSERT failed');
+    const tags = take();
+    expect(tags.some(t => t.kind === 'Refutation' && t.code === 'ASSERT')).toBe(true);
+    delete process.env.DEV_PROOFS;
+  });
+
+  it('conservativity tag on CALL failure', async () => {
+    process.env.DEV_PROOFS = '1';
+    const host = stubHost({ call_tf: () => { throw new Error('bad'); } });
+    const vm = new VM(host);
+    const prog: Program = { regs: 1, instrs: [ { op: 'CALL', dst: 0, tf_id: 'x', args: [] } ] };
+    await expect(vm.run(prog)).rejects.toThrow('bad');
+    const tags = take();
+    expect(tags.some(t => t.kind === 'Conservativity' && t.callee === 'x')).toBe(true);
+    delete process.env.DEV_PROOFS;
+  });
+});


### PR DESCRIPTION
## Summary
- gate proof tag collection behind DEV_PROOFS and re-export sink utilities
- emit transport, witness, refutation, and conservativity tags from VM interpreters
- test tag emission and absence across TS and Rust runtimes

## Testing
- `pnpm -C packages/tf-lang-l0-ts test`
- `pnpm -C packages/tf-lang-l0-ts vectors`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c38b1dc5e483209ec4185acb1f1f10