### PR TITLE
C1: finalize host-lite raw handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,14 @@
-# C1 — Changes (Run 3)
+# C1 — Changes (Run 4)
 
 ## Summary
-Refined `host-lite` to harden error handling and determinism. Added explicit malformed JSON 400s, method gating, and multi-world LRU proofs while keeping proofs gated.
+Finalized `host-lite` with a raw JSON handler shared across `/plan` and `/apply`, ensuring canonical bytes and a unified exec path.
 
 ## Why
-- Advances END_GOAL by ensuring canonical idempotent `/plan` and `/apply` responses with bounded per-world cache and proof toggling.
+- Completes END_GOAL by delivering deterministic, idempotent endpoints with LRU caching and proof gating.
 
 ## Tests
-- Added: malformed JSON 400, method 404, multi-world cache bounds.
-- Updated: boundary scan for package imports.
+- Added: byte determinism, raw handler 400s, import hygiene, package export guard.
+- Updated: multi-world cache bounds now assert map size.
 - Determinism/parity: repeated `pnpm test` runs stable; no sockets/files/network.
 
 ## Notes

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,25 +1,27 @@
-# COMPLIANCE — C1 — Run 3
+# COMPLIANCE — C1 — Run 4
 
 ## Blockers (must all be ✅)
 - [x] No changes to existing kernel semantics or tag schemas from A/B — code link: packages/host-lite/src/server.ts
 - [x] No per-call locks; no `static mut`/`unsafe`; no TS `as any` — code link: packages/host-lite/src/server.ts
-- [x] ESM internal imports include `.js` — code link: packages/host-lite/tests/host-lite.test.ts
+- [x] ESM internal imports include `.js` — test link: packages/host-lite/tests/host-lite.test.ts
 - [x] Tests run in parallel without cross-test state bleed — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] Outputs deterministic via canonical bytes — code/test link: packages/host-lite/src/server.ts
+- [x] Outputs deterministic via canonical bytes — code/test link: packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts
 - [x] Host uses in-memory state only — code link: packages/host-lite/src/server.ts
 - [x] Endpoints limited to `/plan` and `/apply` — code link: packages/host-lite/src/server.ts
 - [x] `/plan` and `/apply` idempotent — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] Proof artifacts gated behind `DEV_PROOFS=1` — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Proof artifacts gated behind `DEV_PROOFS=1` — code/test link: packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts
 - [x] No new runtime dependencies — code link: packages/host-lite/package.json
 - [x] Tests hermetic (no sockets/files/net writes) — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] No per-call locks; no cross-test global state bleed — code/test link: packages/host-lite/src/server.ts
-- [x] Only `/plan` and `/apply`; outputs deterministic — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] 404/400 canonical errors — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Multi-world cache bound proof — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] No deep imports in source — test link: packages/host-lite/tests/host-lite.test.ts
+- [x] Package exports stay `src/server.ts` — test link: packages/host-lite/tests/host-lite.test.ts
 
 ## EXTRA BLOCKERS
 - [x] Do not edit `.codex/tasks/**` — n/a
 - [x] No new runtime deps; Fastify removed — code link: packages/host-lite/package.json
 - [x] Tests hermetic (no sockets/files/net) — test link: packages/host-lite/tests/host-lite.test.ts
-- [x] No `as any`; ESM imports keep `.js` — code link: packages/host-lite/tests/host-lite.test.ts
+- [x] No `as any`; ESM imports keep `.js` — code/test link: packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts
 - [x] Only `/plan` and `/apply`; deterministic outputs — test link: packages/host-lite/tests/host-lite.test.ts
 
 ## Acceptance (oracle)

--- a/OBS_LOG.md
+++ b/OBS_LOG.md
@@ -1,7 +1,7 @@
-# Observation Log — C1 — Run 3
+# Observation Log — C1 — Run 4
 
-- Strategy chosen: Hardened host-lite error paths and cache proofs while maintaining zero-dep runtime.
-- Key changes (files): packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts; packages/host-lite/package.json
+- Strategy chosen: Introduced raw JSON handler to front all requests, tightening error paths and import hygiene.
+- Key changes (files): packages/host-lite/src/server.ts; packages/host-lite/tests/host-lite.test.ts
 - Determinism stress (runs × passes): 3×; stable outputs.
-- Near-misses vs blockers: boundary scan kept local to host-lite to avoid false positives.
-- Notes: proofs hashed only when DEV_PROOFS=1; per-world cache capped at 32.
+- Near-misses vs blockers: ensured test sweep skipped node_modules to avoid false positives.
+- Notes: per-world LRU capped at 32 with map-sized to worlds touched; proofs hashed only when DEV_PROOFS=1.

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,22 +1,22 @@
-# REPORT — C1 — Run 3
+# REPORT — C1 — Run 4
 
 ## End Goal fulfillment
-- EG-1: Minimal host exposes only `/plan` and `/apply` via Node HTTP【F:packages/host-lite/src/server.ts†L74-L83】
-- EG-2: Canonical, idempotent responses with bounded per-world cache【F:packages/host-lite/src/server.ts†L20-L71】【F:packages/host-lite/tests/host-lite.test.ts†L13-L44】【F:packages/host-lite/tests/host-lite.test.ts†L81-L99】
-- EG-3: Proofs gated by `DEV_PROOFS` with no cost when off【F:packages/host-lite/src/server.ts†L49-L53】【F:packages/host-lite/tests/host-lite.test.ts†L26-L44】
-- EG-4: Error model returns canonical 404/400 bodies【F:packages/host-lite/src/server.ts†L85-L110】【F:packages/host-lite/tests/host-lite.test.ts†L59-L76】【F:packages/host-lite/tests/host-lite.test.ts†L100-L113】
-- EG-5: State stays in-memory and resets on new host creation【F:packages/host-lite/tests/host-lite.test.ts†L47-L56】
+- EG-1: Minimal host exposes only `/plan` and `/apply` via Node HTTP and raw handler【F:packages/host-lite/src/server.ts†L88-L132】
+- EG-2: Canonical, idempotent responses with bounded per-world cache【F:packages/host-lite/src/server.ts†L17-L70】【F:packages/host-lite/tests/host-lite.test.ts†L26-L36】【F:packages/host-lite/tests/host-lite.test.ts†L85-L98】
+- EG-3: Proofs gated by `DEV_PROOFS` with no cost when off【F:packages/host-lite/src/server.ts†L62-L64】【F:packages/host-lite/tests/host-lite.test.ts†L38-L56】
+- EG-4: Error model returns canonical 404/400 bodies【F:packages/host-lite/src/server.ts†L97-L126】【F:packages/host-lite/tests/host-lite.test.ts†L60-L71】
+- EG-5: State stays in-memory and resets on new host creation【F:packages/host-lite/tests/host-lite.test.ts†L73-L83】
 
 ## Blockers honored
-- B-1: ✅ Deterministic in-memory host with LRU cache cap 32【F:packages/host-lite/src/server.ts†L10-L37】【F:packages/host-lite/tests/host-lite.test.ts†L81-L99】
-- B-2: ✅ Proof artifacts behind `DEV_PROOFS` gated; zero overhead when disabled【F:packages/host-lite/src/server.ts†L49-L53】【F:packages/host-lite/tests/host-lite.test.ts†L26-L44】
+- B-1: ✅ Deterministic in-memory host with LRU cache cap 32【F:packages/host-lite/src/server.ts†L13-L40】【F:packages/host-lite/tests/host-lite.test.ts†L85-L98】
+- B-2: ✅ Proof artifacts behind `DEV_PROOFS` gated; zero overhead when disabled【F:packages/host-lite/src/server.ts†L62-L64】【F:packages/host-lite/tests/host-lite.test.ts†L38-L56】
 
 ## Lessons / tradeoffs (≤5 bullets)
-- Node HTTP only; no new runtime deps.
-- Cache cap 32 balances determinism and memory; multi-world test proves bound.
-- Parsing moved to handler to surface 400s without sockets.
-- Boundary scan limited to package to avoid repo-wide false positives.
-- Canonicalization centralized in single exec path.
+- Raw handler centralizes JSON parsing; server stays socket-free in tests.
+- Cache map asserts number of worlds touched to prevent unbounded growth.
+- Import sweep ensures no deep or extension-less imports.
+- Canonical bytes verified via determinism test.
+- Proof hashing runs only when requested.
 
 ## Bench notes (optional, off-mode)
 - flag check: n/a


### PR DESCRIPTION
## Summary
- add JSON-parsing `makeRawHandler` shared by `/plan` and `/apply`
- enforce canonical byte responses and LRU cache bounds
- test proof gating, error codes, and import/package hygiene

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c623ce1c8320bc3b9aef4b084cad