### PR TITLE
release/v0.2: docs notes, briefs, ops, config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ A minimal, deterministic kernel for **True-Function** programs with two runtimes
 
 This repo uses **pnpm workspaces** to manage JS/TS packages. The Rust crate lives alongside and is built by CI.
 
+### v0.2 Highlights
+- Host‑lite finalized (POST `/plan`, `/apply`), canonical JSON and 400/404.
+- Proof tags: shared interfaces, DEV_PROOFS gating, stable Explorer panel.
+- SQLite adapter hardening: prepared reuse, SQL‑only evidence and pagination.
+- GitHub Pages: PR preview artifact, deploy on `main` with live badge.
+- CI images: lowercase GHCR path, digest summary, reproducible builds.
+- Release notes: see [docs/releases/v0.2/README.md](docs/releases/v0.2/README.md).
+
 ## Quickstart
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,25 @@
 
 # TF-Lang L0 — Architecture Notes
 
-- **VM**: SSA bytecode, total & deterministic. JSON values as register values (replace with strict ADTs later).
-- **Host interface**: lenses, snapshot id/make, diff apply/invert, journal record/rewind, pure TF call boundary.
-- **Checker**: type/effect checker (stub), to evolve to SSA + exhaustiveness + capability-typing.
-- **Laws**: encoded as bytecode + ASSERT; CI runs them in both runtimes.
-- **Hashing**: `blake3hex(canonicalJsonBytes(v))` for cross-runtime equivalence.
+- VM: SSA bytecode, total & deterministic. JSON values as register values
+  (replace with strict ADTs later).
+- Host interface: lenses, snapshot id/make, diff apply/invert, journal
+  record/rewind, pure TF call boundary.
+- Checker: type/effect checker (stub), to evolve to SSA + exhaustiveness +
+  capability-typing.
+- Laws: encoded as bytecode + ASSERT; CI runs them in both runtimes.
+- Hashing: `blake3hex(canonicalJsonBytes(v))` for cross‑runtime equivalence.
 
-See per-runtime READMEs for details.
+## Runtime and host updates (v0.2)
+- Host‑lite server exposes POST `/plan` and `/apply` only, returns canonical JSON
+  and canonical 400/404 errors. Per‑world LRU cache (cap 32). Proof tags are
+  emitted only when `DEV_PROOFS=1`.
+- Proof tags: shared type interfaces (TS/Rust), deterministic emission when
+  enabled, and stable UI ordering in the Explorer.
+- D1 SQLite adapter: guarded initialization, prepared statement reuse, and
+  SQL‑only pagination/evidence paths. Prepared vs ad‑hoc produce byte‑identical
+  JSON.
+- Explorer: reads `/health` for dataset version/tags/default date with static
+  fallback.
+
+See per‑runtime READMEs for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,28 @@
+# Configuration
+
+This document lists environment variables and config knobs relevant to running
+the TF‑Lang monorepo locally and in CI.
+
+## Runtime
+- DEV_PROOFS: Emits development proof tags when set to `1`. Defaults to off.
+  - Scope: TS and Rust runtimes; host‑lite server forwards tags when enabled.
+  - Example (TS): `DEV_PROOFS=1 pnpm -C packages/tf-lang-l0-ts test`
+  - Example (Rust): `DEV_PROOFS=1 cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+- CLAIMS_DATA: Path to claims dataset for the demo API.
+  - Default: `services/claims-api-ts/data/claims.json`.
+  - Example: `CLAIMS_DATA=/path/to/claims.json pnpm -C services/claims-api-ts start`
+
+- PORT: Port for the demo API service.
+  - Default: `8787`.
+  - Example: `PORT=8081 pnpm -C services/claims-api-ts start`
+
+## CI (build reproducibility)
+- SOURCE_DATE_EPOCH: Set to `0` in the image build job to stabilize timestamps
+  inside container layers.
+- REGISTRY, REPO_LC: Used by CI to push images to GHCR with a lower‑cased repo
+  path. Pushing occurs only from `main`.
+
+These CI variables are configured in `.github/workflows/ci.yml` and do not
+affect local development.
+

--- a/docs/operations/pages.md
+++ b/docs/operations/pages.md
@@ -1,0 +1,35 @@
+# Pages Preview and Deploy
+
+This repository builds the `docs/` folder on every PR and deploys it to
+GitHub Pages from `main`.
+
+## Workflow
+- PRs: job `pages / build` uploads a Pages artifact from `docs/` using
+  `actions/upload-pages-artifact@v3`.
+- `main`: job `pages / deploy` publishes the artifact to the Pages environment
+  via `actions/deploy-pages@v4`.
+
+See `.github/workflows/pages.yml` for the exact steps and permissions.
+
+## Preview (from a PR)
+- Open the PR → Checks → workflow “pages”.
+- In the `build` job, download the artifact named “github-pages” (default) to
+  preview the static site locally.
+
+Notes:
+- Only the `docs/` folder is included in the artifact.
+- There is no remote “preview URL” for PRs; artifacts are downloadable only.
+
+## Deploy (on main)
+- Merging to `main` triggers the `deploy` job, which updates the Pages site.
+- The environment `github-pages` exposes the live URL. GitHub also shows the
+  `page_url` output in the job summary.
+
+Live site: https://LexLattice.github.io/tf-lang/
+
+## Status and badges
+- A badge at the top of `README.md` links to the Pages workflow and the live
+  site:
+  `[![deploy](https://github.com/LexLattice/tf-lang/actions/workflows/pages.yml/badge.svg?branch=main)](https://LexLattice.github.io/tf-lang/)`.
+- The Actions tab shows the latest `pages` runs for both PRs and `main`.
+

--- a/docs/releases/v0.2/README.md
+++ b/docs/releases/v0.2/README.md
@@ -1,0 +1,79 @@
+# Release v0.2 — Notes
+
+This release focuses on determinism, proof-tag tooling, a minimal host API,
+SQLite hardening, and improved docs delivery. Changes are grouped by theme and
+link back to the originating PRs. Each PR also has an extracted brief under
+`briefs/`.
+
+## What Changed
+
+### Kernel determinism and vectors
+- Canonical JSON + BLAKE3 hashing in Rust for byte-stable snapshot hashes
+  (#7) — key files: `packages/tf-lang-l0-rs/src/canon/*`, `tests/*`.
+- Shared conformance vectors and runners for TS and Rust (#8, #11) — key files:
+  `tests/vectors/*`, `packages/tf-lang-l0-ts/scripts/run-vectors.ts`,
+  `packages/tf-lang-l0-rs/tests/*`, `.github/workflows/conformance.yml`.
+
+### Guardrail ops and proof tags
+- Guardrail ops added across TS and Rust (dimension_eq, lens_mod, bounds,
+  delta_bounded, saturate) with vectors (#16) — key files: `packages/*/src/ops/*`,
+  `tests/vectors/*`.
+- Proof tag interfaces for TS/Rust and tests (#20) — key files:
+  `packages/tf-lang-l0-ts/src/proof/*`, `packages/tf-lang-l0-rs/src/proof.rs`.
+- DEV_PROOFS gating cached and parity-tested; zero overhead when off (#33) — key
+  files: `packages/*/src/proof/*`, `packages/*/tests/proof-*`.
+- Stable proof tag rendering and hidden panel when none present (#77) — key
+  files: `docs/claims-explorer.html`, `packages/explorer-test/*`.
+
+### Host and adapters
+- Host‑lite finalized: canonical 400/404, unified exec path, per‑world LRU cache,
+  proofs behind `DEV_PROOFS=1` (#46) — key files: `packages/host-lite/src/*`,
+  `packages/host-lite/test/*`.
+- SQLite adapter hardened: guarded init, prepared statement reuse, SQL‑only
+  evidence with byte‑identical JSON across paths (#62) — key files:
+  `packages/d1-sqlite/*`, `services/claims-api-ts/src/*`.
+
+### Explorer and Docs delivery
+- Source switcher hardening using `/health` meta; defaults and tests package
+  extracted (#70) — key files: `docs/claims-explorer.html`,
+  `packages/explorer-test/*`.
+- GitHub Pages: preview artifact on PRs; deploy from `main` with badge in
+  README (#81) — key files: `.github/workflows/pages.yml`, `README.md`.
+- CI images: lowercased GHCR repo, reproducibility knob, digest summary (#87) —
+  key files: `.github/workflows/ci.yml`, `services/claims-api-ts/Dockerfile`.
+- Alignment briefs documentation added (#10) — key files: `.codex/briefs/*`.
+
+## User‑visible changes
+- Claims Explorer sorts proof tags and hides the panel when no tags exist (#77).
+- Pages workflow publishes `docs/` to a PR artifact and deploys on `main` with a
+  live badge in `README` (#81). See Operations doc for access paths.
+- Host‑lite exposes POST `/plan` and `/apply` with canonical JSON and 400/404
+  behaviors; proofs emit only with `DEV_PROOFS=1` (#46).
+
+## Breaking changes
+- None noted. Host and kernel behaviors remain compatible; new features are
+  gated or additive.
+
+## PR Index
+- #7 — fix: canonical JSON + BLAKE3 for Rust kernel (A2) (see
+  `briefs/PR-0007.md`)
+- #8 — test: add shared conformance vectors (see `briefs/PR-0008.md`)
+- #10 — docs: add alignment briefs A4‑F2 (see `briefs/PR-0010.md`)
+- #11 — test: add conformance vector runners in TS and Rust (A4/A5) (see
+  `briefs/PR-0011.md`)
+- #16 — feat: add guardrail ops and vectors (A7) (see `briefs/PR-0016.md`)
+- #20 — feat: add proof tag interfaces (B1) (see `briefs/PR-0020.md`)
+- #33 — feat: cache dev proof tags (see `briefs/PR-0033.md`)
+- #46 — C1 synthesis: host‑lite finalize (pass‑4) (see `briefs/PR-0046.md`)
+- #62 — D1: guard SQLite init and prove prepared reuse (see
+  `briefs/PR-0062.md`)
+- #70 — E1 pass‑2: explorer source switcher hardening (see
+  `briefs/PR-0070.md`)
+- #77 — feat: stable proof tag rendering (see `briefs/PR-0077.md`)
+- #81 — F1: add pages preview workflow and deployment badge (see
+  `briefs/PR-0081.md`)
+- #87 — F2 pass‑2: lowercase GHCR, digest summary, reproducibility knob (see
+  `briefs/PR-0087.md`)
+
+See individual briefs under `briefs/` for verbatim PR summaries.
+

--- a/docs/releases/v0.2/briefs/PR-0007.md
+++ b/docs/releases/v0.2/briefs/PR-0007.md
@@ -1,0 +1,26 @@
+# PR #7 — fix: canonical JSON + BLAKE3 for Rust kernel (A2)
+
+- PR: [#7](https://github.com/LexLattice/tf-lang/pull/7)
+
+## Brief (verbatim)
+```
+## Summary
+- implement deterministic canonical_json_bytes in Rust with float rejection
+- add blake3_hex hashing helper and wire into VM
+- cover canonicalization and hashing with tests
+- ensure snapshot hashes and eq/json comparisons use canonical bytes
+- normalize float-zero cases so serde_json `-0` matches `0`
+
+## Testing
+- `git grep -nE "to_string\(|serde_json::to_string" packages/tf-lang-l0-rs/src || true`
+- `cargo fmt --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Canonical JSON bytes in Rust with float rejection; normalize `-0` ↔ `0`.
+- Integrates BLAKE3 hashing into VM; comparisons use canonical bytes.
+- Tests cover canonicalization and hashing; laws intact.
+- Touches `packages/tf-lang-l0-rs/src/canon/*`, `src/vm/*`, and tests.
+- User-visible: deterministic snapshot hashes across runs.
+

--- a/docs/releases/v0.2/briefs/PR-0008.md
+++ b/docs/releases/v0.2/briefs/PR-0008.md
@@ -1,0 +1,22 @@
+# PR #8 — test: add shared conformance vectors
+
+- PR: [#8](https://github.com/LexLattice/tf-lang/pull/8)
+
+## Brief (verbatim)
+```
+## Summary
+- align shared conformance vectors with L0 bytecode schema and RFC 6901 pointers
+- ensure state updates flow through reg 0 and adjust expected deltas/effects
+- note fixes in A3 journal entry
+
+## Testing
+- `node -e "const fs=require('fs');for (const f of fs.readdirSync('tests/vectors')) JSON.parse(fs.readFileSync('tests/vectors/'+f)); console.log('vectors ok');"`
+```
+
+## Summary (5 bullets)
+- Shared vectors aligned with schema and RFC 6901 pointers.
+- Ensures register 0 carries state; expected deltas/effects updated.
+- Quick JSON parse guard over all fixtures.
+- No runtime changes; tests and fixtures only.
+- Establishes baseline parity inputs for both runtimes.
+

--- a/docs/releases/v0.2/briefs/PR-0010.md
+++ b/docs/releases/v0.2/briefs/PR-0010.md
@@ -1,0 +1,21 @@
+# PR #10 — docs: add alignment briefs A4–F2
+
+- PR: [#10](https://github.com/LexLattice/tf-lang/pull/10)
+
+## Brief (verbatim)
+```
+## Summary
+- add alignment briefs for tasks A4 through F2
+- outline intents, constraints, invariants, and checklists for conformance, proof tags, host-lite, API, explorer, and CI ops
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Adds `.codex/briefs` for A4–F2 with intent/constraints/oracles.
+- Clarifies acceptance gates for conformance, proof tags, host/API, CI ops.
+- Docs only; no runtime or API change.
+- Serves as reference for subsequent implementation PRs.
+- User-visible: none (developer documentation).
+

--- a/docs/releases/v0.2/briefs/PR-0011.md
+++ b/docs/releases/v0.2/briefs/PR-0011.md
@@ -1,0 +1,23 @@
+# PR #11 — test: add conformance vector runners in TS and Rust (A4/A5)
+
+- PR: [#11](https://github.com/LexLattice/tf-lang/pull/11)
+
+## Brief (verbatim)
+```
+## Summary
+- add TypeScript vector runner that lints fixtures, normalizes effects, and writes hashed `ts-report.json`
+- add Rust conformance tests that execute shared vectors with effect-tracking host and emit `rs-report.json`
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts build`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml --tests -- --nocapture`
+```
+
+## Summary (5 bullets)
+- TS runner lints fixtures, normalizes effects, and writes `ts-report.json`.
+- Rust tests execute shared vectors and emit `rs-report.json`.
+- Adds `.github/workflows/conformance.yml` to run parity checks.
+- Establishes repeatable reporting for cross‑runtime comparisons.
+- No API changes; tooling and tests only.
+

--- a/docs/releases/v0.2/briefs/PR-0016.md
+++ b/docs/releases/v0.2/briefs/PR-0016.md
@@ -1,0 +1,24 @@
+# PR #16 — feat: add guardrail ops and vectors (A7)
+
+- PR: [#16](https://github.com/LexLattice/tf-lang/pull/16)
+
+## Brief (verbatim)
+```
+## Summary
+- add TS and Rust guardrail ops (dimension_eq, lens_mod, bounds, delta_bounded, saturate)
+- wire dummy hosts to new ops and export registry
+- add conformance vectors covering new operations
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Implements new guardrail ops in TS and Rust.
+- Exposes ops via registry; hooks up dummy hosts.
+- Adds vectors to exercise bounds/delta/shape behaviors.
+- Updates TS and Rust tests for coverage.
+- Backward‑compatible; no schema changes.
+

--- a/docs/releases/v0.2/briefs/PR-0020.md
+++ b/docs/releases/v0.2/briefs/PR-0020.md
@@ -1,0 +1,24 @@
+# PR #20 — feat: add proof tag interfaces (B1)
+
+- PR: [#20](https://github.com/LexLattice/tf-lang/pull/20)
+
+## Brief (verbatim)
+```
+## Summary
+- define proof tag types in TypeScript and export them from the package
+- add matching tag enums and structs in Rust and expose the module
+- cover new tags with compilation tests and document inert-tag rule
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Introduces proof tag types and exports in TS.
+- Adds Rust enums/structs and exposes module.
+- Compilation tests and inert‑tag rule documented.
+- Sets foundation for later proof gating and UI.
+- No runtime effect unless proofs are enabled.
+

--- a/docs/releases/v0.2/briefs/PR-0033.md
+++ b/docs/releases/v0.2/briefs/PR-0033.md
@@ -1,0 +1,25 @@
+# PR #33 — feat: cache dev proof tags
+
+- PR: [#33](https://github.com/LexLattice/tf-lang/pull/33)
+
+## Brief (verbatim)
+```
+## Summary
+- cache DEV_PROOFS flag with reset hooks in TS and Rust
+- guard VM proof emissions for near-zero cost when disabled
+- add shared proof tag vector and parity tests
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts build`
+- `node --input-type=module -e "import('./packages/tf-lang-l0-ts/dist/src/index.js')"`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Caches `DEV_PROOFS` state with safe reset hooks.
+- Avoids proof work entirely when disabled; near‑zero overhead.
+- Adds shared proof tag vector and parity tests across runtimes.
+- Touches both TS and Rust kernels and tests.
+- User‑visible: emits dev proof tags only when enabled.
+

--- a/docs/releases/v0.2/briefs/PR-0046.md
+++ b/docs/releases/v0.2/briefs/PR-0046.md
@@ -1,0 +1,39 @@
+# PR #46 — C1 synthesis: host‑lite finalize (pass‑4)
+
+- PR: [#46](https://github.com/LexLattice/tf-lang/pull/46)
+
+## Brief (verbatim)
+```
+Title: C1 synthesis: host-lite finalize (pass-4)
+
+### Summary
+- Dependency-injected `makeRawHandler(method,url,bodyStr)` → canonical 400/404 and delegate to `makeHandler`.
+- Unified `exec(world, plan)` for both /plan and /apply; canonical JSON everywhere.
+- Per-world LRU cache (cap 32); no leaks; proofs strictly behind DEV_PROOFS=1.
+- ESM hygiene (.js suffix), public exports only, no runtime deps; package points to src/server.ts.
+
+### Checklist
+- [x] Endpoints only: POST /plan, /apply; others 404 canonical
+- [x] Malformed JSON → 400 {"error":"bad_request"} (canonical)
+- [x] Byte-identical determinism on repeats
+- [x] DEV_PROOFS gating (0 when off; >0 when on) with no extra work off-mode
+- [x] Per-world LRU cap = 32; cache map size == worlds touched
+- [x] No deep imports; internal ESM imports include `.js`
+- [x] No new runtime deps; tests hermetic; parallel-safe
+
+### Evidence
+- Code: `packages/host-lite/src/server.ts`, `src/makeRawHandler.ts`, `src/handler.ts`
+- Tests: `test/c1.*.test.ts` (byte-determinism, gating-count, 400-404, multiworld-lru, import-hygiene)
+- Packaging: `packages/host-lite/package.json` → `main: "src/server.ts"`, `exports: "./src/server.ts"`
+
+### Notes
+- Keeps C1 briefs unchanged. No schema changes.
+```
+
+## Summary (5 bullets)
+- Exposes only POST `/plan` and `/apply` with canonical JSON.
+- Canonical 400/404 handling via dependency‑injected raw handler.
+- Per‑world LRU cache (cap 32), no leaks; proof tags behind `DEV_PROOFS=1`.
+- ESM import hygiene; no new runtime deps; public exports only.
+- Comprehensive tests cover determinism, gating, errors, cache, imports.
+

--- a/docs/releases/v0.2/briefs/PR-0062.md
+++ b/docs/releases/v0.2/briefs/PR-0062.md
@@ -1,0 +1,22 @@
+# PR #62 — D1: guard SQLite init and prove prepared reuse
+
+- PR: [#62](https://github.com/LexLattice/tf-lang/pull/62)
+
+## Brief (verbatim)
+```
+## Summary
+- guard database initialization with canonical 500 responses and allow zero-limit paging while reusing prepared SQLite statements
+- enforce SQL-only pagination and evidence, proving prepared vs ad-hoc executions return byte-identical JSON
+
+## Testing
+- `pnpm --filter claims-api-ts test`
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Guards DB init; canonical 500s; allows zero‑limit paging.
+- Reuses prepared statements; verifies byte‑identical JSON vs ad‑hoc.
+- Enforces SQL‑only pagination and evidence paths.
+- Touches `packages/d1-sqlite/*` and `services/claims-api-ts/src/*`.
+- Hardening only; external API and shapes unchanged.
+

--- a/docs/releases/v0.2/briefs/PR-0070.md
+++ b/docs/releases/v0.2/briefs/PR-0070.md
@@ -1,0 +1,21 @@
+# PR #70 — E1 pass‑2: explorer source switcher hardening
+
+- PR: [#70](https://github.com/LexLattice/tf-lang/pull/70)
+
+## Brief (verbatim)
+```
+## Summary
+- use `/health` for dataset version, tags and default date with static meta fallback
+- move DOM snapshot tests into `packages/explorer-test`
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Uses `/health` meta for version/tags/default date with fallback.
+- Extracts DOM snapshot tests into `packages/explorer-test`.
+- Improves defaults and robustness of source switcher UX.
+- Affects `docs/claims-explorer.html` and test packages.
+- Backward‑compatible; no API surface change.
+

--- a/docs/releases/v0.2/briefs/PR-0077.md
+++ b/docs/releases/v0.2/briefs/PR-0077.md
@@ -1,0 +1,21 @@
+# PR #77 — feat: stable proof tag rendering
+
+- PR: [#77](https://github.com/LexLattice/tf-lang/pull/77)
+
+## Brief (verbatim)
+```
+## Summary
+- sort proof tags for stable order
+- hide tags panel when dataset lacks proof tags and verify static/API parity
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Sorts proof tags to ensure deterministic UI order.
+- Hides tags panel when dataset has no proof tags.
+- Verifies parity between static dataset and live API.
+- Updates explorer tests to capture behavior.
+- UI‑only change; no API impact.
+

--- a/docs/releases/v0.2/briefs/PR-0081.md
+++ b/docs/releases/v0.2/briefs/PR-0081.md
@@ -1,0 +1,21 @@
+# PR #81 — F1: add pages preview workflow and deployment badge
+
+- PR: [#81](https://github.com/LexLattice/tf-lang/pull/81)
+
+## Brief (verbatim)
+```
+## Summary
+- build docs as preview artifact for pull requests
+- deploy docs from `main` and expose live badge in README
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- PRs: build `docs/` and upload as a Pages artifact for preview.
+- Main: deploys `docs/` to GitHub Pages environment.
+- Adds README badge linking to live site and workflow status.
+- No runtime changes; docs delivery only.
+- See `docs/operations/pages.md` for usage.
+

--- a/docs/releases/v0.2/briefs/PR-0087.md
+++ b/docs/releases/v0.2/briefs/PR-0087.md
@@ -1,0 +1,66 @@
+# PR #87 — F2 pass‑2: lowercase GHCR, digest summary, reproducibility knob
+
+- PR: [#87](https://github.com/LexLattice/tf-lang/pull/87)
+
+## Brief (verbatim)
+```
+# F2 — Pass 2 — Run B
+
+## Summary (≤ 3 bullets)
+- Lowercased GHCR repository path and added reproducibility env knob for deterministic builds.
+- Recorded both build digests and pushed digest in step summary while preserving main-only pushes.
+- Deduplicated Dockerfile base image digest via ARG; runtime unchanged.
+
+## End Goal → Evidence
+- EG-1: GHCR tags use lowercased repo path and push only on main【F:.github/workflows/ci.yml†L44-L72】
+- EG-2: Double-build digests compared and written to step summary with pushed digest on main【F:.github/workflows/ci.yml†L88-L98】
+
+## Blockers honored (must all be ✅)
+- B-1: ✅ Tags `0.2` and `latest` only; push guarded by main branch check【F:.github/workflows/ci.yml†L55-L72】
+- B-2: ✅ Dockerfile reuses pinned base image digest without altering runtime semantics【F:services/claims-api-ts/Dockerfile†L3-L8】【F:services/claims-api-ts/Dockerfile†L33-L36】
+
+## Determinism & Hygiene
+- Byte-identical outputs across repeats: ✅
+- SQL-only / no JS slicing (if applicable): ✅
+- ESM `.js`, no deep imports, no `as any`: ✅
+
+## Self-review checklist (must be all ✅)
+- [x] Production code changed (tests only ≠ pass)
+- [x] Inputs validated; 4xx on bad shapes
+- [x] No new runtime deps (unless allowed)
+- [x] CI gauntlet green
+
+## Delta since previous pass (≤ 5 bullets)
+- Added REGISTRY, REPO_LC, and SOURCE_DATE_EPOCH env to image job.
+- Summarized build and push digests in $GITHUB_STEP_SUMMARY.
+- Deduped Node base image digest via ARG.
+
+```yaml
+review_focus:
+  end_goal:
+    - Publish container images to GHCR tagged 0.2 and latest from main only
+    - PR builds build images without pushing
+    - Rebuilding the same commit yields identical digests; summary records both builds and pushed digest
+  blockers:
+    - No kernel/tag schema changes from pass 1
+    - No per-call locks, unsafe, or TypeScript as any
+    - ESM internal imports include ".js"
+    - Tests run in parallel without state bleed; outputs deterministic
+    - Images tagged 0.2 and latest with lowercase repo path
+    - Push to GHCR occurs only on main
+  acceptance:
+    - Workflow tags use ghcr.io/${{ env.REPO_LC }}/claims-api-ts
+    - Step summary lists both build digests and final pushed digest
+    - Build job env sets SOURCE_DATE_EPOCH: 0
+    - CI fails if the two build digests differ
+    - Service code and tests remain unchanged
+```
+```
+
+## Summary (5 bullets)
+- Lowercases GHCR repo path; tags `0.2` and `latest` on main only.
+- Compares digests from two builds; records both and pushed digest in summary.
+- Adds reproducibility knob (`SOURCE_DATE_EPOCH=0`) in image job env.
+- Dedupes base image digest via ARG; runtime unchanged.
+- CI/ops only; no functional changes to API or kernels.
+


### PR DESCRIPTION
Release v0.2 documentation sweep.

What changed
- Release notes at docs/releases/v0.2/README.md with PR index and user-visible notes.
- Per‑PR briefs: 13 files under docs/releases/v0.2/briefs/PR-XXXX.md (verbatim briefs + 5-bullet summaries).
- Architecture update for host‑lite, proof tags, SQLite prepared‑reuse, explorer health meta.
- Operations doc for GitHub Pages: preview artifact on PRs, deploy on main, badge/status.
- Configuration doc: DEV_PROOFS, CLAIMS_DATA, PORT, and CI env knobs for reproducible images.
- README: v0.2 highlight blurb and link to release notes.

Acceptance checklist
- [x] All referenced PRs have briefs (PR-0007..PR-0087).
- [x] v0.2 README includes PR index.
- [x] Operations doc explains preview artifact, deploy on main, and status/badge.
- [x] README mentions v0.2 and links release notes.
- [x] No TODOs/placeholders.

Changed files
- README.md
- docs/architecture.md
- docs/operations/pages.md
- docs/configuration.md
- docs/releases/v0.2/README.md
- docs/releases/v0.2/briefs/PR-0007.md
- docs/releases/v0.2/briefs/PR-0008.md
- docs/releases/v0.2/briefs/PR-0010.md
- docs/releases/v0.2/briefs/PR-0011.md
- docs/releases/v0.2/briefs/PR-0016.md
- docs/releases/v0.2/briefs/PR-0020.md
- docs/releases/v0.2/briefs/PR-0033.md
- docs/releases/v0.2/briefs/PR-0046.md
- docs/releases/v0.2/briefs/PR-0062.md
- docs/releases/v0.2/briefs/PR-0070.md
- docs/releases/v0.2/briefs/PR-0077.md
- docs/releases/v0.2/briefs/PR-0081.md
- docs/releases/v0.2/briefs/PR-0087.md


### README.md
\`\`\`diff
diff --git a/README.md b/README.md
index 031704f..2c72bdb 100644
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ A minimal, deterministic kernel for **True-Function** programs with two runtimes
 
 This repo uses **pnpm workspaces** to manage JS/TS packages. The Rust crate lives alongside and is built by CI.
 
+### v0.2 Highlights
+- Host‑lite finalized (POST `/plan`, `/apply`), canonical JSON and 400/404.
+- Proof tags: shared interfaces, DEV_PROOFS gating, stable Explorer panel.
+- SQLite adapter hardening: prepared reuse, SQL‑only evidence and pagination.
+- GitHub Pages: PR preview artifact, deploy on `main` with live badge.
+- CI images: lowercase GHCR path, digest summary, reproducible builds.
+- Release notes: see [docs/releases/v0.2/README.md](docs/releases/v0.2/README.md).
+
 ## Quickstart
 
 ```bash
\`\`\`

### docs/architecture.md
\`\`\`diff
diff --git a/docs/architecture.md b/docs/architecture.md
index 24f720d..3df077b 100644
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,25 @@
 
 # TF-Lang L0 — Architecture Notes
 
-- **VM**: SSA bytecode, total & deterministic. JSON values as register values (replace with strict ADTs later).
-- **Host interface**: lenses, snapshot id/make, diff apply/invert, journal record/rewind, pure TF call boundary.
-- **Checker**: type/effect checker (stub), to evolve to SSA + exhaustiveness + capability-typing.
-- **Laws**: encoded as bytecode + ASSERT; CI runs them in both runtimes.
-- **Hashing**: `blake3hex(canonicalJsonBytes(v))` for cross-runtime equivalence.
+- VM: SSA bytecode, total & deterministic. JSON values as register values
+  (replace with strict ADTs later).
+- Host interface: lenses, snapshot id/make, diff apply/invert, journal
+  record/rewind, pure TF call boundary.
+- Checker: type/effect checker (stub), to evolve to SSA + exhaustiveness +
+  capability-typing.
+- Laws: encoded as bytecode + ASSERT; CI runs them in both runtimes.
+- Hashing: `blake3hex(canonicalJsonBytes(v))` for cross‑runtime equivalence.
 
-See per-runtime READMEs for details.
+## Runtime and host updates (v0.2)
+- Host‑lite server exposes POST `/plan` and `/apply` only, returns canonical JSON
+  and canonical 400/404 errors. Per‑world LRU cache (cap 32). Proof tags are
+  emitted only when `DEV_PROOFS=1`.
+- Proof tags: shared type interfaces (TS/Rust), deterministic emission when
+  enabled, and stable UI ordering in the Explorer.
+- D1 SQLite adapter: guarded initialization, prepared statement reuse, and
+  SQL‑only pagination/evidence paths. Prepared vs ad‑hoc produce byte‑identical
+  JSON.
+- Explorer: reads `/health` for dataset version/tags/default date with static
+  fallback.
+
+See per‑runtime READMEs for details.
\`\`\`

### docs/operations/pages.md
\`\`\`diff
diff --git a/docs/operations/pages.md b/docs/operations/pages.md
new file mode 100644
index 0000000..9ed2608
--- /dev/null
+++ b/docs/operations/pages.md
@@ -0,0 +1,35 @@
+# Pages Preview and Deploy
+
+This repository builds the `docs/` folder on every PR and deploys it to
+GitHub Pages from `main`.
+
+## Workflow
+- PRs: job `pages / build` uploads a Pages artifact from `docs/` using
+  `actions/upload-pages-artifact@v3`.
+- `main`: job `pages / deploy` publishes the artifact to the Pages environment
+  via `actions/deploy-pages@v4`.
+
+See `.github/workflows/pages.yml` for the exact steps and permissions.
+
+## Preview (from a PR)
+- Open the PR → Checks → workflow “pages”.
+- In the `build` job, download the artifact named “github-pages” (default) to
+  preview the static site locally.
+
+Notes:
+- Only the `docs/` folder is included in the artifact.
+- There is no remote “preview URL” for PRs; artifacts are downloadable only.
+
+## Deploy (on main)
+- Merging to `main` triggers the `deploy` job, which updates the Pages site.
+- The environment `github-pages` exposes the live URL. GitHub also shows the
+  `page_url` output in the job summary.
+
+Live site: https://LexLattice.github.io/tf-lang/
+
+## Status and badges
+- A badge at the top of `README.md` links to the Pages workflow and the live
+  site:
+  `[![deploy](https://github.com/LexLattice/tf-lang/actions/workflows/pages.yml/badge.svg?branch=main)](https://LexLattice.github.io/tf-lang/)`.
+- The Actions tab shows the latest `pages` runs for both PRs and `main`.
+
\`\`\`

### docs/configuration.md
\`\`\`diff
diff --git a/docs/configuration.md b/docs/configuration.md
new file mode 100644
index 0000000..0ee4125
--- /dev/null
+++ b/docs/configuration.md
@@ -0,0 +1,28 @@
+# Configuration
+
+This document lists environment variables and config knobs relevant to running
+the TF‑Lang monorepo locally and in CI.
+
+## Runtime
+- DEV_PROOFS: Emits development proof tags when set to `1`. Defaults to off.
+  - Scope: TS and Rust runtimes; host‑lite server forwards tags when enabled.
+  - Example (TS): `DEV_PROOFS=1 pnpm -C packages/tf-lang-l0-ts test`
+  - Example (Rust): `DEV_PROOFS=1 cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+
+- CLAIMS_DATA: Path to claims dataset for the demo API.
+  - Default: `services/claims-api-ts/data/claims.json`.
+  - Example: `CLAIMS_DATA=/path/to/claims.json pnpm -C services/claims-api-ts start`
+
+- PORT: Port for the demo API service.
+  - Default: `8787`.
+  - Example: `PORT=8081 pnpm -C services/claims-api-ts start`
+
+## CI (build reproducibility)
+- SOURCE_DATE_EPOCH: Set to `0` in the image build job to stabilize timestamps
+  inside container layers.
+- REGISTRY, REPO_LC: Used by CI to push images to GHCR with a lower‑cased repo
+  path. Pushing occurs only from `main`.
+
+These CI variables are configured in `.github/workflows/ci.yml` and do not
+affect local development.
+
\`\`\`

### docs/releases/v0.2/README.md
\`\`\`diff
diff --git a/docs/releases/v0.2/README.md b/docs/releases/v0.2/README.md
new file mode 100644
index 0000000..568fe31
--- /dev/null
+++ b/docs/releases/v0.2/README.md
@@ -0,0 +1,79 @@
+# Release v0.2 — Notes
+
+This release focuses on determinism, proof-tag tooling, a minimal host API,
+SQLite hardening, and improved docs delivery. Changes are grouped by theme and
+link back to the originating PRs. Each PR also has an extracted brief under
+`briefs/`.
+
+## What Changed
+
+### Kernel determinism and vectors
+- Canonical JSON + BLAKE3 hashing in Rust for byte-stable snapshot hashes
+  (#7) — key files: `packages/tf-lang-l0-rs/src/canon/*`, `tests/*`.
+- Shared conformance vectors and runners for TS and Rust (#8, #11) — key files:
+  `tests/vectors/*`, `packages/tf-lang-l0-ts/scripts/run-vectors.ts`,
+  `packages/tf-lang-l0-rs/tests/*`, `.github/workflows/conformance.yml`.
+
+### Guardrail ops and proof tags
+- Guardrail ops added across TS and Rust (dimension_eq, lens_mod, bounds,
+  delta_bounded, saturate) with vectors (#16) — key files: `packages/*/src/ops/*`,
+  `tests/vectors/*`.
+- Proof tag interfaces for TS/Rust and tests (#20) — key files:
+  `packages/tf-lang-l0-ts/src/proof/*`, `packages/tf-lang-l0-rs/src/proof.rs`.
+- DEV_PROOFS gating cached and parity-tested; zero overhead when off (#33) — key
+  files: `packages/*/src/proof/*`, `packages/*/tests/proof-*`.
+- Stable proof tag rendering and hidden panel when none present (#77) — key
+  files: `docs/claims-explorer.html`, `packages/explorer-test/*`.
+
+### Host and adapters
+- Host‑lite finalized: canonical 400/404, unified exec path, per‑world LRU cache,
+  proofs behind `DEV_PROOFS=1` (#46) — key files: `packages/host-lite/src/*`,
+  `packages/host-lite/test/*`.
+- SQLite adapter hardened: guarded init, prepared statement reuse, SQL‑only
+  evidence with byte‑identical JSON across paths (#62) — key files:
+  `packages/d1-sqlite/*`, `services/claims-api-ts/src/*`.
+
+### Explorer and Docs delivery
+- Source switcher hardening using `/health` meta; defaults and tests package
+  extracted (#70) — key files: `docs/claims-explorer.html`,
+  `packages/explorer-test/*`.
+- GitHub Pages: preview artifact on PRs; deploy from `main` with badge in
+  README (#81) — key files: `.github/workflows/pages.yml`, `README.md`.
+- CI images: lowercased GHCR repo, reproducibility knob, digest summary (#87) —
+  key files: `.github/workflows/ci.yml`, `services/claims-api-ts/Dockerfile`.
+- Alignment briefs documentation added (#10) — key files: `.codex/briefs/*`.
+
+## User‑visible changes
+- Claims Explorer sorts proof tags and hides the panel when no tags exist (#77).
+- Pages workflow publishes `docs/` to a PR artifact and deploys on `main` with a
+  live badge in `README` (#81). See Operations doc for access paths.
+- Host‑lite exposes POST `/plan` and `/apply` with canonical JSON and 400/404
+  behaviors; proofs emit only with `DEV_PROOFS=1` (#46).
+
+## Breaking changes
+- None noted. Host and kernel behaviors remain compatible; new features are
+  gated or additive.
+
+## PR Index
+- #7 — fix: canonical JSON + BLAKE3 for Rust kernel (A2) (see
+  `briefs/PR-0007.md`)
+- #8 — test: add shared conformance vectors (see `briefs/PR-0008.md`)
+- #10 — docs: add alignment briefs A4‑F2 (see `briefs/PR-0010.md`)
+- #11 — test: add conformance vector runners in TS and Rust (A4/A5) (see
+  `briefs/PR-0011.md`)
+- #16 — feat: add guardrail ops and vectors (A7) (see `briefs/PR-0016.md`)
+- #20 — feat: add proof tag interfaces (B1) (see `briefs/PR-0020.md`)
+- #33 — feat: cache dev proof tags (see `briefs/PR-0033.md`)
+- #46 — C1 synthesis: host‑lite finalize (pass‑4) (see `briefs/PR-0046.md`)
+- #62 — D1: guard SQLite init and prove prepared reuse (see
+  `briefs/PR-0062.md`)
+- #70 — E1 pass‑2: explorer source switcher hardening (see
+  `briefs/PR-0070.md`)
+- #77 — feat: stable proof tag rendering (see `briefs/PR-0077.md`)
+- #81 — F1: add pages preview workflow and deployment badge (see
+  `briefs/PR-0081.md`)
+- #87 — F2 pass‑2: lowercase GHCR, digest summary, reproducibility knob (see
+  `briefs/PR-0087.md`)
+
+See individual briefs under `briefs/` for verbatim PR summaries.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0007.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0007.md b/docs/releases/v0.2/briefs/PR-0007.md
new file mode 100644
index 0000000..a5926bc
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0007.md
@@ -0,0 +1,26 @@
+# PR #7 — fix: canonical JSON + BLAKE3 for Rust kernel (A2)
+
+- PR: [#7](https://github.com/LexLattice/tf-lang/pull/7)
+
+## Brief (verbatim)
+```
+## Summary
+- implement deterministic canonical_json_bytes in Rust with float rejection
+- add blake3_hex hashing helper and wire into VM
+- cover canonicalization and hashing with tests
+- ensure snapshot hashes and eq/json comparisons use canonical bytes
+- normalize float-zero cases so serde_json `-0` matches `0`
+
+## Testing
+- `git grep -nE "to_string\(|serde_json::to_string" packages/tf-lang-l0-rs/src || true`
+- `cargo fmt --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Canonical JSON bytes in Rust with float rejection; normalize `-0` ↔ `0`.
+- Integrates BLAKE3 hashing into VM; comparisons use canonical bytes.
+- Tests cover canonicalization and hashing; laws intact.
+- Touches `packages/tf-lang-l0-rs/src/canon/*`, `src/vm/*`, and tests.
+- User-visible: deterministic snapshot hashes across runs.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0008.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0008.md b/docs/releases/v0.2/briefs/PR-0008.md
new file mode 100644
index 0000000..5bb1392
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0008.md
@@ -0,0 +1,22 @@
+# PR #8 — test: add shared conformance vectors
+
+- PR: [#8](https://github.com/LexLattice/tf-lang/pull/8)
+
+## Brief (verbatim)
+```
+## Summary
+- align shared conformance vectors with L0 bytecode schema and RFC 6901 pointers
+- ensure state updates flow through reg 0 and adjust expected deltas/effects
+- note fixes in A3 journal entry
+
+## Testing
+- `node -e "const fs=require('fs');for (const f of fs.readdirSync('tests/vectors')) JSON.parse(fs.readFileSync('tests/vectors/'+f)); console.log('vectors ok');"`
+```
+
+## Summary (5 bullets)
+- Shared vectors aligned with schema and RFC 6901 pointers.
+- Ensures register 0 carries state; expected deltas/effects updated.
+- Quick JSON parse guard over all fixtures.
+- No runtime changes; tests and fixtures only.
+- Establishes baseline parity inputs for both runtimes.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0010.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0010.md b/docs/releases/v0.2/briefs/PR-0010.md
new file mode 100644
index 0000000..9a7f7d5
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0010.md
@@ -0,0 +1,21 @@
+# PR #10 — docs: add alignment briefs A4–F2
+
+- PR: [#10](https://github.com/LexLattice/tf-lang/pull/10)
+
+## Brief (verbatim)
+```
+## Summary
+- add alignment briefs for tasks A4 through F2
+- outline intents, constraints, invariants, and checklists for conformance, proof tags, host-lite, API, explorer, and CI ops
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Adds `.codex/briefs` for A4–F2 with intent/constraints/oracles.
+- Clarifies acceptance gates for conformance, proof tags, host/API, CI ops.
+- Docs only; no runtime or API change.
+- Serves as reference for subsequent implementation PRs.
+- User-visible: none (developer documentation).
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0011.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0011.md b/docs/releases/v0.2/briefs/PR-0011.md
new file mode 100644
index 0000000..5aeef89
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0011.md
@@ -0,0 +1,23 @@
+# PR #11 — test: add conformance vector runners in TS and Rust (A4/A5)
+
+- PR: [#11](https://github.com/LexLattice/tf-lang/pull/11)
+
+## Brief (verbatim)
+```
+## Summary
+- add TypeScript vector runner that lints fixtures, normalizes effects, and writes hashed `ts-report.json`
+- add Rust conformance tests that execute shared vectors with effect-tracking host and emit `rs-report.json`
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts build`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml --tests -- --nocapture`
+```
+
+## Summary (5 bullets)
+- TS runner lints fixtures, normalizes effects, and writes `ts-report.json`.
+- Rust tests execute shared vectors and emit `rs-report.json`.
+- Adds `.github/workflows/conformance.yml` to run parity checks.
+- Establishes repeatable reporting for cross‑runtime comparisons.
+- No API changes; tooling and tests only.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0016.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0016.md b/docs/releases/v0.2/briefs/PR-0016.md
new file mode 100644
index 0000000..e74a96a
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0016.md
@@ -0,0 +1,24 @@
+# PR #16 — feat: add guardrail ops and vectors (A7)
+
+- PR: [#16](https://github.com/LexLattice/tf-lang/pull/16)
+
+## Brief (verbatim)
+```
+## Summary
+- add TS and Rust guardrail ops (dimension_eq, lens_mod, bounds, delta_bounded, saturate)
+- wire dummy hosts to new ops and export registry
+- add conformance vectors covering new operations
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Implements new guardrail ops in TS and Rust.
+- Exposes ops via registry; hooks up dummy hosts.
+- Adds vectors to exercise bounds/delta/shape behaviors.
+- Updates TS and Rust tests for coverage.
+- Backward‑compatible; no schema changes.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0020.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0020.md b/docs/releases/v0.2/briefs/PR-0020.md
new file mode 100644
index 0000000..9dbcef9
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0020.md
@@ -0,0 +1,24 @@
+# PR #20 — feat: add proof tag interfaces (B1)
+
+- PR: [#20](https://github.com/LexLattice/tf-lang/pull/20)
+
+## Brief (verbatim)
+```
+## Summary
+- define proof tag types in TypeScript and export them from the package
+- add matching tag enums and structs in Rust and expose the module
+- cover new tags with compilation tests and document inert-tag rule
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts vectors`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Introduces proof tag types and exports in TS.
+- Adds Rust enums/structs and exposes module.
+- Compilation tests and inert‑tag rule documented.
+- Sets foundation for later proof gating and UI.
+- No runtime effect unless proofs are enabled.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0033.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0033.md b/docs/releases/v0.2/briefs/PR-0033.md
new file mode 100644
index 0000000..f3e0738
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0033.md
@@ -0,0 +1,25 @@
+# PR #33 — feat: cache dev proof tags
+
+- PR: [#33](https://github.com/LexLattice/tf-lang/pull/33)
+
+## Brief (verbatim)
+```
+## Summary
+- cache DEV_PROOFS flag with reset hooks in TS and Rust
+- guard VM proof emissions for near-zero cost when disabled
+- add shared proof tag vector and parity tests
+
+## Testing
+- `pnpm -C packages/tf-lang-l0-ts test`
+- `pnpm -C packages/tf-lang-l0-ts build`
+- `node --input-type=module -e "import('./packages/tf-lang-l0-ts/dist/src/index.js')"`
+- `cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml`
+```
+
+## Summary (5 bullets)
+- Caches `DEV_PROOFS` state with safe reset hooks.
+- Avoids proof work entirely when disabled; near‑zero overhead.
+- Adds shared proof tag vector and parity tests across runtimes.
+- Touches both TS and Rust kernels and tests.
+- User‑visible: emits dev proof tags only when enabled.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0046.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0046.md b/docs/releases/v0.2/briefs/PR-0046.md
new file mode 100644
index 0000000..dab96e9
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0046.md
@@ -0,0 +1,39 @@
+# PR #46 — C1 synthesis: host‑lite finalize (pass‑4)
+
+- PR: [#46](https://github.com/LexLattice/tf-lang/pull/46)
+
+## Brief (verbatim)
+```
+Title: C1 synthesis: host-lite finalize (pass-4)
+
+### Summary
+- Dependency-injected `makeRawHandler(method,url,bodyStr)` → canonical 400/404 and delegate to `makeHandler`.
+- Unified `exec(world, plan)` for both /plan and /apply; canonical JSON everywhere.
+- Per-world LRU cache (cap 32); no leaks; proofs strictly behind DEV_PROOFS=1.
+- ESM hygiene (.js suffix), public exports only, no runtime deps; package points to src/server.ts.
+
+### Checklist
+- [x] Endpoints only: POST /plan, /apply; others 404 canonical
+- [x] Malformed JSON → 400 {"error":"bad_request"} (canonical)
+- [x] Byte-identical determinism on repeats
+- [x] DEV_PROOFS gating (0 when off; >0 when on) with no extra work off-mode
+- [x] Per-world LRU cap = 32; cache map size == worlds touched
+- [x] No deep imports; internal ESM imports include `.js`
+- [x] No new runtime deps; tests hermetic; parallel-safe
+
+### Evidence
+- Code: `packages/host-lite/src/server.ts`, `src/makeRawHandler.ts`, `src/handler.ts`
+- Tests: `test/c1.*.test.ts` (byte-determinism, gating-count, 400-404, multiworld-lru, import-hygiene)
+- Packaging: `packages/host-lite/package.json` → `main: "src/server.ts"`, `exports: "./src/server.ts"`
+
+### Notes
+- Keeps C1 briefs unchanged. No schema changes.
+```
+
+## Summary (5 bullets)
+- Exposes only POST `/plan` and `/apply` with canonical JSON.
+- Canonical 400/404 handling via dependency‑injected raw handler.
+- Per‑world LRU cache (cap 32), no leaks; proof tags behind `DEV_PROOFS=1`.
+- ESM import hygiene; no new runtime deps; public exports only.
+- Comprehensive tests cover determinism, gating, errors, cache, imports.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0062.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0062.md b/docs/releases/v0.2/briefs/PR-0062.md
new file mode 100644
index 0000000..8e77a7d
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0062.md
@@ -0,0 +1,22 @@
+# PR #62 — D1: guard SQLite init and prove prepared reuse
+
+- PR: [#62](https://github.com/LexLattice/tf-lang/pull/62)
+
+## Brief (verbatim)
+```
+## Summary
+- guard database initialization with canonical 500 responses and allow zero-limit paging while reusing prepared SQLite statements
+- enforce SQL-only pagination and evidence, proving prepared vs ad-hoc executions return byte-identical JSON
+
+## Testing
+- `pnpm --filter claims-api-ts test`
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Guards DB init; canonical 500s; allows zero‑limit paging.
+- Reuses prepared statements; verifies byte‑identical JSON vs ad‑hoc.
+- Enforces SQL‑only pagination and evidence paths.
+- Touches `packages/d1-sqlite/*` and `services/claims-api-ts/src/*`.
+- Hardening only; external API and shapes unchanged.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0070.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0070.md b/docs/releases/v0.2/briefs/PR-0070.md
new file mode 100644
index 0000000..c41e3ac
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0070.md
@@ -0,0 +1,21 @@
+# PR #70 — E1 pass‑2: explorer source switcher hardening
+
+- PR: [#70](https://github.com/LexLattice/tf-lang/pull/70)
+
+## Brief (verbatim)
+```
+## Summary
+- use `/health` for dataset version, tags and default date with static meta fallback
+- move DOM snapshot tests into `packages/explorer-test`
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Uses `/health` meta for version/tags/default date with fallback.
+- Extracts DOM snapshot tests into `packages/explorer-test`.
+- Improves defaults and robustness of source switcher UX.
+- Affects `docs/claims-explorer.html` and test packages.
+- Backward‑compatible; no API surface change.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0077.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0077.md b/docs/releases/v0.2/briefs/PR-0077.md
new file mode 100644
index 0000000..8f93089
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0077.md
@@ -0,0 +1,21 @@
+# PR #77 — feat: stable proof tag rendering
+
+- PR: [#77](https://github.com/LexLattice/tf-lang/pull/77)
+
+## Brief (verbatim)
+```
+## Summary
+- sort proof tags for stable order
+- hide tags panel when dataset lacks proof tags and verify static/API parity
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- Sorts proof tags to ensure deterministic UI order.
+- Hides tags panel when dataset has no proof tags.
+- Verifies parity between static dataset and live API.
+- Updates explorer tests to capture behavior.
+- UI‑only change; no API impact.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0081.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0081.md b/docs/releases/v0.2/briefs/PR-0081.md
new file mode 100644
index 0000000..eceaa56
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0081.md
@@ -0,0 +1,21 @@
+# PR #81 — F1: add pages preview workflow and deployment badge
+
+- PR: [#81](https://github.com/LexLattice/tf-lang/pull/81)
+
+## Brief (verbatim)
+```
+## Summary
+- build docs as preview artifact for pull requests
+- deploy docs from `main` and expose live badge in README
+
+## Testing
+- `pnpm test`
+```
+
+## Summary (5 bullets)
+- PRs: build `docs/` and upload as a Pages artifact for preview.
+- Main: deploys `docs/` to GitHub Pages environment.
+- Adds README badge linking to live site and workflow status.
+- No runtime changes; docs delivery only.
+- See `docs/operations/pages.md` for usage.
+
\`\`\`

### docs/releases/v0.2/briefs/PR-0087.md
\`\`\`diff
diff --git a/docs/releases/v0.2/briefs/PR-0087.md b/docs/releases/v0.2/briefs/PR-0087.md
new file mode 100644
index 0000000..71b0d06
--- /dev/null
+++ b/docs/releases/v0.2/briefs/PR-0087.md
@@ -0,0 +1,66 @@
+# PR #87 — F2 pass‑2: lowercase GHCR, digest summary, reproducibility knob
+
+- PR: [#87](https://github.com/LexLattice/tf-lang/pull/87)
+
+## Brief (verbatim)
+```
+# F2 — Pass 2 — Run B
+
+## Summary (≤ 3 bullets)
+- Lowercased GHCR repository path and added reproducibility env knob for deterministic builds.
+- Recorded both build digests and pushed digest in step summary while preserving main-only pushes.
+- Deduplicated Dockerfile base image digest via ARG; runtime unchanged.
+
+## End Goal → Evidence
+- EG-1: GHCR tags use lowercased repo path and push only on main【F:.github/workflows/ci.yml†L44-L72】
+- EG-2: Double-build digests compared and written to step summary with pushed digest on main【F:.github/workflows/ci.yml†L88-L98】
+
+## Blockers honored (must all be ✅)
+- B-1: ✅ Tags `0.2` and `latest` only; push guarded by main branch check【F:.github/workflows/ci.yml†L55-L72】
+- B-2: ✅ Dockerfile reuses pinned base image digest without altering runtime semantics【F:services/claims-api-ts/Dockerfile†L3-L8】【F:services/claims-api-ts/Dockerfile†L33-L36】
+
+## Determinism & Hygiene
+- Byte-identical outputs across repeats: ✅
+- SQL-only / no JS slicing (if applicable): ✅
+- ESM `.js`, no deep imports, no `as any`: ✅
+
+## Self-review checklist (must be all ✅)
+- [x] Production code changed (tests only ≠ pass)
+- [x] Inputs validated; 4xx on bad shapes
+- [x] No new runtime deps (unless allowed)
+- [x] CI gauntlet green
+
+## Delta since previous pass (≤ 5 bullets)
+- Added REGISTRY, REPO_LC, and SOURCE_DATE_EPOCH env to image job.
+- Summarized build and push digests in $GITHUB_STEP_SUMMARY.
+- Deduped Node base image digest via ARG.
+
+```yaml
+review_focus:
+  end_goal:
+    - Publish container images to GHCR tagged 0.2 and latest from main only
+    - PR builds build images without pushing
+    - Rebuilding the same commit yields identical digests; summary records both builds and pushed digest
+  blockers:
+    - No kernel/tag schema changes from pass 1
+    - No per-call locks, unsafe, or TypeScript as any
+    - ESM internal imports include ".js"
+    - Tests run in parallel without state bleed; outputs deterministic
+    - Images tagged 0.2 and latest with lowercase repo path
+    - Push to GHCR occurs only on main
+  acceptance:
+    - Workflow tags use ghcr.io/${{ env.REPO_LC }}/claims-api-ts
+    - Step summary lists both build digests and final pushed digest
+    - Build job env sets SOURCE_DATE_EPOCH: 0
+    - CI fails if the two build digests differ
+    - Service code and tests remain unchanged
+```
+```
+
+## Summary (5 bullets)
+- Lowercases GHCR repo path; tags `0.2` and `latest` on main only.
+- Compares digests from two builds; records both and pushed digest in summary.
+- Adds reproducibility knob (`SOURCE_DATE_EPOCH=0`) in image job env.
+- Dedupes base image digest via ARG; runtime unchanged.
+- CI/ops only; no functional changes to API or kernels.
+
\`\`\`
