### PR TITLE
E2: deterministic proof tags panel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,3 +121,19 @@ Claims API now loads legal datasets from SQLite and computes canonical BLAKE3 qu
 
 ## Notes
 - Static scans confirm no `.slice(`/`.filter(` in production code.
+
+# E2 — Changes (Run 1)
+
+## Summary
+Explorer now renders proof tags in sorted order and keeps the tags panel hidden when datasets provide none, ensuring deterministic DOM across sources.
+
+## Why
+- Stable tag ordering prevents flicker across reloads and APIs.
+- Hiding the panel avoids synthetic tags and matches dataset semantics.
+
+## Tests
+- Updated: `docs/claims-explorer.html`; `packages/explorer-test/claims-explorer.test.ts`.
+- Determinism/parity: `pnpm test`.
+
+## Notes
+- No schema changes; minimal surface.

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -209,3 +209,27 @@
 - Tests: services/claims-api-ts/test/sqlite.test.ts
 - Runs: `pnpm --filter claims-api-ts test`; `pnpm test`
 - Bench (off-mode, if applicable): n/a
+
+# COMPLIANCE — E2 — Run 1
+
+## Blockers (must all be ✅)
+- [x] No kernel/schema changes — n/a
+- [x] No per-call locks or `as any` — code link: docs/claims-explorer.html
+- [x] ESM internal imports include `.js` — code link: packages/explorer-test/claims-explorer.test.ts
+- [x] Tests parallel-safe, deterministic — test link: packages/explorer-test/claims-explorer.test.ts
+- [x] Proof tags rendered only from dataset data — code link: docs/claims-explorer.html
+- [x] Stable tag ordering — code/test link: docs/claims-explorer.html / packages/explorer-test/claims-explorer.test.ts
+- [x] Tags panel hidden when no proof tags — code/test link: docs/claims-explorer.html / packages/explorer-test/claims-explorer.test.ts
+
+## Acceptance (oracle)
+- [x] Visible sorted tags when present
+- [x] No tags panel when absent
+- [x] Deterministic static vs API snapshots
+- [x] Build/packaging correctness (ESM)
+- [x] Code quality
+
+## Evidence
+- Code: docs/claims-explorer.html
+- Tests: packages/explorer-test/claims-explorer.test.ts
+- Runs: `pnpm test`
+- Bench (off-mode, if applicable): n/a

--- a/OBS_LOG.md
+++ b/OBS_LOG.md
@@ -53,3 +53,11 @@
 - Determinism stress: 3× `pnpm --filter claims-api-ts test` — stable.
 - Near-misses vs blockers: adjusted filter bounds to allow `limit=0` while keeping validation.
 - Notes: rg scan expanded to entire src to enforce SQL-only pagination.
+
+# Observation Log — E2 — Run 1
+
+- Strategy chosen: sort dataset tags on render and test cross-source parity.
+- Key changes (files): docs/claims-explorer.html; packages/explorer-test/claims-explorer.test.ts; CHANGES.md; COMPLIANCE.md; REPORT.md.
+- Determinism stress (runs × passes): `pnpm test` ×1 — all green.
+- Near-misses vs blockers: had to install vitest; offline API error printed but handled.
+- Notes: none.

--- a/REPORT.md
+++ b/REPORT.md
@@ -134,3 +134,30 @@
 
 ## Determinism runs
 - `pnpm --filter claims-api-ts test` repeated 3× — stable.
+
+# REPORT — E2 — Run 1
+
+## End Goal fulfillment
+- EG-1: Proof tags render in sorted order when present【F:docs/claims-explorer.html†L206-L221】【F:packages/explorer-test/claims-explorer.test.ts†L82-L116】
+- EG-2: Tags panel hidden when dataset lacks proof tags【F:docs/claims-explorer.html†L206-L216】【F:packages/explorer-test/claims-explorer.test.ts†L140-L144】
+- EG-3: Static vs API renders yield identical DOM snapshots【F:packages/explorer-test/claims-explorer.test.ts†L82-L116】
+
+## Blockers honored
+- B-1: ✅ No kernel/tag schema changes — n/a
+- B-2: ✅ No locks or `as any`; imports include `.js`【F:packages/explorer-test/claims-explorer.test.ts†L1-L3】
+- B-3: ✅ Tags sourced from dataset only and sorted for stability【F:docs/claims-explorer.html†L206-L221】
+- B-4: ✅ Tags panel hidden when absent【F:docs/claims-explorer.html†L206-L216】【F:packages/explorer-test/claims-explorer.test.ts†L140-L144】
+
+## Lessons / tradeoffs (≤5 bullets)
+- Sorting at render guarantees deterministic order across sources.
+- Jsdom tests with explicit datasets prove parity without network access.
+- Installing vitest was required but kept out of commits.
+
+## Bench notes (optional, off-mode)
+- n/a
+
+## Self-review
+- [x] No `as any`, locks, or unsafe constructs
+- [x] Internal imports include `.js`
+- [x] Tests cover tag presence/absence and determinism
+- [x] `pnpm test` passes

--- a/docs/claims-explorer.html
+++ b/docs/claims-explorer.html
@@ -213,7 +213,7 @@ function updateTagsPanel(){
   }
   panel.style.display = '';
   list.innerHTML = '';
-  for(const t of DATA_TAGS){
+  for(const t of DATA_TAGS.slice().sort((a,b)=>a.localeCompare(b))){
     const li = document.createElement('li');
     li.textContent = t;
     list.appendChild(li);

--- a/packages/explorer-test/claims-explorer.test.ts
+++ b/packages/explorer-test/claims-explorer.test.ts
@@ -79,11 +79,16 @@ async function setup(opts: {
 }
 
 describe('claims explorer', () => {
-  it('renders identically across sources and preserves state', async () => {
-    const { document, window, fetchCalls, dom } = await setup();
+  it('renders deterministically with tags across sources', async () => {
+    const data = { ...BASE_DATA, tags: ['t2', 't1'] };
+    const { document, window, fetchCalls, dom } = await setup({ staticData: data });
     const at = document.getElementById('at') as HTMLInputElement;
     expect(at.value).toBe('2025-09-09');
     expect(fetchCalls).toHaveLength(1);
+    const panel = document.getElementById('tagsPanel')!;
+    expect(panel.style.display).not.toBe('none');
+    const tags = Array.from(document.querySelectorAll('#tagsList li')).map(li => (li as HTMLElement).textContent);
+    expect(tags).toEqual(['t1', 't2']);
     const bodyStatic = document.body.innerHTML;
 
     const sourceSel = document.getElementById('source') as HTMLSelectElement;
@@ -97,6 +102,8 @@ describe('claims explorer', () => {
       check();
     });
     expect(at.value).toBe('2025-09-09');
+    const tagsApi = Array.from(document.querySelectorAll('#tagsList li')).map(li => (li as HTMLElement).textContent);
+    expect(tagsApi).toEqual(['t1', 't2']);
     const bodyApi = document.body.innerHTML;
     expect(bodyApi).toBe(bodyStatic);
 
@@ -130,17 +137,9 @@ describe('claims explorer', () => {
     dom.window.close();
   });
 
-  it('renders tags panel only when tags exist', async () => {
+  it('hides tags panel when dataset lacks tags', async () => {
     const { document, dom } = await setup();
     expect(document.getElementById('tagsPanel')!.style.display).toBe('none');
     dom.window.close();
-
-    const data = { ...BASE_DATA, tags: ['t2', 't1'] };
-    const { document: doc2, dom: dom2 } = await setup({ staticData: data });
-    const panel = doc2.getElementById('tagsPanel')!;
-    expect(panel.style.display).not.toBe('none');
-    const tags = Array.from(doc2.getElementById('tagsList')!.children).map(li => (li as HTMLElement).textContent);
-    expect(tags).toEqual(['t1', 't2']);
-    dom2.window.close();
   });
 });


### PR DESCRIPTION
## Summary
- sort dataset proof tags before rendering to keep order stable
- hide tags panel entirely when no proof tags exist

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c54d3a3e248320b5304f64c47f93d0