### PR TITLE
D1 pass-2: SQLite adapter hardening (param queries, SQL paging, types)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ docs/pr/
 # --- Codex runs ---
 .codex/runs/
 
+
+# SQLite artifacts
+*.db
+*.sqlite*
+*.db-shm
+*.db-wal

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,3 +21,52 @@ Finalize `host-lite` on top of PR #46 with a unified raw JSON handler path and d
 
 ## Notes
 - In-memory only; no new runtime deps; ESM imports include `.js` for internal paths.
+
+# D1 — Changes (Run 1)
+
+## Summary
+Claims API now loads legal datasets from SQLite and computes canonical BLAKE3 query hashes. Responses expose dataset version and deterministic evidence samples.
+
+## Why
+- Switch from JSON files to SQLite for stable storage.
+- Canonical hashing ensures identical queries map to the same `query_hash`.
+
+## Tests
+- Added: `services/claims-api-ts/test/sqlite.test.ts`.
+- Updated: n/a.
+- Determinism/parity: repeated `pnpm --filter claims-api-ts test` stable.
+
+## Notes
+- No schema changes; minimal surface.
+
+# D1 — Changes (Run 2)
+
+## Summary
+- Remove committed SQLite DB; switch to in-memory sql.js with schema/seed fixtures.
+
+## Why
+- Ensure repo hygiene and deterministic in-memory storage for portable tests.
+
+## Tests
+- Updated: services/claims-api-ts/test/sqlite.test.ts.
+- Added: packages/d1-sqlite/fixtures/schema.sql; packages/d1-sqlite/fixtures/seed.sql; packages/d1-sqlite/src/db.js.
+- Determinism/parity: repeated `pnpm --filter claims-api-ts test` stable.
+
+## Notes
+- Queries include ORDER BY for stable row order; evidence sampling yields ≥10 distinct hashes.
+
+# D1 — Changes (Run pass-2)
+
+## Summary
+- Harden SQLite adapter with parameterized queries, SQL-based paging, and type-safe DTOs.
+- Validate query inputs and expose Fastify instance for testable 400 responses.
+
+## Why
+- Ensures deterministic, injection-resistant storage with runtime type checks.
+
+## Tests
+- Updated: services/claims-api-ts/test/sqlite.test.ts.
+- Determinism/parity: repeated `pnpm --filter claims-api-ts test` stable.
+
+## Notes
+- No schema changes; diffs kept minimal.

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -35,3 +35,84 @@
 - Tests: packages/host-lite/test/c1.byte-determinism.test.ts; packages/host-lite/test/c1.proofs-gating-count.test.ts; packages/host-lite/test/c1.http-400-404.test.ts; packages/host-lite/test/c1.lru-multiworld.test.ts; packages/host-lite/test/c1.import-hygiene.test.ts
 - Runs: `pnpm -F host-lite-ts test`
 - Bench (off-mode, if applicable): n/a
+
+# COMPLIANCE — D1 — Run 1
+
+## Blockers (must all be ✅)
+- [x] No changes to kernel/tag schemas — n/a
+- [x] No per-call locks or `as any` — code link: services/claims-api-ts/src/db.ts
+- [x] ESM internal imports include `.js` — code link: services/claims-api-ts/src/server.ts
+- [x] Tests parallel-safe, deterministic — test link: services/claims-api-ts/test/sqlite.test.ts
+- [x] Storage strictly SQLite — code link: services/claims-api-ts/src/db.ts
+- [x] Responses include `dataset_version` and BLAKE3 `query_hash` — code link: services/claims-api-ts/src/db.ts
+- [x] Identical queries stable; ≥10 evidence samples — test link: services/claims-api-ts/test/sqlite.test.ts
+
+## Acceptance (oracle)
+- [x] Storage via SQLite only
+- [x] Hashes/versions match expected
+- [x] Stability across identical queries
+- [x] ≥10 evidence samples per response
+- [ ] Cross-runtime parity (n/a)
+- [x] Build/packaging correctness (ESM)
+- [x] Code quality
+
+## Evidence
+- Code: services/claims-api-ts/src/db.ts; services/claims-api-ts/src/util.ts; services/claims-api-ts/src/server.ts
+- Tests: services/claims-api-ts/test/sqlite.test.ts
+- CI runs: `pnpm --filter claims-api-ts test`
+- Bench: n/a
+
+# COMPLIANCE — D1 — Run 2
+
+## Blockers (must all be ✅)
+- [x] Remove repo-tracked DB; ignore SQLite artifacts — code link: .gitignore
+- [x] Storage via in-memory sql.js builder with fixtures — code link: packages/d1-sqlite/src/db.js
+- [x] All queries ORDER BY; no `as any`; ≥10 evidence — code link: services/claims-api-ts/src/db.ts
+- [x] Responses expose dataset version and BLAKE3 `query_hash` — code link: services/claims-api-ts/src/db.ts
+- [x] Tests hermetic; no binaries tracked — test link: services/claims-api-ts/test/sqlite.test.ts
+
+## Acceptance (oracle)
+- [x] `git ls-files` returns no `.db` or `.sqlite` files
+- [x] Stability across identical queries
+- [x] ≥10 evidence samples per count response
+- [x] Storage proof: only `sql.js` imported
+- [ ] Cross-runtime parity (n/a)
+- [x] Build/packaging correctness (ESM)
+- [x] Code quality
+
+## Evidence
+- Code: packages/d1-sqlite/src/db.js; services/claims-api-ts/src/db.ts; services/claims-api-ts/src/server.ts; .gitignore
+- Tests: services/claims-api-ts/test/sqlite.test.ts
+- Runs: `pnpm --filter claims-api-ts test`
+
+# COMPLIANCE — D1 — Run pass-2
+
+## Blockers (must all be ✅)
+- [x] No changes to kernel/tag schemas — n/a
+- [x] No per-call locks or `as any` — code link: services/claims-api-ts/src/db.ts
+- [x] ESM internal imports include `.js` — test link: services/claims-api-ts/test/sqlite.test.ts
+- [x] Tests parallel-safe, deterministic — test link: services/claims-api-ts/test/sqlite.test.ts
+- [x] Storage strictly SQLite — code link: services/claims-api-ts/src/db.ts
+- [x] Responses include `dataset_version` and BLAKE3 `query_hash` — code link: services/claims-api-ts/src/db.ts
+- [x] Identical queries stable; ≥10 evidence samples — test link: services/claims-api-ts/test/sqlite.test.ts
+
+## EXTRA BLOCKERS (pass-2)
+- [x] Parameterized SQL queries only — code link: services/claims-api-ts/src/db.ts
+- [x] No JS paging; SQL `LIMIT/OFFSET` — code/test link: services/claims-api-ts/src/db.ts; services/claims-api-ts/test/sqlite.test.ts
+- [x] Input validation; 400 for invalid shapes — code/test link: services/claims-api-ts/src/server.ts; services/claims-api-ts/test/sqlite.test.ts
+- [x] Injection-shaped value safe — test link: services/claims-api-ts/test/sqlite.test.ts
+- [x] No committed DB binaries — test link: services/claims-api-ts/test/sqlite.test.ts
+- [x] ESM hygiene scan — test link: services/claims-api-ts/test/sqlite.test.ts
+
+## Acceptance (oracle)
+- [x] Storage via SQLite only
+- [x] Hashes/versions match expected
+- [x] Stability across identical queries
+- [x] ≥10 evidence samples per response
+- [x] Build/packaging correctness (ESM)
+- [x] Code quality
+
+## Evidence
+- Code: services/claims-api-ts/src/db.ts; services/claims-api-ts/src/server.ts; services/claims-api-ts/src/types.ts
+- Tests: services/claims-api-ts/test/sqlite.test.ts
+- CI runs: `pnpm --filter claims-api-ts test`; `pnpm test`

--- a/OBS_LOG.md
+++ b/OBS_LOG.md
@@ -6,3 +6,27 @@
  - Determinism runs: 5× `pnpm -r test` executed in parallel — all green.
 - Tradeoffs: Did not split handlers into multiple source files to avoid churn; imports remain via public `tf-lang-l0` exports; no new deps.
 - Proof gating: Explicit count check in tests; zero overhead when off (no proof fields computed/emitted).
+
+# Observation Log — D1 — Run 1
+
+- Strategy chosen: replace JSON loader with CLI-backed SQLite adapter; add BLAKE3 hashing.
+- Key changes (files): services/claims-api-ts/src/db.ts; services/claims-api-ts/src/util.ts; services/claims-api-ts/src/server.ts; services/claims-api-ts/test/sqlite.test.ts; services/claims-api-ts/data/claims.db.
+- Determinism stress (runs × passes): 3× `pnpm --filter claims-api-ts test` — stable.
+- Near-misses vs blockers: initial attempt with `sql.js` dropped due to build complexity; switched to `sqlite3` CLI.
+- Notes: evidence generation uses first 10 ordered rows; CLI keeps storage SQLite-only.
+
+# Observation Log — D1 — Run 2
+
+- Strategy: drop file-backed SQLite and rebuild dataset via sql.js using schema/seed fixtures.
+- Key changes: packages/d1-sqlite/src/db.js; services/claims-api-ts/src/db.ts; services/claims-api-ts/src/server.ts; tests updated for determinism and storage proof.
+- Determinism stress: 3× `pnpm --filter claims-api-ts test` — stable, byte-identical.
+- Tradeoffs: sql.js wasm load adds slight startup cost but avoids native deps; fixtures read once at init.
+- Notes: added .gitignore entries to prevent accidental commit of DB artifacts.
+
+# Observation Log — D1 — Run pass-2
+
+- Strategy: parameterize SQL queries and move paging into SQL; exported server for input validation tests.
+- Key changes: services/claims-api-ts/src/db.ts; services/claims-api-ts/src/server.ts; services/claims-api-ts/src/types.ts; services/claims-api-ts/test/sqlite.test.ts.
+- Determinism stress: 3× `pnpm --filter claims-api-ts test` — stable.
+- Tradeoffs: extra prepared statements for counts; scanning source for hygiene instead of runtime checks.
+- Notes: injection test ensures bindings; Fastify injected for 400 validation.

--- a/REPORT.md
+++ b/REPORT.md
@@ -16,3 +16,57 @@
 
 ## Determinism runs
 - Repeated `pnpm -F host-lite-ts test` stable across 5 runs (documented in OBS_LOG.md).
+
+# REPORT — D1 — Run 1
+
+## End Goal fulfillment
+- EG-1: SQLite adapter serves counts and clauses via CLI-backed queries【F:services/claims-api-ts/src/db.ts†L10-L42】
+- EG-2: Responses expose `dataset_version` and BLAKE3 `query_hash` with ≥10 evidence samples【F:services/claims-api-ts/src/db.ts†L37-L41】【F:services/claims-api-ts/src/util.ts†L2-L7】【F:services/claims-api-ts/test/sqlite.test.ts†L34-L45】
+
+## Blockers honored
+- B-1: ✅ Storage uses SQLite only (no JSON queries)【F:services/claims-api-ts/src/db.ts†L28-L30】
+- B-2: ✅ Identical queries return stable results【F:services/claims-api-ts/test/sqlite.test.ts†L34-L55】
+
+## Lessons / tradeoffs (≤5 bullets)
+- Switched from JS libraries to `sqlite3` CLI for deterministic, zero-dep storage.
+- Evidence sampling fixed at first 10 ordered rows for stability.
+- Canonical JSON hashing guarantees query-key determinism.
+
+## Bench notes (optional, off-mode)
+- n/a
+
+# REPORT — D1 — Run 2
+
+## End Goal fulfillment
+- EG-1: In-memory sql.js database built from schema/seed fixtures; queries are ordered for determinism【F:packages/d1-sqlite/src/db.js†L1-L15】【F:services/claims-api-ts/src/db.ts†L23-L47】
+- EG-2: Responses expose dataset version and BLAKE3 `query_hash` with ≥10 distinct evidence samples【F:services/claims-api-ts/src/db.ts†L32-L47】【F:services/claims-api-ts/test/sqlite.test.ts†L18-L30】
+
+## Blockers honored
+- B-1: ✅ No SQLite binaries tracked; ignore rules added【F:.gitignore†L62-L65】【F:services/claims-api-ts/test/sqlite.test.ts†L6-L10】
+- B-2: ✅ Only `sql.js` imported; repeated queries byte-identical【F:services/claims-api-ts/src/server.ts†L1-L43】【F:services/claims-api-ts/test/sqlite.test.ts†L12-L24】
+
+## Lessons / tradeoffs
+- Replaced native CLI with WASM `sql.js` for portability.
+- Fixture-driven dataset keeps tests hermetic and deterministic.
+- Memoized in-memory DB avoids filesystem I/O.
+
+## Determinism runs
+- `pnpm --filter claims-api-ts test` repeated 3× — stable.
+
+# REPORT — D1 — Run pass-2
+
+## End Goal fulfillment
+- EG-1: SQLite adapter uses parameterized queries with SQL paging and ORDER BY for determinism【F:services/claims-api-ts/src/db.ts†L27-L98】
+- EG-2: Responses include dataset version and BLAKE3 query hashes with ≥10 distinct evidence samples【F:services/claims-api-ts/src/db.ts†L47-L72】【F:services/claims-api-ts/test/sqlite.test.ts†L51-L60】
+
+## Blockers honored
+- B-1: ✅ Storage uses in-memory SQLite only【F:services/claims-api-ts/src/db.ts†L1-L98】
+- B-2: ✅ Identical queries return stable results with ≥10 evidence samples【F:services/claims-api-ts/test/sqlite.test.ts†L51-L68】
+
+## Lessons / tradeoffs (≤5 bullets)
+- Parameterized statements add verbosity but ensure injection safety.
+- SQL-side LIMIT/OFFSET avoids JS paging and preserves determinism.
+- Exported Fastify instance enables hermetic HTTP validation.
+
+## Determinism runs
+- `pnpm --filter claims-api-ts test` repeated 3× — stable.

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
 	"devDependencies": {
 		"typescript": "^5.5.3"
 	},
-	"pnpm": {
-		"allowScripts": {
-			"esbuild": true
-		}
-	}
+        "pnpm": {
+                "allowScripts": {
+                        "esbuild": true
+                }
+        }
 }

--- a/packages/d1-sqlite/fixtures/schema.sql
+++ b/packages/d1-sqlite/fixtures/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE claims(
+  id TEXT PRIMARY KEY,
+  modality TEXT,
+  jurisdiction TEXT,
+  effective_from TEXT,
+  effective_to TEXT,
+  status TEXT,
+  data TEXT
+);

--- a/packages/d1-sqlite/fixtures/seed.sql
+++ b/packages/d1-sqlite/fixtures/seed.sql
@@ -1,0 +1,7 @@
+INSERT INTO meta(key,value) VALUES('dataset_version','ro-mini-2025-09-09');
+INSERT INTO claims VALUES ('C1','FORBIDDEN','RO','2024-01-01',NULL,'determinate','{"id":"C1","kind":"DEONTIC","modality":"FORBIDDEN","scope":{"jurisdiction":"RO"},"effective":{"from":"2024-01-01","to":null},"status":"determinate","explanation":null,"evidence":[{"source_uri":"https://gov.ro/lege-sanatate#art10","span":null,"hash":"b8395a9234b7b33300dda4a0d382ec09","rule_id":"regex.v1"}],"dataset_version":"ro-mini-2025-09-09","query_hash":"0"}');
+WITH RECURSIVE cnt(x) AS (SELECT 0 UNION ALL SELECT x+1 FROM cnt WHERE x < 19)
+INSERT INTO claims
+SELECT 'A'||x, modality, jurisdiction, effective_from, effective_to, status,
+       json_set(data,'$.id','A'||x,'$.evidence[0].hash','h'||x)
+FROM cnt, (SELECT * FROM claims WHERE id='C1');

--- a/packages/d1-sqlite/package.json
+++ b/packages/d1-sqlite/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tf-lang/d1-sqlite",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "main": "src/db.js",
+  "exports": "./src/db.js",
+  "dependencies": {
+    "sql.js": "^1.9.2"
+  }
+}

--- a/packages/d1-sqlite/src/db.js
+++ b/packages/d1-sqlite/src/db.js
@@ -1,0 +1,17 @@
+import initSqlJs from 'sql.js';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const wasmPath = require.resolve('sql.js/dist/sql-wasm.wasm');
+const wasmBinary = readFileSync(wasmPath);
+const schema = readFileSync(new URL('../fixtures/schema.sql', import.meta.url), 'utf8');
+const seed = readFileSync(new URL('../fixtures/seed.sql', import.meta.url), 'utf8');
+const SQL = await initSqlJs({ wasmBinary });
+
+export function buildDb() {
+  const db = new SQL.Database();
+  db.run(schema);
+  db.run(seed);
+  return db;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,12 @@ importers:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@24.3.1)
 
+  packages/d1-sqlite:
+    dependencies:
+      sql.js:
+        specifier: ^1.9.2
+        version: 1.13.0
+
   packages/host-lite:
     dependencies:
       tf-lang-l0:
@@ -65,6 +71,12 @@ importers:
 
   services/claims-api-ts:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.4.0
+        version: 1.8.0
+      '@tf-lang/d1-sqlite':
+        specifier: workspace:*
+        version: link:../../packages/d1-sqlite
       claims-core-ts:
         specifier: workspace:*
         version: link:../../packages/claims-core-ts
@@ -75,6 +87,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@24.3.1)
 
 packages:
 
@@ -384,8 +399,16 @@ packages:
   '@fastify/merge-json-schemas@0.1.1':
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.0.0':
     resolution: {integrity: sha512-h8VUBlE8R42+XIDO229cgisD287im3kdY6nbNZJFjc6ZvKIXPYXe6Vc/t+kyjFdMFyt5JpapzTsEg8n63w5/lw==}
@@ -496,11 +519,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@24.3.1':
     resolution: {integrity: sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==}
+
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -519,20 +548,41 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -553,6 +603,13 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -568,17 +625,31 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -589,9 +660,17 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -608,6 +687,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -657,12 +740,33 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   json-schema-ref-resolver@1.0.1:
     resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
@@ -673,11 +777,28 @@ packages:
   light-my-request@5.14.0:
     resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -687,12 +808,38 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -711,9 +858,16 @@ packages:
     resolution: {integrity: sha512-d1XorUQ7sSKqVcYdXuEYs2h1LKxejSorMEJ76XoZ0pPDf8VzJMe7GlPXpMBZeQ9gE4ZPIp5uGD+5Nw7scxiigg==}
     hasBin: true
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
@@ -727,6 +881,9 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -773,8 +930,20 @@ packages:
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -787,11 +956,21 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sql.js@1.13.0:
+    resolution: {integrity: sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -802,12 +981,20 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -823,13 +1010,25 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -867,6 +1066,31 @@ packages:
       terser:
         optional: true
 
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vitest@2.1.9:
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -892,10 +1116,19 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
 snapshots:
 
@@ -1062,7 +1295,13 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.0': {}
 
@@ -1129,11 +1368,19 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.50.1':
     optional: true
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@24.3.1':
     dependencies:
       undici-types: 7.10.0
+
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -1154,10 +1401,22 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
       pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      pretty-format: 29.7.0
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -1165,9 +1424,20 @@ snapshots:
       magic-string: 0.30.19
       pathe: 1.1.2
 
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -1176,6 +1446,12 @@ snapshots:
       tinyrainbow: 1.2.0
 
   abstract-logging@2.0.1: {}
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -1192,6 +1468,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-styles@5.2.0: {}
+
+  assertion-error@1.1.0: {}
+
   assertion-error@2.0.1: {}
 
   atomic-sleep@1.0.0: {}
@@ -1203,6 +1483,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -1211,15 +1501,33 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
+
   check-error@2.1.1: {}
 
+  confbox@0.1.8: {}
+
   cookie@0.7.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-eql@5.0.2: {}
+
+  diff-sequences@29.6.3: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1281,6 +1589,18 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   expect-type@1.2.2: {}
 
@@ -1344,11 +1664,23 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-func-name@2.0.2: {}
+
+  get-stream@8.0.1: {}
+
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  human-signals@5.0.0: {}
+
   ipaddr.js@1.9.1: {}
+
+  is-stream@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   json-schema-ref-resolver@1.0.1:
     dependencies:
@@ -1362,19 +1694,59 @@ snapshots:
       process-warning: 3.0.0
       set-cookie-parser: 2.7.1
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   loupe@3.2.1: {}
 
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  merge-stream@2.0.0: {}
+
+  mimic-fn@4.0.0: {}
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
   on-exit-leak-free@2.1.2: {}
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
   pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   pathval@2.0.1: {}
 
@@ -1400,11 +1772,23 @@ snapshots:
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   process-warning@3.0.0: {}
 
@@ -1416,6 +1800,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   quick-format-unescaped@4.0.4: {}
+
+  react-is@18.3.1: {}
 
   real-require@0.2.0: {}
 
@@ -1468,7 +1854,15 @@ snapshots:
 
   set-cookie-parser@2.7.1: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   sonic-boom@4.2.0:
     dependencies:
@@ -1478,9 +1872,17 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sql.js@1.13.0: {}
+
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
+
+  strip-final-newline@3.0.0: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   thread-stream@3.1.0:
     dependencies:
@@ -1490,9 +1892,13 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinypool@0.8.4: {}
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
+
+  tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -1505,9 +1911,31 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-detect@4.1.0: {}
+
   typescript@5.9.2: {}
 
+  ufo@1.6.1: {}
+
   undici-types@7.10.0: {}
+
+  vite-node@1.6.1(@types/node@24.3.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@24.3.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vite-node@2.1.9(@types/node@24.3.1):
     dependencies:
@@ -1535,6 +1963,40 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.1
       fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@24.3.1):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.1
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@24.3.1)
+      vite-node: 1.6.1(@types/node@24.3.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.3.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.9(@types/node@24.3.1):
     dependencies:
@@ -1571,7 +2033,13 @@ snapshots:
       - supports-color
       - terser
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yocto-queue@1.2.1: {}

--- a/services/claims-api-ts/package.json
+++ b/services/claims-api-ts/package.json
@@ -8,13 +8,17 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
-    "dev": "node --watch dist/server.js & (tsc -w -p tsconfig.json)"
+    "dev": "node --watch dist/server.js & (tsc -w -p tsconfig.json)",
+    "test": "vitest run"
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "claims-core-ts": "workspace:*"
+    "claims-core-ts": "workspace:*",
+    "@noble/hashes": "^1.4.0",
+    "@tf-lang/d1-sqlite": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/services/claims-api-ts/src/db.ts
+++ b/services/claims-api-ts/src/db.ts
@@ -1,0 +1,108 @@
+import type { Filters, Claim, Evidence, CountResponse, ListResponse } from './types.js';
+import { queryHash } from './util.js';
+import { buildDb } from '@tf-lang/d1-sqlite';
+import type { Database, Statement } from 'sql.js';
+
+export interface ClaimDb {
+  db: Database;
+  datasetVersion: string;
+}
+
+let memo: ClaimDb | null = null;
+export function openDb(): ClaimDb {
+  if (!memo) {
+    const db = buildDb();
+    const res = db.exec("SELECT value FROM meta WHERE key='dataset_version';");
+    const datasetVersion = res[0]?.values[0][0] as string;
+    memo = { db, datasetVersion };
+  }
+  return memo;
+}
+
+interface WhereFrag {
+  sql: string;
+  params: unknown[];
+}
+
+function buildWhere(f: Filters): WhereFrag {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+  if (f.modality) { clauses.push('modality = ?'); params.push(f.modality); }
+  if (f.jurisdiction) { clauses.push('jurisdiction = ?'); params.push(f.jurisdiction); }
+  if (f.at) {
+    clauses.push('effective_from <= ? AND ? <= IFNULL(effective_to, \"9999-12-31\")');
+    params.push(f.at, f.at);
+  }
+  const sql = clauses.length ? 'WHERE ' + clauses.join(' AND ') : '';
+  return { sql, params };
+}
+
+function all<T>(stmt: Statement, mapper: (row: unknown[]) => T): T[] {
+  const out: T[] = [];
+  while (stmt.step()) out.push(mapper(stmt.get()));
+  stmt.free();
+  return out;
+}
+
+export function count(db: ClaimDb, f: Filters): CountResponse {
+  const { sql, params } = buildWhere(f);
+  const countStmt = db.db.prepare(`SELECT COUNT(*) FROM claims ${sql};`);
+  countStmt.bind(params);
+  countStmt.step();
+  const n = countStmt.get()[0] as number;
+  countStmt.free();
+
+  const sampleStmt = db.db.prepare(`SELECT data FROM claims ${sql} ORDER BY id LIMIT 100;`);
+  sampleStmt.bind(params);
+  const evidences: Evidence[] = [];
+  const seen = new Set<string>();
+  while (sampleStmt.step() && evidences.length < 10) {
+    const claim = JSON.parse(sampleStmt.get()[0] as string) as Claim;
+    const ev = claim.evidence?.[0];
+    if (ev && !seen.has(ev.hash)) { seen.add(ev.hash); evidences.push(ev); }
+  }
+  sampleStmt.free();
+
+  return {
+    dataset_version: db.datasetVersion,
+    query_hash: queryHash(f),
+    filters: f,
+    n,
+    samples: evidences,
+  };
+}
+
+export function list(db: ClaimDb, f: Filters): ListResponse {
+  const { sql, params } = buildWhere(f);
+  const offset = Number.isFinite(f.offset) ? Math.max(0, Number(f.offset)) : 0;
+  const limit0 = Number.isFinite(f.limit) ? Number(f.limit) : 10;
+  const limit = Math.min(Math.max(1, limit0), 200);
+
+  const itemsStmt = db.db.prepare(`SELECT data FROM claims ${sql} ORDER BY id LIMIT ? OFFSET ?;`);
+  itemsStmt.bind([...params, limit, offset]);
+  const items = all(itemsStmt, r => JSON.parse(r[0] as string) as Claim);
+
+  const totalStmt = db.db.prepare(`SELECT COUNT(*) FROM claims ${sql};`);
+  totalStmt.bind(params);
+  totalStmt.step();
+  const total = totalStmt.get()[0] as number;
+  totalStmt.free();
+
+  const responseFilters: Filters = { ...f, offset, limit };
+  return {
+    dataset_version: db.datasetVersion,
+    query_hash: queryHash(responseFilters),
+    filters: responseFilters,
+    total,
+    items,
+  };
+}
+
+export function getClaim(db: ClaimDb, id: string): Claim | null {
+  const stmt = db.db.prepare('SELECT data FROM claims WHERE id = ?;');
+  stmt.bind([id]);
+  const ok = stmt.step();
+  const row = ok ? stmt.get()[0] : null;
+  stmt.free();
+  return row ? (JSON.parse(row as string) as Claim) : null;
+}

--- a/services/claims-api-ts/src/server.ts
+++ b/services/claims-api-ts/src/server.ts
@@ -1,19 +1,15 @@
-
 import Fastify from 'fastify';
-import fs from 'node:fs';
-import path from 'node:path';
-import { count as qCount, list as qList, type Claim } from 'claims-core-ts';
-import type { Filters } from './types.js';
-import { queryHash } from './util.js';
+import type { Filters, Modality } from './types.js';
+import { openDb, count as qCount, list as qList, getClaim } from './db.js';
 
 const PORT = Number(process.env.PORT || 8787);
 const HOST = process.env.HOST || '0.0.0.0';
-const DATA_PATH = process.env.CLAIMS_DATA || path.join(process.cwd(), 'data', 'claims.json');
+const DB = openDb();
 
-const fastify = Fastify({ logger: false });
+export const fastify = Fastify({ logger: false });
 
 // CORS: permissive for demo (consider tightening in production)
-fastify.addHook('onSend', async (req, reply, payload) => {
+fastify.addHook('onSend', async (_req, reply, payload) => {
   reply.header('Access-Control-Allow-Origin', '*');
   reply.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
   reply.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
@@ -21,82 +17,61 @@ fastify.addHook('onSend', async (req, reply, payload) => {
 });
 fastify.options('/*', async (_req, reply) => reply.code(200).send());
 
+fastify.get('/health', async () => ({ ok: true, dataset_version: DB.datasetVersion }));
 
-type Dataset = { dataset_version: string; claims: Claim[] };
-let DATA: Dataset = { dataset_version: 'dev', claims: [] };
-
-function loadDataset() {
-  const raw = fs.readFileSync(DATA_PATH, 'utf-8');
-  DATA = JSON.parse(raw);
+function parseFilters(q: Record<string, string>): Filters {
+  const f: Filters = {};
+  if (q.modality !== undefined) {
+    const mods: Modality[] = ['FORBIDDEN', 'PERMITTED', 'OBLIGATORY', 'EXEMPT', 'EXCEPTION'];
+    if (!mods.includes(q.modality as Modality)) throw new Error('bad modality');
+    f.modality = q.modality as Modality;
+  }
+  if (q.jurisdiction !== undefined) {
+    if (!/^[A-Za-z]{2}$/.test(q.jurisdiction)) throw new Error('bad jurisdiction');
+    f.jurisdiction = q.jurisdiction;
+  }
+  if (q.at !== undefined) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(q.at)) throw new Error('bad at');
+    f.at = q.at;
+  }
+  if (q.limit !== undefined) {
+    const lim = Number(q.limit);
+    if (!Number.isFinite(lim)) throw new Error('bad limit');
+    f.limit = lim;
+  }
+  if (q.offset !== undefined) {
+    const off = Number(q.offset);
+    if (!Number.isFinite(off)) throw new Error('bad offset');
+    f.offset = off;
+  }
+  return f;
 }
-
-function toWhere(f: Filters): any {
-  const where: any = { };
-  if (f.modality) where.modality = f.modality;
-  if (f.jurisdiction) where.scope = { jurisdiction: f.jurisdiction };
-  if (f.at) where.at = f.at;
-  return where;
-}
-
-fastify.get('/health', async () => ({ ok: true, dataset_version: DATA.dataset_version }));
 
 fastify.get('/claims/count', async (req, reply) => {
-  const f: Filters = {
-    modality: (req.query as any).modality,
-    jurisdiction: (req.query as any).jurisdiction,
-    at: (req.query as any).at,
-  };
-  const where = toWhere(f);
-  const res = qCount(DATA.claims, where);
-  return {
-    dataset_version: DATA.dataset_version,
-    query_hash: queryHash(f),
-    filters: f,
-    n: res.n,
-    samples: res.samples,
-  };
+  try {
+    const f = parseFilters(req.query as Record<string, string>);
+    return qCount(DB, f);
+  } catch {
+    return reply.code(400).send({ error: 'bad_request' });
+  }
 });
 
 fastify.get('/claims/list', async (req, reply) => {
-  const f: Filters = {
-    modality: (req.query as any).modality,
-    jurisdiction: (req.query as any).jurisdiction,
-    at: (req.query as any).at,
-    limit: (req.query as any).limit,
-    offset: (req.query as any).offset,
-  };
-  const where = toWhere(f);
-  const rows = qList(DATA.claims, where).items;
-  const rawOffset = Number(f.offset);
-  const offset = Number.isFinite(rawOffset) ? Math.max(0, rawOffset) : 0;
-  const rawLimit = Number(f.limit);
-  const limit0 = Number.isFinite(rawLimit) ? rawLimit : 10;
-  const limit  = Math.min(Math.max(1, limit0), 200);
-  const items = rows.slice(offset, offset + limit);
-
-  const responseFilters: Filters = {
-    modality: f.modality,
-    jurisdiction: f.jurisdiction,
-    at: f.at,
-    offset: offset,
-    limit: limit,
+  try {
+    const f = parseFilters(req.query as Record<string, string>);
+    return qList(DB, f);
+  } catch {
+    return reply.code(400).send({ error: 'bad_request' });
   }
-
-  return {
-    dataset_version: DATA.dataset_version,
-    query_hash: queryHash(responseFilters),
-    filters: responseFilters,
-    total: rows.length,
-    items,
-  };
 });
 
 fastify.get('/claims/explain/:id', async (req, reply) => {
-  const { id } = req.params as any;
-  const item = DATA.claims.find(c => c.id === id);
+  const { id } = req.params as Record<string, string>;
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) return reply.code(400).send({ error: 'bad_request' });
+  const item = getClaim(DB, id);
   if (!item) return reply.code(404).send({ error: 'not_found' });
   return {
-    dataset_version: DATA.dataset_version,
+    dataset_version: DB.datasetVersion,
     claim: item,
     evidence: item.evidence,
     explanation: item.explanation ?? null,
@@ -106,12 +81,13 @@ fastify.get('/claims/explain/:id', async (req, reply) => {
 fastify.get('/', async () => ({
   service: 'claims-api-ts',
   endpoints: ['/health','/claims/count','/claims/list','/claims/explain/:id'],
-  dataset_version: DATA.dataset_version,
-  data_path: DATA_PATH,
+  dataset_version: DB.datasetVersion,
 }));
 
-loadDataset();
+if (process.env.NODE_ENV !== 'test') {
+  fastify.listen({ port: PORT, host: HOST }).then(() => {
+    console.log(`[claims-api] listening on http://${HOST}:${PORT}`);
+  });
+}
 
-fastify.listen({ port: PORT, host: HOST }).then(() => {
-  console.log(`[claims-api] listening on http://${HOST}:${PORT} using ${DATA_PATH}`);
-});
+export default fastify;

--- a/services/claims-api-ts/src/types.ts
+++ b/services/claims-api-ts/src/types.ts
@@ -7,3 +7,31 @@ export interface Filters {
   limit?: number;
   offset?: number;
 }
+
+export interface Evidence {
+  hash: string;
+  [k: string]: unknown;
+}
+
+export interface Claim {
+  id: string;
+  evidence: Evidence[];
+  explanation?: string | null;
+  [k: string]: unknown;
+}
+
+export interface CountResponse {
+  dataset_version: string;
+  query_hash: string;
+  filters: Filters;
+  n: number;
+  samples: Evidence[];
+}
+
+export interface ListResponse {
+  dataset_version: string;
+  query_hash: string;
+  filters: Filters;
+  total: number;
+  items: Claim[];
+}

--- a/services/claims-api-ts/src/util.ts
+++ b/services/claims-api-ts/src/util.ts
@@ -1,7 +1,9 @@
 
-import { createHash } from 'crypto';
+import { blake3 } from '@noble/hashes/blake3';
+import { utf8ToBytes } from '@noble/hashes/utils';
+import type { Filters } from './types.js';
 
-export function queryHash(obj: any): string {
+export function queryHash(obj: Filters): string {
   const s = JSON.stringify(obj, Object.keys(obj).sort());
-  return createHash('sha256').update(s).digest('hex');
+  return Buffer.from(blake3(utf8ToBytes(s))).toString('hex');
 }

--- a/services/claims-api-ts/test/sqlite.test.ts
+++ b/services/claims-api-ts/test/sqlite.test.ts
@@ -1,0 +1,88 @@
+import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import fastify from '../src/server.js';
+import { openDb, count, list, getClaim } from '../src/db.js';
+import { queryHash } from '../src/util.js';
+import type { Filters } from '../src/types.js';
+import { it, expect, afterAll } from 'vitest';
+
+afterAll(async () => { await fastify.close(); });
+
+it('has no binary DB files tracked', () => {
+  const out = execSync("git ls-files '*.db' '*.sqlite*'").toString().trim();
+  expect(out).toBe('');
+});
+
+it('imports only sql.js', () => {
+  const sqljs = execSync("rg \"from 'sql.js'\" src").toString();
+  expect(sqljs.length).toBeGreaterThan(0);
+  const sqlite3 = execSync("rg sqlite3 src || true").toString().trim();
+  expect(sqlite3).toBe('');
+});
+
+it('internal imports include .js and avoid deep paths', () => {
+  const files: string[] = [];
+  function walk(dir: string) {
+    for (const ent of readdirSync(dir)) {
+      const p = join(dir, ent);
+      if (statSync(p).isDirectory()) walk(p); else files.push(p);
+    }
+  }
+  walk(join(__dirname, '../src'));
+  for (const f of files) {
+    const src = readFileSync(f, 'utf8');
+    const regex = /from\s+['"](\.\.\/|\.\/)([^'"]+)['"]/g;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(src))) {
+      expect(m[2].endsWith('.js')).toBe(true);
+      expect(m[2].includes('..')).toBe(false);
+    }
+  }
+});
+
+it('db layer uses SQL LIMIT/OFFSET without JS slicing', () => {
+  const src = readFileSync(join(__dirname, '../src/db.ts'), 'utf8');
+  expect(src).toMatch(/LIMIT \?/);
+  expect(src).toMatch(/OFFSET \?/);
+  expect(src).not.toMatch(/\.slice/);
+});
+
+it('count returns stable results with ≥10 distinct evidence samples', () => {
+  const db = openDb();
+  const filters: Filters = {};
+  const results = Array.from({ length: 3 }, () => JSON.stringify(count(db, filters)));
+  for (let i = 1; i < results.length; i++) expect(results[i]).toBe(results[0]);
+  const parsed = JSON.parse(results[0]);
+  expect(parsed.dataset_version).toBe('ro-mini-2025-09-09');
+  expect(parsed.query_hash).toBe(queryHash(filters));
+  expect(new Set(parsed.samples.map((s: { hash: string }) => s.hash)).size).toBeGreaterThanOrEqual(10);
+});
+
+it('list paging stable and SQL-driven', () => {
+  const db = openDb();
+  const filters: Filters = { modality: 'FORBIDDEN', jurisdiction: 'RO', at: '2025-09-09', limit: 5, offset: 2 };
+  const outputs = Array.from({ length: 3 }, () => JSON.stringify(list(db, filters)));
+  expect(outputs[1]).toBe(outputs[0]);
+  expect(outputs[2]).toBe(outputs[0]);
+});
+
+it('injection-shaped value does not alter results', () => {
+  const db = openDb();
+  const inj = count(db, { jurisdiction: "' OR 1=1 --" });
+  const safe = count(db, { jurisdiction: "' OR 1=1 --" });
+  expect(JSON.stringify(inj)).toBe(JSON.stringify(safe));
+  expect(inj.n).toBe(0);
+});
+
+it('server rejects invalid filter shapes', async () => {
+  const res = await fastify.inject('/claims/list?limit=notnum');
+  expect(res.statusCode).toBe(400);
+});
+
+it('getClaim fetches a clause with evidence', () => {
+  const db = openDb();
+  const claim = getClaim(db, 'C1');
+  expect(claim).not.toBeNull();
+  expect(claim!.evidence.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- parameterize SQLite queries with SQL LIMIT/OFFSET paging
- add type-safe DTOs and input validation rejecting malformed filters
- test injection safety and `.js` import hygiene for deterministic responses

## Testing
- `pnpm --filter claims-api-ts test`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e1f9d53c83209ed26e4dfeb234c8