### PR TITLE
B2: emit proof tags in dev mode

### DIFF
--- a/.codex/JOURNAL.md
+++ b/.codex/JOURNAL.md
@@ -535,3 +535,15 @@ Next suggested step:
   - pnpm -C packages/tf-lang-l0-ts test
 - Results:
   - tests passed
+## [B2-polish3] Async proof log & atomic env cache
+- Start: 2025-09-12 08:40 UTC
+- End:   2025-09-12 08:45 UTC
+- Changes:
+  - replaced TS proof log with AsyncLocalStorage and added explicit .js imports
+  - switched Rust DEV_PROOFS cache to atomic and removed unnecessary clone
+  - strengthened env flag cache tests in TS and Rust
+- Verification:
+  - pnpm -C packages/tf-lang-l0-ts test
+  - cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml
+- Results:
+  - tests passed

--- a/.codex/polish/B2.md
+++ b/.codex/polish/B2.md
@@ -1,2 +1,3 @@
 - TS interpreter: emit normalization tags via loop over ['delta','effect'] to reduce repetition.
 - Rust interpreter: likewise loop emitting Normalization tags for 'delta' and 'effect'.
+- tests/helpers/env.ts: store `Object.keys(vars)` in a variable and reuse in both loops.

--- a/.codex/self-plans/B2.md
+++ b/.codex/self-plans/B2.md
@@ -23,3 +23,27 @@
 - Proof tags emitted in both TS and Rust VMs only when `DEV_PROOFS=1`.
 - Tests cover presence and absence of tags.
 - Journal updated and repository tests pass.
+
+## Plan 2025-09-12
+1. Add `.js` extension to `packages/tf-lang-l0-ts/src/proof/index.ts` import.
+2. Replace module-level proof log with `AsyncLocalStorage` and expose `withProofLog` wrapper.
+3. Wrap test helper `withEnv` with `withProofLog` for isolated logs and add `.js` extensions in tests.
+4. Implement byte-wise comparison in TS VM interpreter and remove `as any` cast using `as const`.
+5. Swap Rust `static mut` cache for atomic `AtomicU8` implementation.
+6. Avoid unnecessary clone of `final_state` in Rust VM interpreter.
+7. Strengthen TS and Rust cache tests with post-reset assertions.
+8. Run `pnpm -C packages/tf-lang-l0-ts test` and `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`.
+9. Append B2-polish3 entry to `.codex/JOURNAL.md`.
+
+## Tests
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+## Risks
+- AsyncLocalStorage usage may not propagate in all async flows.
+- Atomic env cache must correctly handle concurrent init.
+- Test expectations may need updates after refactors.
+
+## Definition of Done
+- All reviewer comments addressed.
+- Tests pass and journal updated.

--- a/packages/tf-lang-l0-rs/src/vm/interpreter.rs
+++ b/packages/tf-lang-l0-rs/src/vm/interpreter.rs
@@ -194,15 +194,15 @@ impl<'h> VM<'h> {
         let delta = if final_state == initial_state {
             None
         } else {
-            Some(Replace { replace: final_state.clone() })
+            Some(Replace { replace: final_state })
         };
         emit(ProofTag::Witness { delta: delta.clone(), effect: Effect::default() });
         for target in [NormalizationTarget::Delta, NormalizationTarget::Effect] {
             emit(ProofTag::Normalization { target });
         }
-        let out = match delta {
+        let out = match &delta {
             None => serde_json::Value::Null,
-            Some(d) => serde_json::json!({ "replace": d.replace }),
+            Some(d) => serde_json::json!({ "replace": d.replace.clone() }),
         };
 
         Ok(out)

--- a/packages/tf-lang-l0-rs/tests/dev_proofs_flag.rs
+++ b/packages/tf-lang-l0-rs/tests/dev_proofs_flag.rs
@@ -11,4 +11,5 @@ fn dev_proofs_is_cached() {
     let _g2 = EnvVarGuard::unset("DEV_PROOFS");
     assert!(dev_proofs_enabled());
     __reset_env_cache_for_tests__();
+    assert!(!dev_proofs_enabled());
 }

--- a/packages/tf-lang-l0-ts/src/proof/index.ts
+++ b/packages/tf-lang-l0-ts/src/proof/index.ts
@@ -1,16 +1,23 @@
 export * from './tags.js';
 import type { ProofTag } from './tags.js';
-import { devProofsEnabled } from '../util/env';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { devProofsEnabled } from '../util/env.js';
 
-const log: ProofTag[] = [];
+const storage = new AsyncLocalStorage<ProofTag[]>();
+
+export function withProofLog<T>(fn: () => T): T {
+  return storage.run([], fn);
+}
 
 export function emit(tag: ProofTag): void {
-  if (devProofsEnabled()) {
-    log.push(tag);
-  }
+  if (!devProofsEnabled()) return;
+  const log = storage.getStore();
+  if (log) log.push(tag);
 }
 
 export function flush(): ProofTag[] {
+  const log = storage.getStore();
+  if (!log) return [];
   const out = log.slice();
   log.length = 0;
   return out;

--- a/packages/tf-lang-l0-ts/src/vm/interpreter.ts
+++ b/packages/tf-lang-l0-ts/src/vm/interpreter.ts
@@ -4,6 +4,12 @@ import type { Value, World, JournalEntry } from '../model/types.js';
 import { canonicalJsonBytes, blake3hex } from '../canon/index.js';
 import { emit } from '../proof/index.js';
 
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
 export class VM {
   constructor(public host: Host) {}
 
@@ -108,9 +114,9 @@ export class VM {
     // identity => null; otherwise full replace
     const a = canonicalJsonBytes(initialState);
     const b = canonicalJsonBytes(finalState);
-    const delta = Buffer.from(a).equals(Buffer.from(b)) ? null : { replace: finalState };
+    const delta = bytesEqual(a, b) ? null : { replace: finalState };
     emit({ kind: 'Witness', delta, effect: { read: [], write: [], external: [] } });
-    ['delta', 'effect'].forEach(target => emit({ kind: 'Normalization', target: target as any }));
+    (['delta', 'effect'] as const).forEach(target => emit({ kind: 'Normalization', target }));
     return delta;
   }
 }

--- a/packages/tf-lang-l0-ts/tests/helpers/env.ts
+++ b/packages/tf-lang-l0-ts/tests/helpers/env.ts
@@ -1,19 +1,22 @@
 // Scoped env override for tests to avoid leaking state across parallel cases.
+import { withProofLog } from '../../src/proof/index.js';
+
 export async function withEnv<T>(
   vars: Record<string, string | undefined>,
   fn: () => Promise<T> | T
 ): Promise<T> {
   const prev: Record<string, string | undefined> = {};
-  for (const k of Object.keys(vars)) {
+  const keys = Object.keys(vars);
+  for (const k of keys) {
     prev[k] = process.env[k];
     const v = vars[k];
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
   }
   try {
-    return await fn();
+    return await withProofLog(fn);
   } finally {
-    for (const k of Object.keys(vars)) {
+    for (const k of keys) {
       const v = prev[k];
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;

--- a/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
@@ -3,8 +3,8 @@ import { VM } from '../src/vm/index.js';
 import type { Program } from '../src/model/bytecode.js';
 import { DummyHost } from '../src/host/memory.js';
 import { flush } from '../src/proof/index.js';
-import { withEnv } from './helpers/env';
-import { __resetEnvCacheForTests__ } from '../src/util/env';
+import { withEnv } from './helpers/env.js';
+import { __resetEnvCacheForTests__ } from '../src/util/env.js';
 
 describe('proof dev mode', () => {
   afterEach(() => __resetEnvCacheForTests__());

--- a/packages/tf-lang-l0-ts/tests/proofs/dev_proofs_flag.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proofs/dev_proofs_flag.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { devProofsEnabled, __resetEnvCacheForTests__ } from '../../src/util/env';
-import { withEnv } from '../helpers/env';
+import { devProofsEnabled, __resetEnvCacheForTests__ } from '../../src/util/env.js';
+import { withEnv } from '../helpers/env.js';
 
 describe('DEV_PROOFS caching (TS)', () => {
   afterEach(() => __resetEnvCacheForTests__());
 
-  it('reads once and caches', async () => {
+  it('reads once, caches, and resets', async () => {
     await withEnv({ DEV_PROOFS: '1' }, () => {
       expect(devProofsEnabled()).toBe(true);
     });
     // Flip env but cache should hold until reset
     await withEnv({ DEV_PROOFS: '0' }, () => {
       expect(devProofsEnabled()).toBe(true);
+    });
+
+    __resetEnvCacheForTests__();
+
+    await withEnv({ DEV_PROOFS: '0' }, () => {
+      expect(devProofsEnabled()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- isolate TypeScript proof logs with AsyncLocalStorage and fix ESM import
- atomically cache `DEV_PROOFS` flag in Rust and drop unnecessary clone
- strengthen environment cache tests across TS and Rust

## Testing
- `pnpm -C packages/tf-lang-l0-ts test`
- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c3dc99a1a08320b8b8f66639966c1e