### PR TITLE
C1: finalize host-lite raw handler and canonical tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,15 @@
-# C1 — Changes (Run 3)
+# C1 — Changes (Run 4)
 
 ## Summary
-Refined `host-lite` to harden error handling and determinism. Added explicit malformed JSON 400s, method gating, and multi-world LRU proofs while keeping proofs gated.
+Finalized `host-lite` with a raw JSON handler to unify `/plan` and `/apply`, enforcing canonical bytes and stricter error paths.
 
 ## Why
-- Advances END_GOAL by ensuring canonical idempotent `/plan` and `/apply` responses with bounded per-world cache and proof toggling.
+- Delivers deterministic, idempotent planning/apply with per-world LRU and proof gating.
 
 ## Tests
-- Added: malformed JSON 400, method 404, multi-world cache bounds.
-- Updated: boundary scan for package imports.
-- Determinism/parity: repeated `pnpm test` runs stable; no sockets/files/network.
+- Added: byte determinism, DEV_PROOFS gating, deep import sweep, package export guard.
+- Updated: cache bounds to track world count, consolidated error checks.
+- Determinism/parity: repeated `pnpm -F host-lite-ts test` runs stable; no sockets/network.
 
 ## Notes
-- No schema changes unless explicitly allowed.
-- Diffs kept minimal.
+- In-memory only; no new runtime deps.

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,39 +1,35 @@
-# COMPLIANCE — C1 — Run 3
+# COMPLIANCE — C1 — Run 4
 
 ## Blockers (must all be ✅)
-- [x] No changes to existing kernel semantics or tag schemas from A/B — code link: packages/host-lite/src/server.ts
-- [x] No per-call locks; no `static mut`/`unsafe`; no TS `as any` — code link: packages/host-lite/src/server.ts
-- [x] ESM internal imports include `.js` — code link: packages/host-lite/tests/host-lite.test.ts
-- [x] Tests run in parallel without cross-test state bleed — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] Outputs deterministic via canonical bytes — code/test link: packages/host-lite/src/server.ts
-- [x] Host uses in-memory state only — code link: packages/host-lite/src/server.ts
-- [x] Endpoints limited to `/plan` and `/apply` — code link: packages/host-lite/src/server.ts
+- [x] No kernel/schema changes — code link: packages/host-lite/src/server.ts
+- [x] No per-call locks or `as any` — code link: packages/host-lite/src/server.ts
+- [x] ESM internal imports include `.js` — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Tests parallel-safe, no global bleed — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Deterministic canonical outputs — code/test link: packages/host-lite/src/server.ts
+- [x] In-memory host only `/plan` & `/apply` — code link: packages/host-lite/src/server.ts
 - [x] `/plan` and `/apply` idempotent — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] Proof artifacts gated behind `DEV_PROOFS=1` — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Proofs gated behind `DEV_PROOFS=1` — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Per-world LRU cache cap 32 — code/test link: packages/host-lite/src/server.ts
 - [x] No new runtime dependencies — code link: packages/host-lite/package.json
-- [x] Tests hermetic (no sockets/files/net writes) — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] No per-call locks; no cross-test global state bleed — code/test link: packages/host-lite/src/server.ts
-- [x] Only `/plan` and `/apply`; outputs deterministic — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Tests hermetic (no sockets/network) — test link: packages/host-lite/tests/host-lite.test.ts
 
 ## EXTRA BLOCKERS
 - [x] Do not edit `.codex/tasks/**` — n/a
-- [x] No new runtime deps; Fastify removed — code link: packages/host-lite/package.json
-- [x] Tests hermetic (no sockets/files/net) — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] No `as any`; ESM imports keep `.js` — code link: packages/host-lite/tests/host-lite.test.ts
-- [x] Only `/plan` and `/apply`; deterministic outputs — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Deep import sweep clean — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Package exports remain `src/server.ts` — code/test link: packages/host-lite/package.json
 
 ## Acceptance (oracle)
-- [x] Enable/disable behavior (both runtimes)
-- [x] Cache: cold→warm; reset forces re-read; no per-call locks
+- [x] Enable/disable behavior
+- [x] Cache cold→warm; reset forces re-read
 - [x] Parallel determinism (repeat runs stable)
 - [ ] Cross-runtime parity (if applicable)
-- [x] Build/packaging correctness (e.g., ESM)
-- [x] Code quality (naming, no unnecessary clones/copies)
+- [x] Build/packaging correctness (ESM)
+- [x] Code quality (minimal diff)
 - [x] 404/400 canonical errors — test link: packages/host-lite/tests/host-lite.test.ts
 - [x] Multi-world cache bound proof — test link: packages/host-lite/tests/host-lite.test.ts
 
 ## Evidence
 - Code: packages/host-lite/src/server.ts; packages/host-lite/package.json
 - Tests: packages/host-lite/tests/host-lite.test.ts
-- CI runs: pnpm test
+- CI runs: pnpm -F host-lite-ts test
 - Bench (off-mode, if applicable): n/a

--- a/OBS_LOG.md
+++ b/OBS_LOG.md
@@ -1,7 +1,7 @@
-# Observation Log — C1 — Run 3
+# Observation Log — C1 — Run 4
 
-- Strategy chosen: Hardened host-lite error paths and cache proofs while maintaining zero-dep runtime.
-- Key changes (files): packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts; packages/host-lite/package.json
-- Determinism stress (runs × passes): 3×; stable outputs.
-- Near-misses vs blockers: boundary scan kept local to host-lite to avoid false positives.
-- Notes: proofs hashed only when DEV_PROOFS=1; per-world cache capped at 32.
+- Strategy chosen: Introduced raw JSON handler to centralize parsing and response bytes.
+- Key changes (files): packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts; CHANGES.md; COMPLIANCE.md; REPORT.md.
+- Determinism stress (runs × passes): 3×; outputs identical.
+- Near-misses vs blockers: ensured deep import sweep covered tests without hitting workspace symlinks.
+- Notes: cache map constrained to touched worlds; proof hashing only when DEV_PROOFS=1.

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,22 +1,22 @@
-# REPORT — C1 — Run 3
+# REPORT — C1 — Run 4
 
 ## End Goal fulfillment
-- EG-1: Minimal host exposes only `/plan` and `/apply` via Node HTTP【F:packages/host-lite/src/server.ts†L74-L83】
-- EG-2: Canonical, idempotent responses with bounded per-world cache【F:packages/host-lite/src/server.ts†L20-L71】【F:packages/host-lite/tests/host-lite.test.ts†L13-L44】【F:packages/host-lite/tests/host-lite.test.ts†L81-L99】
-- EG-3: Proofs gated by `DEV_PROOFS` with no cost when off【F:packages/host-lite/src/server.ts†L49-L53】【F:packages/host-lite/tests/host-lite.test.ts†L26-L44】
-- EG-4: Error model returns canonical 404/400 bodies【F:packages/host-lite/src/server.ts†L85-L110】【F:packages/host-lite/tests/host-lite.test.ts†L59-L76】【F:packages/host-lite/tests/host-lite.test.ts†L100-L113】
-- EG-5: State stays in-memory and resets on new host creation【F:packages/host-lite/tests/host-lite.test.ts†L47-L56】
+- EG-1: Raw handler enforces JSON parsing and routes only `/plan` and `/apply`【F:packages/host-lite/src/server.ts†L84-L104】
+- EG-2: Canonical, idempotent responses with per-world LRU cache【F:packages/host-lite/src/server.ts†L13-L66】【F:packages/host-lite/tests/host-lite.test.ts†L24-L34】【F:packages/host-lite/tests/host-lite.test.ts†L92-L105】
+- EG-3: Proofs gated by `DEV_PROOFS` with no overhead when off【F:packages/host-lite/src/server.ts†L57-L60】【F:packages/host-lite/tests/host-lite.test.ts†L36-L55】
+- EG-4: Canonical 404/400 error bodies via raw handler【F:packages/host-lite/src/server.ts†L84-L104】【F:packages/host-lite/tests/host-lite.test.ts†L57-L68】
+- EG-5: Package remains ESM with explicit export checks【F:packages/host-lite/package.json†L1-L18】【F:packages/host-lite/tests/host-lite.test.ts†L107-L127】
 
 ## Blockers honored
-- B-1: ✅ Deterministic in-memory host with LRU cache cap 32【F:packages/host-lite/src/server.ts†L10-L37】【F:packages/host-lite/tests/host-lite.test.ts†L81-L99】
-- B-2: ✅ Proof artifacts behind `DEV_PROOFS` gated; zero overhead when disabled【F:packages/host-lite/src/server.ts†L49-L53】【F:packages/host-lite/tests/host-lite.test.ts†L26-L44】
+- B-1: ✅ Deterministic in-memory host with per-world LRU cap 32【F:packages/host-lite/src/server.ts†L13-L36】【F:packages/host-lite/tests/host-lite.test.ts†L82-L105】
+- B-2: ✅ Proof artifacts appear only when `DEV_PROOFS=1`【F:packages/host-lite/src/server.ts†L57-L60】【F:packages/host-lite/tests/host-lite.test.ts†L36-L55】
 
 ## Lessons / tradeoffs (≤5 bullets)
-- Node HTTP only; no new runtime deps.
-- Cache cap 32 balances determinism and memory; multi-world test proves bound.
-- Parsing moved to handler to surface 400s without sockets.
-- Boundary scan limited to package to avoid repo-wide false positives.
-- Canonicalization centralized in single exec path.
+- Centralized JSON parsing simplified tests and server wiring.
+- Deep import sweep restricted to package to avoid cross-repo noise.
+- Cache map size check confirmed multi-world isolation.
+- Using package name in tests avoided deep import violations.
+- Canonical bytes derived once per exec for determinism.
 
 ## Bench notes (optional, off-mode)
 - flag check: n/a

--- a/packages/host-lite/src/server.ts
+++ b/packages/host-lite/src/server.ts
@@ -1,8 +1,4 @@
-import {
-  createServer as createHttpServer,
-  IncomingMessage,
-  ServerResponse,
-} from 'node:http';
+import { createServer as createHttpServer } from 'node:http';
 import { canonicalJsonBytes, blake3hex, DummyHost } from 'tf-lang-l0';
 
 const td = new TextDecoder();
@@ -94,38 +90,37 @@ export function makeHandler(host = createHost()) {
   };
 }
 
-export function createNodeHandler(host = createHost()) {
+export function makeRawHandler(host = createHost()) {
   const handler = makeHandler(host);
-  return async (req: IncomingMessage, res: ServerResponse) => {
-    const chunks: Uint8Array[] = [];
-    req.on('data', (c) => chunks.push(c));
-    req.on('end', async () => {
-      const bodyStr = Buffer.concat(chunks).toString() || '{}';
-      let body: unknown;
-      try {
-        body = JSON.parse(bodyStr);
-      } catch {
-        res.statusCode = 400;
-        res.setHeader('content-type', 'application/json');
-        const bytes = canonicalJsonBytes({ error: 'bad_request' });
-        res.end(Buffer.from(bytes));
-        return;
-      }
-      const { status, body: respBody } = await handler(
-        req.method ?? '',
-        req.url ?? '',
-        body,
-      );
-      res.statusCode = status;
-      res.setHeader('content-type', 'application/json');
-      const bytes = canonicalJsonBytes(respBody);
-      res.end(Buffer.from(bytes));
-    });
+  return async (method: string, url: string, bodyStr: string) => {
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyStr || '{}');
+    } catch {
+      return { status: 400, body: { error: 'bad_request' } };
+    }
+    return handler(method, url, body);
   };
 }
 
 export function createServer(host = createHost()) {
-  return createHttpServer(createNodeHandler(host));
+  const rawHandler = makeRawHandler(host);
+  return createHttpServer((req, res) => {
+    const chunks: Uint8Array[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', async () => {
+      const bodyStr = Buffer.concat(chunks).toString();
+      const { status, body } = await rawHandler(
+        req.method ?? '',
+        req.url ?? '',
+        bodyStr,
+      );
+      res.statusCode = status;
+      res.setHeader('content-type', 'application/json');
+      const bytes = canonicalJsonBytes(body);
+      res.end(Buffer.from(bytes));
+    });
+  });
 }
 
 if (process.argv[1] === new URL(import.meta.url).pathname) {

--- a/packages/host-lite/tests/host-lite.test.ts
+++ b/packages/host-lite/tests/host-lite.test.ts
@@ -1,49 +1,70 @@
 import { describe, it, expect } from 'vitest';
-import { makeHandler, createHost, createNodeHandler } from '../src/server.js';
+import { makeHandler, createHost, makeRawHandler } from 'host-lite-ts';
 import { canonicalJsonBytes, blake3hex } from 'tf-lang-l0';
-import { readFile } from 'node:fs/promises';
-import { IncomingMessage, ServerResponse } from 'node:http';
-import { PassThrough } from 'node:stream';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const td = new TextDecoder();
 
 interface JournalEntry { canon: string; proof?: string }
 interface Resp { world: unknown; delta: unknown; journal: JournalEntry[] }
 
+async function collectTs(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) files.push(...(await collectTs(p)));
+    else if (p.endsWith('.ts')) files.push(p);
+  }
+  return files;
+}
+
 describe('host-lite', () => {
-  it('idempotent plan and apply', async () => {
+  it('byte-identical plan and apply', async () => {
     const host = createHost();
-    const handler = makeHandler(host);
-    const body = { world: 'w', plan: 1 };
-    const p1 = await handler('POST', '/plan', body);
-    const p2 = await handler('POST', '/plan', body);
-    expect(p1.status).toBe(200);
-    expect(p2.status).toBe(200);
-    expect(p1.body).toEqual(p2.body);
-    const a1 = await handler('POST', '/apply', body);
-    const a2 = await handler('POST', '/apply', body);
-    expect(a1.body).toEqual(a2.body);
+    const handler = makeRawHandler(host);
+    const bodyStr = JSON.stringify({ world: 'w', plan: 1 });
+    const p1 = await handler('POST', '/plan', bodyStr);
+    const p2 = await handler('POST', '/plan', bodyStr);
+    expect(td.decode(canonicalJsonBytes(p1.body))).toBe(td.decode(canonicalJsonBytes(p2.body)));
+    const a1 = await handler('POST', '/apply', bodyStr);
+    const a2 = await handler('POST', '/apply', bodyStr);
+    expect(td.decode(canonicalJsonBytes(a1.body))).toBe(td.decode(canonicalJsonBytes(a2.body)));
   });
 
-  it('canonical journal and proof gating', async () => {
-    const body = { world: 'c', plan: 2 };
+  it('DEV_PROOFS gating', async () => {
+    const bodyStr = JSON.stringify({ world: 'c', plan: 2 });
     delete process.env.DEV_PROOFS;
-    const h0 = makeHandler(createHost());
-    const r0 = await h0('POST', '/apply', body);
+    const h0 = makeRawHandler(createHost());
+    const r0 = await h0('POST', '/apply', bodyStr);
     const j0 = (r0.body as Resp).journal[0];
-    expect(j0.proof).toBeUndefined();
+    expect(Object.keys(j0)).toEqual(['canon']);
     const canon0 = td.decode(canonicalJsonBytes(JSON.parse(j0.canon)));
     expect(canon0).toBe(j0.canon);
 
     process.env.DEV_PROOFS = '1';
-    const h1 = makeHandler(createHost());
-    const r1 = await h1('POST', '/apply', body);
+    const h1 = makeRawHandler(createHost());
+    const r1 = await h1('POST', '/apply', bodyStr);
     const j1 = (r1.body as Resp).journal[0];
     const canon1 = td.decode(canonicalJsonBytes(JSON.parse(j1.canon)));
     expect(canon1).toBe(j1.canon);
     const hash = blake3hex(canonicalJsonBytes(JSON.parse(j1.canon)));
     expect(j1.proof).toBe(hash);
     delete process.env.DEV_PROOFS;
+  });
+
+  it('404 and 400 errors', async () => {
+    const handler = makeRawHandler(createHost());
+    const r1 = await handler('POST', '/nope', '{}');
+    expect(r1.status).toBe(404);
+    expect(td.decode(canonicalJsonBytes(r1.body))).toBe('{"error":"not_found"}');
+    const r2 = await handler('GET', '/plan', '{}');
+    expect(r2.status).toBe(404);
+    expect(td.decode(canonicalJsonBytes(r2.body))).toBe('{"error":"not_found"}');
+    const r3 = await handler('POST', '/plan', '{');
+    expect(r3.status).toBe(400);
+    expect(td.decode(canonicalJsonBytes(r3.body))).toBe('{"error":"bad_request"}');
   });
 
   it('state is ephemeral', async () => {
@@ -56,22 +77,6 @@ describe('host-lite', () => {
     const r2 = await h2('POST', '/plan', { world: 'e', plan: 0 });
     const w2 = (r2.body as Resp).world;
     expect(w1).not.toEqual(w2);
-  });
-
-  it('404 for unknown path', async () => {
-    const handler = makeHandler(createHost());
-    const r = await handler('POST', '/nope', {});
-    expect(r.status).toBe(404);
-    const canon = td.decode(canonicalJsonBytes(r.body));
-    expect(canon).toBe('{"error":"not_found"}');
-  });
-
-  it('404 for wrong method', async () => {
-    const handler = makeHandler(createHost());
-    const r = await handler('GET', '/plan', {});
-    expect(r.status).toBe(404);
-    const canon = td.decode(canonicalJsonBytes(r.body));
-    expect(canon).toBe('{"error":"not_found"}');
   });
 
   it('bounded cache prevents growth', async () => {
@@ -92,34 +97,32 @@ describe('host-lite', () => {
         await handler('POST', '/plan', { world: `mw${w}`, plan: i });
       }
     }
+    expect(host.cache.size).toBe(4);
     for (let w = 0; w < 4; w++) {
       const worldCache = host.cache.get(`mw${w}`);
       expect(worldCache?.size ?? 0).toBeLessThanOrEqual(32);
     }
   });
 
-  it('400 for malformed JSON', async () => {
-    const handler = createNodeHandler();
-    const req = new IncomingMessage(new PassThrough());
-    req.method = 'POST';
-    req.url = '/plan';
-    const res = new ServerResponse(req);
-    let body = '';
-    res.end = (chunk?: unknown) => {
-      if (chunk) body += Buffer.from(chunk as Uint8Array).toString();
-      res.emit('finish');
-    };
-    const finished = new Promise((resolve) => res.on('finish', resolve));
-    handler(req, res);
-    req.emit('data', Buffer.from('{'));
-    req.emit('end');
-    await finished;
-    expect(res.statusCode).toBe(400);
-    expect(body).toBe('{"error":"bad_request"}');
+  it('no deep imports and .js extensions', async () => {
+    const root = new URL('..', import.meta.url).pathname;
+    const files = await collectTs(root);
+    for (const file of files) {
+      const src = await readFile(file, 'utf8');
+      const importRegex = /import\s+[^'";]+['"]([^'"]+)['"]/g;
+      let m: RegExpExecArray | null;
+      while ((m = importRegex.exec(src))) {
+        const p = m[1];
+        expect(p.includes('../')).toBe(false);
+        expect(p.includes('tf-lang-l0/')).toBe(false);
+        if (p.startsWith('.')) expect(p.endsWith('.js')).toBe(true);
+      }
+    }
   });
 
-  it('no deep imports across packages', async () => {
-    const src = await readFile(new URL('../src/server.ts', import.meta.url), 'utf8');
-    expect(src.includes('../')).toBe(false);
+  it('package exports main', async () => {
+    const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+    expect(pkg.main).toBe('src/server.ts');
+    expect(pkg.exports).toBe('./src/server.ts');
   });
 });


### PR DESCRIPTION
## Summary
- centralize plan/apply routing with a JSON-parsing raw handler
- ensure createServer emits canonical bytes and 404/400 errors
- broaden tests for determinism, DEV_PROOFS gating, and package hygiene

## Testing
- `pnpm -F host-lite-ts test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c623ce1c8320bc3b9aef4b084cad