### PR TITLE
feat: emit dev proof tags

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -500,3 +500,20 @@ Next suggested step:
   - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
 - Results:
   - tests and vectors passed
+
+## [B2] DEV proof tags
+- Start: 2025-09-12 02:50 UTC
+- End:   2025-09-12 03:00 UTC
+- Lessons consulted:
+  - A1–B1
+- Changes:
+  - gated proof-tag sink in TS and Rust VMs emitting witness, normalization, transport, refutation, and conservativity tags
+  - added tests for tag presence/absence in both runtimes
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts test
+  - pnpm -C packages/tf-lang-l0-ts vectors
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - tests and vectors passed
+- Next suggested step:
+  - C1

--- a/.codex/LESSONS.md
+++ b/.codex/LESSONS.md
@@ -18,3 +18,4 @@
 - [A4/A5][2025-09-11] Rule: "LENS ops restricted to dst:0; explicit opcode whitelist." Guardrail: lens:dst_only+opcode_whitelist
 - [A7][2025-09-11] Rule: "Guardrail ops must propagate errors; hosts must not swallow them." Guardrail: host:propagate_guardrail_errors
 - [B1][2025-09-11] Rule: "Proof tags are inert and excluded from hashes." Guardrail: proof:tag_inert
+- [B2][2025-09-12] Rule: "Emit proof tags only when DEV_PROOFS=1." Guardrail: proof:dev_flag

--- a/.codex/polish/B2.md
+++ b/.codex/polish/B2.md
@@ -1,0 +1,2 @@
+# Polish for Task B2
+- Clear `DEV_PROOFS` after Rust tests to avoid environment bleed.

--- a/.codex/self-plans/B2.md
+++ b/.codex/self-plans/B2.md
@@ -1,0 +1,27 @@
+# Plan for Task B2
+
+## Steps
+1. Add proof-tag emission to TS VM (`packages/tf-lang-l0-ts/src/vm/interpreter.ts`).
+   - Initialize optional `tags` array when `process.env.DEV_PROOFS === '1'`.
+   - Provide `emit` helper and push Witness/Normalization tags after final delta, Transport tags for lens ops, Refutation on failed ASSERT, and Conservativity when `call_tf` returns `null`.
+2. Mirror the same logic in Rust VM (`packages/tf-lang-l0-rs/src/vm/interpreter.rs`).
+   - Use `Option<Vec<ProofTag>>` gated by `std::env::var("DEV_PROOFS") == Ok("1".into())`.
+3. Add tests verifying tag emission and absence.
+   - TS: new tests under `packages/tf-lang-l0-ts/tests` covering witness/transport, refutation, conservativity, and off-by-default.
+   - Rust: analogous tests under `packages/tf-lang-l0-rs/tests`.
+4. Append B2 entry to `.codex/JOURNAL.md`; add lesson if a general rule emerges.
+
+## Test Changes
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks & Rollback
+- Tag emission may alter runtime behavior if not fully gated; ensure tags only stored when flag enabled.
+- Rust env handling may differ across platforms; tests set variable explicitly.
+- Rollback by removing tag-related code and tests.
+
+## Definition of Done
+- TS and Rust VMs emit proof tags only when DEV_PROOFS=1.
+- Tests cover presence/absence and pass alongside existing suite.
+- Journal updated (and lesson added if applicable).

--- a/packages/tf-lang-l0-rs/tests/laws.rs
+++ b/packages/tf-lang-l0-rs/tests/laws.rs
@@ -108,7 +108,7 @@ fn vm_runs_halt_program() -> Result<()> {
         regs: 2,
         instrs: vec![Instr::Halt],
     };
-    let vm = VM { host: &DummyHost };
+    let mut vm = VM::new(&DummyHost);
     let out = vm.run(&prog)?;
     assert_eq!(out, serde_json::Value::Null);
     Ok(())
@@ -143,7 +143,7 @@ fn vm_basic_ops() -> Result<()> {
             Instr::Halt,
         ],
     };
-    let vm = VM { host: &DummyHost };
+    let mut vm = VM::new(&DummyHost);
     let out = vm.run(&prog)?;
     // r0 is returned by our VM.run. It should be untouched Null unless overwritten.
     assert_eq!(out, serde_json::Value::Null);
@@ -237,7 +237,7 @@ fn law_rewind_apply_id_pair_ids_equal() -> Result<()> {
             Instr::Halt,
         ],
     };
-    let vm = VM { host: &DummyHost };
+    let mut vm = VM::new(&DummyHost);
     let out = vm.run(&prog)?;
     let obj = out
         .get("replace")

--- a/packages/tf-lang-l0-rs/tests/proof.rs
+++ b/packages/tf-lang-l0-rs/tests/proof.rs
@@ -1,5 +1,9 @@
 use serde_json::{json, Value};
-use tflang_l0::proof::{Delta, Effect, NormalizationTarget, Replace, ProofTag, TransportOp};
+use tflang_l0::proof::{Delta, Effect, NormalizationTarget, ProofTag, Replace, TransportOp};
+use tflang_l0::vm::interpreter::VM;
+use tflang_l0::vm::opcode::Host;
+use tflang_l0::model::{Instr, Program};
+use anyhow::Result;
 
 #[test]
 fn proof_tag_shapes() {
@@ -25,4 +29,104 @@ fn serde_roundtrip_normalization() {
     let n = ProofTag::Normalization { target: NormalizationTarget::Delta };
     let v = serde_json::to_value(&n).unwrap();
     assert_eq!(v, json!({"kind":"Normalization","target":"delta"}));
+}
+
+struct MiniHost;
+
+impl Host for MiniHost {
+    fn lens_project(&self, state: &Value, region: &str) -> anyhow::Result<Value> {
+        Ok(json!({"region": region, "state": state}))
+    }
+    fn lens_merge(&self, state: &Value, _region: &str, substate: &Value) -> anyhow::Result<Value> {
+        Ok(json!({"orig": state, "sub": substate}))
+    }
+    fn snapshot_make(&self, state: &Value) -> anyhow::Result<Value> { Ok(state.clone()) }
+    fn snapshot_id(&self, _snapshot: &Value) -> anyhow::Result<String> { Ok("id".into()) }
+    fn diff_apply(&self, state: &Value, delta: &Value) -> anyhow::Result<Value> {
+        if let Some(arr) = state.as_array() {
+            if let Some(v) = delta.get("append") {
+                let mut new = arr.clone();
+                new.push(v.clone());
+                return Ok(Value::Array(new));
+            }
+        }
+        Ok(state.clone())
+    }
+    fn diff_invert(&self, delta: &Value) -> anyhow::Result<Value> { Ok(json!({"invert": delta})) }
+    fn journal_record(&self, _plan: &Value, delta: &Value, s0: &str, s1: &str, _meta: &Value) -> anyhow::Result<tflang_l0::model::JournalEntry> {
+        Ok(tflang_l0::model::JournalEntry(json!({"delta": delta, "from": s0, "to": s1})))
+    }
+    fn journal_rewind(&self, world: &tflang_l0::model::World, _entry: &tflang_l0::model::JournalEntry) -> anyhow::Result<tflang_l0::model::World> {
+        Ok(world.clone())
+    }
+    fn call_tf(&self, tf_id: &str, _args: &[Value]) -> anyhow::Result<Value> {
+        if tf_id == "tf://missing@0.1" {
+            Ok(Value::Null)
+        } else {
+            Ok(Value::Null)
+        }
+    }
+}
+
+#[test]
+fn emits_tags_when_enabled() -> Result<()> {
+    std::env::set_var("DEV_PROOFS", "1");
+    let prog = Program {
+        version: "0.1".into(),
+        regs: 3,
+        instrs: vec![
+            Instr::Const { dst: 0, value: json!([]) },
+            Instr::Const { dst: 1, value: json!({"append": 1}) },
+            Instr::DiffApply { dst: 0, state: 0, delta: 1 },
+            Instr::LensProj { dst: 2, state: 0, region: "r".into() },
+            Instr::Halt,
+        ],
+    };
+    let mut vm = VM::new(&MiniHost);
+    vm.run(&prog)?;
+    let tags = vm.tags.unwrap();
+    assert!(tags.iter().any(|t| matches!(t, ProofTag::Witness { .. })));
+    assert!(tags.iter().any(|t| matches!(t, ProofTag::Transport { .. })));
+    assert!(tags.iter().filter(|t| matches!(t, ProofTag::Normalization { .. })).count() > 0);
+    std::env::remove_var("DEV_PROOFS");
+    Ok(())
+}
+
+#[test]
+fn refutation_and_conservativity() -> Result<()> {
+    std::env::set_var("DEV_PROOFS", "1");
+    let prog = Program {
+        version: "0.1".into(),
+        regs: 2,
+        instrs: vec![
+            Instr::Const { dst: 0, value: json!(0) },
+            Instr::Assert { pred: 0, msg: "no".into() },
+        ],
+    };
+    let mut vm = VM::new(&MiniHost);
+    assert!(vm.run(&prog).is_err());
+    let tags = vm.tags.unwrap();
+    assert!(tags.iter().any(|t| matches!(t, ProofTag::Refutation { .. })));
+
+    let prog2 = Program {
+        version: "0.1".into(),
+        regs: 1,
+        instrs: vec![Instr::Call { dst: 0, tf_id: "tf://missing@0.1".into(), args: vec![] }],
+    };
+    let mut vm2 = VM::new(&MiniHost);
+    vm2.run(&prog2)?;
+    let tags2 = vm2.tags.unwrap();
+    assert!(tags2.iter().any(|t| matches!(t, ProofTag::Conservativity { .. })));
+    std::env::remove_var("DEV_PROOFS");
+    Ok(())
+}
+
+#[test]
+fn silent_when_disabled() -> Result<()> {
+    std::env::remove_var("DEV_PROOFS");
+    let prog = Program { version: "0.1".into(), regs: 1, instrs: vec![Instr::Halt] };
+    let mut vm = VM::new(&MiniHost);
+    vm.run(&prog)?;
+    assert!(vm.tags.is_none());
+    Ok(())
 }

--- a/packages/tf-lang-l0-rs/tests/vectors.rs
+++ b/packages/tf-lang-l0-rs/tests/vectors.rs
@@ -423,7 +423,7 @@ fn vectors() -> Result<()> {
         lint_vector(&vec)?;
 
         let host = EffectHost::new(DummyHost);
-        let vm = VM { host: &host };
+        let mut vm = VM::new(&host);
         let run_res = vm.run(&vec.bytecode);
         let (delta, err_msg) = match run_res {
             Ok(d) => (d, None),

--- a/packages/tf-lang-l0-ts/tests/dev-proofs.test.ts
+++ b/packages/tf-lang-l0-ts/tests/dev-proofs.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { VM } from '../src/vm/interpreter.js';
+import { DummyHost } from '../src/host/memory.js';
+import type { Program } from '../src/model/bytecode.js';
+
+afterEach(() => {
+  delete process.env.DEV_PROOFS;
+});
+
+describe('DEV_PROOFS emission', () => {
+  it('emits witness and transport tags', async () => {
+    process.env.DEV_PROOFS = '1';
+    const prog: Program = {
+      version: '0.1',
+      regs: 3,
+      instrs: [
+        { op: 'CONST', dst: 0, value: [] },
+        { op: 'CONST', dst: 1, value: { append: 1 } },
+        { op: 'DIFF_APPLY', dst: 0, state: 0, delta: 1 },
+        { op: 'LENS_PROJ', dst: 2, state: 0, region: 'r' },
+        { op: 'HALT' },
+      ],
+    };
+    const vm = new VM(DummyHost);
+    await vm.run(prog);
+    expect(vm.tags?.some(t => t.kind === 'Witness')).toBe(true);
+    expect(vm.tags?.filter(t => t.kind === 'Normalization').length).toBeGreaterThan(0);
+    expect(vm.tags?.some(t => t.kind === 'Transport' && t.op === 'LENS_PROJ')).toBe(true);
+  });
+
+  it('emits refutation on ASSERT failure', async () => {
+    process.env.DEV_PROOFS = '1';
+    const prog: Program = {
+      version: '0.1',
+      regs: 1,
+      instrs: [
+        { op: 'CONST', dst: 0, value: 0 },
+        { op: 'ASSERT', pred: 0, msg: 'no' },
+      ],
+    };
+    const vm = new VM(DummyHost);
+    await expect(vm.run(prog)).rejects.toThrow();
+    expect(vm.tags?.some(t => t.kind === 'Refutation')).toBe(true);
+  });
+
+  it('emits conservativity on missing call', async () => {
+    process.env.DEV_PROOFS = '1';
+    const prog: Program = {
+      version: '0.1',
+      regs: 1,
+      instrs: [
+        { op: 'CALL', dst: 0, tf_id: 'tf://missing@0.1', args: [] },
+        { op: 'HALT' },
+      ],
+    };
+    const vm = new VM(DummyHost);
+    await vm.run(prog);
+    expect(vm.tags?.some(t => t.kind === 'Conservativity')).toBe(true);
+  });
+
+  it('is silent when DEV_PROOFS unset', async () => {
+    const prog: Program = { version: '0.1', regs: 1, instrs: [ { op: 'HALT' } ] };
+    const vm = new VM(DummyHost);
+    await vm.run(prog);
+    expect(vm.tags).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- gate proof-tag collection behind `DEV_PROOFS` and emit witness, normalization, transport, refutation, and conservativity tags in TS and Rust VMs
- cover proof-tag emission/absence with new unit tests in both runtimes
- document rule about DEV_PROOFS in lessons and journal entry

## Testing
- `pnpm -C packages/tf-lang-l0-ts test`
- `pnpm -C packages/tf-lang-l0-ts vectors`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c38b1dc5e483209ec4185acb1f1f10