### PR TITLE
B2: emit proof tags in dev mode

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -500,3 +500,27 @@ Next suggested step:
   - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
 - Results:
   - tests and vectors passed
+## [B2] Proof tag emission
+- Start: 2025-09-11 23:00 UTC
+- End:   2025-09-11 23:30 UTC
+- Changes:
+  - added DEV_PROOFS-gated proof log in TS and Rust
+  - VMs emit Witness, Normalization, Transport, Refutation, and Conservativity tags
+  - tests cover tag emission toggled by DEV_PROOFS
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts test
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - tests passed
+## [B2-polish] Cache DEV_PROOFS
+- Start: 2025-09-11 23:40 UTC
+- End:   2025-09-11 23:55 UTC
+- Changes:
+  - centralized cached DEV_PROOFS flag in TS and Rust runtimes
+  - scoped env helpers for tests and JSON shape lock
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts test
+  - pnpm -C packages/tf-lang-l0-ts vectors
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - tests and vectors passed

--- a/.codex/LESSONS.md
+++ b/.codex/LESSONS.md
@@ -18,3 +18,5 @@
 - [A4/A5][2025-09-11] Rule: "LENS ops restricted to dst:0; explicit opcode whitelist." Guardrail: lens:dst_only+opcode_whitelist
 - [A7][2025-09-11] Rule: "Guardrail ops must propagate errors; hosts must not swallow them." Guardrail: host:propagate_guardrail_errors
 - [B1][2025-09-11] Rule: "Proof tags are inert and excluded from hashes." Guardrail: proof:tag_inert
+- [B2][2025-09-11] Rule: "Proof tags emitted only when DEV_PROOFS=1." Guardrail: proof:dev_flag
+- [B2-polish][2025-09-11] Rule: "Cache feature flags; tests use scoped env guards." Guardrail: proof:env_cache

--- a/.codex/polish/B2.md
+++ b/.codex/polish/B2.md
@@ -1,0 +1,2 @@
+- TS interpreter: emit normalization tags via loop over ['delta','effect'] to reduce repetition.
+- Rust interpreter: likewise loop emitting Normalization tags for 'delta' and 'effect'.

--- a/.codex/self-plans/B2.md
+++ b/.codex/self-plans/B2.md
@@ -1,0 +1,25 @@
+# Plan for B2
+
+## Steps
+1. Create a proof logging module in TS that collects proof tags when `DEV_PROOFS=1` and expose emit/flush helpers.
+2. Update TS VM interpreter to emit Transport tags for lens ops, Refutation tags on ASSERT failures, Witness and Normalization tags after run, and Conservativity tags on CALL errors.
+3. Export the new proof module and adjust tests to verify tags appear only when `DEV_PROOFS=1`.
+4. Implement analogous proof logging in Rust: global log with `emit` and `flush`, gated by `DEV_PROOFS` env var.
+5. Update Rust VM interpreter to emit tags for lens ops, asserts, calls, and final witness/normalization, mirroring TS behavior.
+6. Add Rust tests ensuring tags are emitted only in dev mode.
+7. Run `pnpm -C packages/tf-lang-l0-ts test` and `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml` to verify.
+8. Update `.codex/JOURNAL.md` with a new B2 entry; add a lesson if a new general rule emerges.
+
+## Tests
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks
+- Environment variable may leak between tests; ensure logs are flushed and variables reset.
+- Synchronizing tag structures across runtimes might be inconsistent.
+- Adding dependency `once_cell` for Rust logging could impact build.
+
+## Definition of Done
+- Proof tags emitted in both TS and Rust VMs only when `DEV_PROOFS=1`.
+- Tests cover presence and absence of tags.
+- Journal updated and repository tests pass.

--- a/packages/tf-lang-l0-rs/Cargo.lock
+++ b/packages/tf-lang-l0-rs/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +174,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "once_cell",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/packages/tf-lang-l0-rs/Cargo.toml
+++ b/packages/tf-lang-l0-rs/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 blake3 = "1.5"
+once_cell = "1"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/packages/tf-lang-l0-rs/src/env.rs
+++ b/packages/tf-lang-l0-rs/src/env.rs
@@ -1,0 +1,25 @@
+use std::sync::{Mutex, OnceLock};
+/// Centralized, cached environment feature flags for the Rust runtime.
+static DEV_PROOFS: OnceLock<Mutex<Option<bool>>> = OnceLock::new();
+
+pub fn dev_proofs_enabled() -> bool {
+    let lock = DEV_PROOFS.get_or_init(|| Mutex::new(None));
+    let mut cache = lock.lock().unwrap();
+    if let Some(v) = *cache {
+        v
+    } else {
+        let v = std::env::var("DEV_PROOFS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        *cache = Some(v);
+        v
+    }
+}
+
+/// TESTS ONLY: clear cached flags
+#[doc(hidden)]
+pub fn __reset_env_cache_for_tests__() {
+    if let Some(lock) = DEV_PROOFS.get() {
+        *lock.lock().unwrap() = None;
+    }
+}

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -5,5 +5,6 @@ pub mod util;
 pub mod vm;
 pub mod ops;
 pub mod proof;
+pub mod env;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/proof.rs
+++ b/packages/tf-lang-l0-rs/src/proof.rs
@@ -42,3 +42,19 @@ pub enum ProofTag {
     Refutation { code: String, msg: Option<String> },
     Conservativity { callee: String, expected: String, found: String },
 }
+
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use crate::env::dev_proofs_enabled;
+
+pub static PROOF_LOG: Lazy<Mutex<Vec<ProofTag>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+pub fn emit(tag: ProofTag) {
+    if dev_proofs_enabled() {
+        PROOF_LOG.lock().unwrap().push(tag);
+    }
+}
+
+pub fn flush() -> Vec<ProofTag> {
+    PROOF_LOG.lock().unwrap().drain(..).collect()
+}

--- a/packages/tf-lang-l0-rs/tests/dev_proofs_flag.rs
+++ b/packages/tf-lang-l0-rs/tests/dev_proofs_flag.rs
@@ -1,0 +1,14 @@
+use tflang_l0::env::{dev_proofs_enabled, __reset_env_cache_for_tests__};
+mod util;
+use util::env::EnvVarGuard;
+
+#[test]
+fn dev_proofs_is_cached() {
+    let _g = EnvVarGuard::set("DEV_PROOFS", "1");
+    assert!(dev_proofs_enabled());
+    drop(_g); // restore
+    // Flip env, but cache should hold until reset
+    let _g2 = EnvVarGuard::unset("DEV_PROOFS");
+    assert!(dev_proofs_enabled());
+    __reset_env_cache_for_tests__();
+}

--- a/packages/tf-lang-l0-rs/tests/proof_dev.rs
+++ b/packages/tf-lang-l0-rs/tests/proof_dev.rs
@@ -1,0 +1,65 @@
+use serde_json::json;
+use tflang_l0::model::{Instr, Program};
+use tflang_l0::vm::interpreter::VM;
+use tflang_l0::vm::opcode::Host;
+use tflang_l0::proof::{flush, ProofTag, TransportOp};
+use tflang_l0::env::__reset_env_cache_for_tests__;
+mod util;
+use util::env::EnvVarGuard;
+
+struct DummyHost;
+
+impl Host for DummyHost {
+    fn lens_project(&self, state: &serde_json::Value, region: &str) -> anyhow::Result<serde_json::Value> {
+        Ok(json!({"region": region, "state": state}))
+    }
+    fn lens_merge(&self, state: &serde_json::Value, _region: &str, substate: &serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        Ok(json!({"orig": state, "sub": substate}))
+    }
+    fn snapshot_make(&self, state: &serde_json::Value) -> anyhow::Result<serde_json::Value> { Ok(state.clone()) }
+    fn snapshot_id(&self, _snapshot: &serde_json::Value) -> anyhow::Result<String> { Ok("id".into()) }
+    fn diff_apply(&self, state: &serde_json::Value, _delta: &serde_json::Value) -> anyhow::Result<serde_json::Value> { Ok(state.clone()) }
+    fn diff_invert(&self, delta: &serde_json::Value) -> anyhow::Result<serde_json::Value> { Ok(delta.clone()) }
+    fn journal_record(&self, _plan: &serde_json::Value, _delta: &serde_json::Value, _s0: &str, _s1: &str, _meta: &serde_json::Value) -> anyhow::Result<tflang_l0::model::JournalEntry> {
+        Ok(tflang_l0::model::JournalEntry(serde_json::Value::Null))
+    }
+    fn journal_rewind(&self, world: &tflang_l0::model::World, _entry: &tflang_l0::model::JournalEntry) -> anyhow::Result<tflang_l0::model::World> {
+        Ok(tflang_l0::model::World(world.0.clone()))
+    }
+    fn call_tf(&self, _tf_id: &str, _args: &[serde_json::Value]) -> anyhow::Result<serde_json::Value> { Ok(serde_json::Value::Null) }
+}
+
+fn sample_prog() -> Program {
+    Program {
+        version: "0.1".into(),
+        regs: 2,
+        instrs: vec![
+            Instr::Const { dst: 0, value: json!({}) },
+            Instr::LensProj { dst: 1, state: 0, region: "r".into() },
+            Instr::Const { dst: 0, value: json!({"x":1}) },
+            Instr::Halt,
+        ],
+    }
+}
+
+#[test]
+fn dev_proofs_toggles_tags() {
+    {
+        let _g = EnvVarGuard::set("DEV_PROOFS", "1");
+        __reset_env_cache_for_tests__();
+        let vm = VM { host: &DummyHost };
+        let _ = vm.run(&sample_prog()).unwrap();
+        let tags = flush();
+        assert!(tags.iter().any(|t| matches!(t, ProofTag::Transport { op: TransportOp::LensProj, .. })));
+        assert!(tags.iter().any(|t| matches!(t, ProofTag::Witness { .. })));
+    }
+
+    {
+        let _g = EnvVarGuard::unset("DEV_PROOFS");
+        __reset_env_cache_for_tests__();
+        let vm = VM { host: &DummyHost };
+        let _ = vm.run(&sample_prog()).unwrap();
+        let tags = flush();
+        assert!(tags.is_empty());
+    }
+}

--- a/packages/tf-lang-l0-rs/tests/serde_shapes.rs
+++ b/packages/tf-lang-l0-rs/tests/serde_shapes.rs
@@ -1,0 +1,9 @@
+use serde_json::json;
+use tflang_l0::proof::{ProofTag, NormalizationTarget};
+
+#[test]
+fn proof_tag_normalization_shape() {
+    let n = ProofTag::Normalization { target: NormalizationTarget::Delta };
+    let v = serde_json::to_value(&n).unwrap();
+    assert_eq!(v, json!({"kind":"Normalization","target":"delta"}));
+}

--- a/packages/tf-lang-l0-rs/tests/util/env.rs
+++ b/packages/tf-lang-l0-rs/tests/util/env.rs
@@ -1,0 +1,26 @@
+use std::env;
+/// RAII guard for scoped env overrides to prevent test flakiness.
+pub struct EnvVarGuard {
+    key: String,
+    prev: Option<String>,
+}
+impl EnvVarGuard {
+    pub fn set(key: &str, val: &str) -> Self {
+        let prev = env::var(key).ok();
+        env::set_var(key, val);
+        Self { key: key.to_string(), prev }
+    }
+    pub fn unset(key: &str) -> Self {
+        let prev = env::var(key).ok();
+        env::remove_var(key);
+        Self { key: key.to_string(), prev }
+    }
+}
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => env::set_var(&self.key, v),
+            None => env::remove_var(&self.key),
+        }
+    }
+}

--- a/packages/tf-lang-l0-rs/tests/util/mod.rs
+++ b/packages/tf-lang-l0-rs/tests/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod env;

--- a/packages/tf-lang-l0-ts/src/index.ts
+++ b/packages/tf-lang-l0-ts/src/index.ts
@@ -5,4 +5,4 @@ export * as check from './check/index.js';
 export { canonicalJsonBytes } from './canon/json.js';
 export { blake3hex } from './canon/hash.js';
 export * as ops from './ops/index.js';
-export * as proof from './proof/tags.js';
+export * as proof from './proof/index.js';

--- a/packages/tf-lang-l0-ts/src/proof/index.ts
+++ b/packages/tf-lang-l0-ts/src/proof/index.ts
@@ -1,0 +1,17 @@
+export * from './tags.js';
+import type { ProofTag } from './tags.js';
+import { devProofsEnabled } from '../util/env';
+
+const log: ProofTag[] = [];
+
+export function emit(tag: ProofTag): void {
+  if (devProofsEnabled()) {
+    log.push(tag);
+  }
+}
+
+export function flush(): ProofTag[] {
+  const out = log.slice();
+  log.length = 0;
+  return out;
+}

--- a/packages/tf-lang-l0-ts/src/util/env.ts
+++ b/packages/tf-lang-l0-ts/src/util/env.ts
@@ -1,0 +1,14 @@
+// Centralized, cached environment feature flags for the TS runtime.
+let _devProofs: boolean | undefined;
+export function devProofsEnabled(): boolean {
+  if (_devProofs === undefined) {
+    const v = (process.env.DEV_PROOFS || '').toLowerCase();
+    _devProofs = v === '1' || v === 'true';
+  }
+  return _devProofs;
+}
+
+// For tests only: reset the cached flag (not exported in build).
+export function __resetEnvCacheForTests__() {
+  _devProofs = undefined;
+}

--- a/packages/tf-lang-l0-ts/tests/helpers/env.ts
+++ b/packages/tf-lang-l0-ts/tests/helpers/env.ts
@@ -1,0 +1,22 @@
+// Scoped env override for tests to avoid leaking state across parallel cases.
+export async function withEnv<T>(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<T> | T
+): Promise<T> {
+  const prev: Record<string, string | undefined> = {};
+  for (const k of Object.keys(vars)) {
+    prev[k] = process.env[k];
+    const v = vars[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const k of Object.keys(vars)) {
+      const v = prev[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}

--- a/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { VM } from '../src/vm/index.js';
+import type { Program } from '../src/model/bytecode.js';
+import { DummyHost } from '../src/host/memory.js';
+import { flush } from '../src/proof/index.js';
+import { withEnv } from './helpers/env';
+import { __resetEnvCacheForTests__ } from '../src/util/env';
+
+describe('proof dev mode', () => {
+  afterEach(() => __resetEnvCacheForTests__());
+  const prog: Program = {
+    version: '0.1',
+    regs: 2,
+    instrs: [
+      { op: 'CONST', dst: 0, value: {} },
+      { op: 'LENS_PROJ', dst: 1, state: 0, region: 'r' },
+      { op: 'CONST', dst: 0, value: { x: 1 } },
+      { op: 'HALT' },
+    ],
+  };
+
+  it('emits tags when DEV_PROOFS=1', async () => {
+    await withEnv({ DEV_PROOFS: '1' }, async () => {
+      const vm = new VM(DummyHost);
+      await vm.run(prog);
+      const tags = flush();
+      expect(tags.some(t => t.kind === 'Transport')).toBe(true);
+      expect(tags.some(t => t.kind === 'Witness')).toBe(true);
+    });
+  });
+
+  it('no tags when DEV_PROOFS is unset', async () => {
+    await withEnv({ DEV_PROOFS: undefined }, async () => {
+      const vm = new VM(DummyHost);
+      await vm.run(prog);
+      const tags = flush();
+      expect(tags.length).toBe(0);
+    });
+  });
+});

--- a/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Witness, Normalization, Transport, Refutation, Conservativity, ProofTag } from '../src/proof/tags.js';
+import type { Witness, Normalization, Transport, Refutation, Conservativity, ProofTag } from '../src/proof/index.js';
 
 describe('proof tags', () => {
   it('compile tag shapes', () => {

--- a/packages/tf-lang-l0-ts/tests/proofs/dev_proofs_flag.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proofs/dev_proofs_flag.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { devProofsEnabled, __resetEnvCacheForTests__ } from '../../src/util/env';
+import { withEnv } from '../helpers/env';
+
+describe('DEV_PROOFS caching (TS)', () => {
+  afterEach(() => __resetEnvCacheForTests__());
+
+  it('reads once and caches', async () => {
+    await withEnv({ DEV_PROOFS: '1' }, () => {
+      expect(devProofsEnabled()).toBe(true);
+    });
+    // Flip env but cache should hold until reset
+    await withEnv({ DEV_PROOFS: '0' }, () => {
+      expect(devProofsEnabled()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- cache DEV_PROOFS checks in TS and Rust runtimes with test-only reset hooks
- add scoped env helpers for tests to avoid leakage
- add serde lock test for ProofTag Normalization shape

## Testing
- `pnpm -C packages/tf-lang-l0-ts test`
- `pnpm -C packages/tf-lang-l0-ts vectors`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c38b1dc5e483209ec4185acb1f1f10