### PR TITLE
T1_1: add tf spec schema and adapters [auto]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,32 @@ jobs:
       - run: $HOME/.cargo/bin/cargo build --verbose
       - run: $HOME/.cargo/bin/cargo test --verbose
 
+  tf-spec:
+    name: tf-spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - run: pnpm i --frozen-lockfile=false
+      - run: node scripts/validate-tf-spec.mjs
+      - run: pnpm exec vitest run packages/tf-lang-l0-ts/tests/spec-adapter.test.ts
+      - name: Install Rust
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl build-essential pkg-config libssl-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml --test spec_adapter --verbose
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tf-spec
+          path: tf-spec/validation.txt
+
   image:
     name: Container image
     runs-on: ubuntu-latest

--- a/docs/specs/tf-spec.md
+++ b/docs/specs/tf-spec.md
@@ -1,0 +1,23 @@
+# TF Spec
+
+Defines a minimal intent schema with a fixed version and `echo` steps.
+
+## Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `version` | integer | Schema version (must be `1`). |
+| `description` | string | Human description of the intent. |
+| `steps` | array | Ordered actions to perform. |
+| `steps[].type` | string | Action type; only `echo` is supported. |
+| `steps[].message` | string | Message for `echo` steps. |
+
+## Examples
+
+- [hello.json](../../examples/specs/hello.json) — prints hello
+- [multi.json](../../examples/specs/multi.json) — prints two messages
+- [empty.json](../../examples/specs/empty.json) — no steps
+
+## Versioning
+
+This is version `1` of the schema. Future extensions may add new step types or fields while preserving backward compatibility.

--- a/examples/specs/empty.json
+++ b/examples/specs/empty.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "description": "No steps",
+  "steps": []
+}

--- a/examples/specs/hello.json
+++ b/examples/specs/hello.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "description": "Prints hello",
+  "steps": [
+    { "type": "echo", "message": "hello" }
+  ]
+}

--- a/examples/specs/multi.json
+++ b/examples/specs/multi.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "description": "Prints two messages",
+  "steps": [
+    { "type": "echo", "message": "first" },
+    { "type": "echo", "message": "second" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
                 "check:fixtures": "tsx .codex/scripts/check-fixtures-json.ts"
         },
         "devDependencies": {
-                "typescript": "5.9.2"
+                "typescript": "5.9.2",
+                "ajv": "^8.12.0"
         },
         "pnpm": {
                 "allowScripts": {

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -5,5 +5,6 @@ pub mod util;
 pub mod vm;
 pub mod ops;
 pub mod proof;
+pub mod spec;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/spec/adapter.rs
+++ b/packages/tf-lang-l0-rs/src/spec/adapter.rs
@@ -1,0 +1,35 @@
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use crate::canon::canonical_json_bytes;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Step {
+    #[serde(rename = "type")]
+    pub step_type: String,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Spec {
+    pub version: u32,
+    pub description: Option<String>,
+    pub steps: Vec<Step>,
+}
+
+pub fn parse_spec(bytes: &[u8]) -> Result<Spec> {
+    let spec: Spec = serde_json::from_slice(bytes)?;
+    if spec.version != 1 {
+        bail!("E_SPEC_VERSION");
+    }
+    for step in &spec.steps {
+        if step.step_type != "echo" {
+            bail!("E_SPEC_STEP");
+        }
+    }
+    Ok(spec)
+}
+
+pub fn serialize_spec(spec: &Spec) -> Result<Vec<u8>> {
+    let val = serde_json::to_value(spec)?;
+    Ok(canonical_json_bytes(&val)?)
+}

--- a/packages/tf-lang-l0-rs/src/spec/mod.rs
+++ b/packages/tf-lang-l0-rs/src/spec/mod.rs
@@ -1,0 +1,3 @@
+pub mod adapter;
+
+pub use adapter::{parse_spec, serialize_spec, Spec, Step};

--- a/packages/tf-lang-l0-rs/tests/spec_adapter.rs
+++ b/packages/tf-lang-l0-rs/tests/spec_adapter.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use std::fs;
+use std::path::PathBuf;
+use serde_json::Value;
+use tflang_l0::spec::{parse_spec, serialize_spec};
+use tflang_l0::canon::canonical_json_bytes;
+
+#[test]
+fn round_trip_examples() -> Result<()> {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/specs");
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if !entry.file_name().to_string_lossy().ends_with(".json") {
+            continue;
+        }
+        let data = fs::read(entry.path())?;
+        let spec = parse_spec(&data)?;
+        let bytes = serialize_spec(&spec)?;
+        let orig: Value = serde_json::from_slice(&data)?;
+        assert_eq!(bytes, canonical_json_bytes(&orig)?);
+        let bytes2 = serialize_spec(&spec)?;
+        assert_eq!(bytes, bytes2);
+    }
+    Ok(())
+}

--- a/packages/tf-lang-l0-ts/src/spec/adapter.ts
+++ b/packages/tf-lang-l0-ts/src/spec/adapter.ts
@@ -1,0 +1,32 @@
+import { canonicalJsonBytes } from '../canon/index.js';
+
+export interface Step {
+  type: 'echo';
+  message: string;
+}
+
+export interface Spec {
+  version: number;
+  description?: string;
+  steps: Step[];
+}
+
+export function parseSpec(input: string | Uint8Array): Spec {
+  const text = typeof input === 'string' ? input : new TextDecoder().decode(input);
+  const data = JSON.parse(text);
+  if (data.version !== 1) throw new Error('E_SPEC_VERSION');
+  if (!Array.isArray(data.steps)) throw new Error('E_SPEC_STEPS');
+  const steps: Step[] = [];
+  for (const s of data.steps) {
+    if (!s || typeof s.type !== 'string') throw new Error('E_SPEC_STEP');
+    if (s.type !== 'echo' || typeof s.message !== 'string') throw new Error('E_SPEC_STEP');
+    steps.push({ type: 'echo', message: s.message });
+  }
+  const spec: Spec = { version: 1, steps };
+  if (typeof data.description === 'string') spec.description = data.description;
+  return spec;
+}
+
+export function serializeSpec(spec: Spec): Uint8Array {
+  return canonicalJsonBytes(spec);
+}

--- a/packages/tf-lang-l0-ts/tests/spec-adapter.test.ts
+++ b/packages/tf-lang-l0-ts/tests/spec-adapter.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseSpec, serializeSpec } from '../src/spec/adapter.js';
+import { canonicalJsonBytes } from '../src/canon/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const td = new TextDecoder();
+
+describe('spec adapter', () => {
+  const dir = path.join(__dirname, '../../../examples/specs');
+  for (const file of fs.readdirSync(dir).filter(f => f.endsWith('.json'))) {
+    const json = fs.readFileSync(path.join(dir, file));
+    it(`round-trips ${file}`, () => {
+      const spec = parseSpec(json);
+      const bytes = serializeSpec(spec);
+      const orig = canonicalJsonBytes(JSON.parse(td.decode(json)));
+      expect(Buffer.from(bytes)).toEqual(Buffer.from(orig));
+      const bytes2 = serializeSpec(spec);
+      expect(Buffer.from(bytes)).toEqual(Buffer.from(bytes2));
+    });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
       typescript:
         specifier: 5.9.2
         version: 5.9.2

--- a/schema/tf-spec.schema.json
+++ b/schema/tf-spec.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TF Spec",
+  "type": "object",
+  "required": ["version", "steps"],
+  "properties": {
+    "version": { "type": "integer", "enum": [1] },
+    "description": { "type": "string" },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": { "type": "string", "enum": ["echo"] },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": { "properties": { "type": { "const": "echo" } } },
+            "then": { "required": ["message"] }
+          }
+        ]
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate-tf-spec.mjs
+++ b/scripts/validate-tf-spec.mjs
@@ -1,0 +1,19 @@
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import Ajv from 'ajv';
+
+const ajv = new Ajv({ allErrors: true });
+const schema = JSON.parse(readFileSync('schema/tf-spec.schema.json', 'utf8'));
+const validate = ajv.compile(schema);
+const files = readdirSync('examples/specs').filter(f => f.endsWith('.json'));
+let out = '';
+for (const f of files) {
+  const data = JSON.parse(readFileSync(`examples/specs/${f}`, 'utf8'));
+  if (!validate(data)) {
+    console.error(f, validate.errors);
+    process.exit(1);
+  }
+  out += `${f}: OK\n`;
+}
+mkdirSync('tf-spec', { recursive: true });
+writeFileSync('tf-spec/validation.txt', out);
+console.log(out);


### PR DESCRIPTION
# T1_1 — Pass 1 — Run auto

## Summary (≤ 3 bullets)
- Added JSON Schema and docs for minimal TF intent format.
- Implemented TS and Rust adapters with round-trip tests.
- Provided sample specs and validation script.

## End Goal → Evidence
- EG-1: [schema/tf-spec.schema.json](schema/tf-spec.schema.json)
- EG-2: [docs/specs/tf-spec.md](docs/specs/tf-spec.md)
- EG-3: [examples/specs](examples/specs) validated via [scripts/validate-tf-spec.mjs](scripts/validate-tf-spec.mjs)
- EG-4: TS [adapter](packages/tf-lang-l0-ts/src/spec/adapter.ts) & [test](packages/tf-lang-l0-ts/tests/spec-adapter.test.ts); Rust [adapter](packages/tf-lang-l0-rs/src/spec/adapter.rs) & [test](packages/tf-lang-l0-rs/tests/spec_adapter.rs)

## Blockers honored (must all be ✅)
- B-1: ✅ dev-only dependency [package.json](package.json#L10-L13)
- B-2: ✅ ESM `.js` imports [packages/tf-lang-l0-ts/src/spec/adapter.ts](packages/tf-lang-l0-ts/src/spec/adapter.ts#L1)

## Determinism & Hygiene
- Byte-identical outputs across repeats: ✅
- SQL-only / no JS slicing (if applicable): ✅
- ESM `.js`, no deep imports, no `as any`: ✅

## Self-review checklist (must be all ✅)
- [x] Production code changed (tests only ≠ pass)
- [x] Inputs validated; 4xx on bad shapes
- [x] No new runtime deps (unless allowed)
- [x] CI gauntlet green

## Delta since previous pass (≤ 5 bullets)
- initial implementation

## Review Focus
```yaml
determinism: true
scope: tf-spec schema and adapters
```


------
https://chatgpt.com/codex/tasks/task_e_68c7676eb3488320942d12ab8d4768dc