### PR TITLE
F1: add Pages preview and badge

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
 permissions:
   contents: read
   pages: write
@@ -20,6 +24,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+# F1 — Changes (Run 1)
+
+## Summary
+GitHub Pages workflow builds docs for pull requests as downloadable preview artifacts and deploys on `main`. The README now exposes a deployment badge linking to the live site.
+
+## Why
+- PR runs provide artifacts without public deploys per END_GOAL.
+- Pushes to `main` keep the site live.
+
+## Tests
+- Added: tests/pages-workflow.test.mjs.
+- Updated: .github/workflows/pages.yml; README.md; package.json.
+- Determinism/parity: `pnpm test`.
+
+## Notes
+- No schema changes; minimal surface.
+
 # E2 — Changes (Run 1)
 
 ## Summary

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,3 +1,24 @@
+# COMPLIANCE — F1 — Run 1
+
+## Blockers (must all be ✅)
+- [x] No changes to kernel/tag schemas — n/a
+- [x] No per-call locks; no `static mut`/`unsafe`; no TS `as any` — code link: README.md
+- [x] ESM internal imports include `.js` — code link: tests/pages-workflow.test.mjs
+- [x] Tests parallel-safe, deterministic — test link: tests/pages-workflow.test.mjs
+- [x] PR builds produce artifacts only — code link: .github/workflows/pages.yml
+- [x] `main` deploys live site — code link: .github/workflows/pages.yml
+- [x] README has deployment badge to live site — code link: README.md
+
+## Acceptance (oracle)
+- [x] PR workflow uploads preview artifact; no public deploy — test link: tests/pages-workflow.test.mjs
+- [x] Main workflow deploys to production URL — code link: .github/workflows/pages.yml
+- [x] README badge points to deployed site — code link: README.md
+
+## Evidence
+- Code: .github/workflows/pages.yml; README.md; package.json; tests/pages-workflow.test.mjs
+- Tests: tests/pages-workflow.test.mjs
+- Runs: `pnpm test`
+
 # COMPLIANCE — E2 — Run 1
 
 ## Blockers (must all be ✅)

--- a/OBS_LOG.md
+++ b/OBS_LOG.md
@@ -1,3 +1,11 @@
+# Observation Log — F1 — Run 1
+
+- Strategy chosen: extend Pages workflow for PR previews and gate deploys to `main`; expose live badge in README.
+- Key changes (files): .github/workflows/pages.yml; README.md; tests/pages-workflow.test.mjs; package.json; CHANGES.md; COMPLIANCE.md; REPORT.md.
+- Determinism stress (runs × passes): `pnpm test` — all green.
+- Near-misses vs blockers: ensured deploy step skipped on PRs via `if` guard.
+- Notes: preview artifact uses `upload-pages-artifact`; badge links to live site.
+
 # Observation Log — E2 — Run 1
 
 - Strategy chosen: sort proof tags via `localeCompare` and verify static/API DOM snapshots.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 # TF-Lang Monorepo
+[![pages](https://github.com/LexLattice/tf-lang/actions/workflows/pages.yml/badge.svg)](https://lexlattice.github.io/tf-lang/)
 
 A minimal, deterministic kernel for **True-Function** programs with two runtimes:
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,3 +1,27 @@
+# REPORT — F1 — Run 1
+
+## End Goal fulfillment
+- EG-1: PR builds upload preview artifact without public deploy【F:.github/workflows/pages.yml†L3-L12】【F:tests/pages-workflow.test.mjs†L7-L11】
+- EG-2: `main` deploys site to production and README exposes badge linking to the live URL【F:.github/workflows/pages.yml†L24-L31】【F:README.md†L3-L4】
+
+## Blockers honored
+- B-1: ✅ PR builds produce artifacts only, deploy gated to `main`【F:.github/workflows/pages.yml†L24-L31】
+- B-2: ✅ README badge references live site URL【F:README.md†L3-L4】
+
+## Lessons / tradeoffs (≤5 bullets)
+- Branch guard keeps preview runs private.
+- Minimal workflow keeps build identical across PR and main.
+- Badge leverages GitHub status for visibility.
+
+## Bench notes (optional, off-mode)
+- n/a
+
+## Self-review
+- [x] `pnpm test` passes
+- [x] All blockers satisfied
+- [x] No extraneous commits or files
+- [x] No `as any`, per-call locks, or schema changes
+
 # REPORT — E2 — Run 1
 
 ## End Goal fulfillment

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "tf-lang",
 	"private": true,
         "scripts": {
-        "test": "pnpm run --recursive test",
+                "test": "pnpm run --recursive test && node --test tests/pages-workflow.test.mjs",
                 "build": "pnpm run --recursive build",
                 "preinstall": "npx only-allow pnpm"
         },

--- a/tests/pages-workflow.test.mjs
+++ b/tests/pages-workflow.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const pages = readFileSync('.github/workflows/pages.yml', 'utf8');
+
+test('pages workflow has preview artifact and gated deploy', () => {
+  assert.ok(pages.includes('pull_request'), 'missing pull_request trigger');
+  assert.ok(pages.includes("if: github.ref == 'refs/heads/main'"), 'deploy job not gated to main');
+});
+
+const readme = readFileSync('README.md', 'utf8');
+
+test('README has deployment badge', () => {
+  assert.match(readme, /\[!\[.*\]\(https:\/\/github.com\/.*\/actions\/workflows\/pages.yml\/badge.svg\)\]\(https:\/\/.*github.io\/[^)]+\)/);
+});


### PR DESCRIPTION
## Summary
- build docs on PRs with downloadable preview artifact
- deploy docs on `main` only
- show live deployment badge in README

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c569c1778483208ed9464f229884cb