### PR TITLE
T1_1: add tf-spec schema and adapters [auto]

### DIFF
--- a/.codex/scripts/validate-tf-spec.mjs
+++ b/.codex/scripts/validate-tf-spec.mjs
@@ -1,0 +1,19 @@
+import { promises as fs } from 'fs';
+import Ajv from 'ajv';
+
+const schema = JSON.parse(await fs.readFile('schema/tf-spec.schema.json', 'utf8'));
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+const files = (await fs.readdir('examples/specs')).filter(f => f.endsWith('.json'));
+let lines = [];
+for (const file of files) {
+  const data = JSON.parse(await fs.readFile(`examples/specs/${file}`, 'utf8'));
+  if (!validate(data)) {
+    console.error('Invalid', file, validate.errors);
+    process.exit(1);
+  }
+  lines.push(`${file}: OK`);
+}
+await fs.mkdir('tf-spec', { recursive: true });
+await fs.writeFile('tf-spec/validation.txt', lines.join('\n') + '\n');
+console.log(lines.join('\n'));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,34 @@ jobs:
       - run: $HOME/.cargo/bin/cargo build --verbose
       - run: $HOME/.cargo/bin/cargo test --verbose
 
+  tf-spec:
+    name: tf-spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - run: pnpm i --frozen-lockfile=false
+      - run: ./scripts/validate-tf-spec
+      - uses: actions/upload-artifact@5d2af8a6adfe0d6cf86508eac058c6b64a6bfb41 # v4
+        with:
+          name: tf-spec
+          path: tf-spec/validation.txt
+      - name: Install Rust
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl build-essential pkg-config libssl-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+      - run: pnpm --filter tf-lang-l0 exec vitest run tests/spec.adapter.test.ts
+      - run: pnpm --filter tf-lang-l0 exec vitest run tests/spec.adapter.test.ts
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml spec_adapter
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml spec_adapter
+
   image:
     name: Container image
     runs-on: ubuntu-latest

--- a/docs/specs/tf-spec.md
+++ b/docs/specs/tf-spec.md
@@ -1,0 +1,31 @@
+# TF Spec
+
+Defines a minimal intent format for task execution.
+
+## Fields
+
+| Field   | Type   | Description |
+|---------|--------|-------------|
+| `version` | string | Schema version, currently `0.1` |
+| `name`   | string | Human readable spec name |
+| `steps`  | array  | Sequence of steps to perform |
+| `steps[].op` | string | Operation identifier |
+| `steps[].params` | object | Operation parameters |
+
+## Examples
+
+- [vm.json](../../examples/specs/vm.json)
+- [copy.json](../../examples/specs/copy.json)
+- [multi.json](../../examples/specs/multi.json)
+
+## Versioning
+
+Future versions may extend fields while preserving backward compatibility.
+
+## Supported operations
+
+| Operation | Required params | Effect |
+|-----------|-----------------|--------|
+| `copy` | `src`, `dest` (strings) | Copy a file from `src` to `dest` |
+| `create_vm` | `image` (string), `cpus` (integer ≥1) | Create a virtual machine |
+| `create_network` | `cidr` (string) | Create a network with the given CIDR |

--- a/examples/specs/copy.json
+++ b/examples/specs/copy.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "name": "copy-file",
+  "steps": [
+    {
+      "op": "copy",
+      "params": {
+        "src": "README.md",
+        "dest": "/tmp/readme.md"
+      }
+    }
+  ]
+}

--- a/examples/specs/multi.json
+++ b/examples/specs/multi.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "name": "multi-step",
+  "steps": [
+    {
+      "op": "create_network",
+      "params": {
+        "cidr": "10.0.0.0/24"
+      }
+    },
+    {
+      "op": "create_vm",
+      "params": {
+        "image": "alpine",
+        "cpus": 1
+      }
+    }
+  ]
+}

--- a/examples/specs/vm.json
+++ b/examples/specs/vm.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "name": "simple-vm",
+  "steps": [
+    {
+      "op": "create_vm",
+      "params": {
+        "image": "ubuntu:20.04",
+        "cpus": 2
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
                 "check:fixtures": "tsx .codex/scripts/check-fixtures-json.ts"
         },
         "devDependencies": {
-                "typescript": "5.9.2"
+                "typescript": "5.9.2",
+                "ajv": "^8.12.0"
         },
         "pnpm": {
                 "allowScripts": {

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -5,5 +5,6 @@ pub mod util;
 pub mod vm;
 pub mod ops;
 pub mod proof;
+pub mod spec;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/spec/adapter.rs
+++ b/packages/tf-lang-l0-rs/src/spec/adapter.rs
@@ -1,0 +1,55 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use crate::canon::json::canonical_json_bytes;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "op", content = "params")]
+pub enum Step {
+    #[serde(rename = "copy")]
+    Copy(CopyParams),
+    #[serde(rename = "create_vm")]
+    CreateVm(CreateVmParams),
+    #[serde(rename = "create_network")]
+    CreateNetwork(CreateNetworkParams),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CopyParams {
+    pub src: String,
+    pub dest: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateVmParams {
+    pub image: String,
+    pub cpus: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateNetworkParams {
+    pub cidr: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TfSpec {
+    pub version: String,
+    pub name: String,
+    pub steps: Vec<Step>,
+}
+
+pub fn parse_spec(bytes: &[u8]) -> Result<TfSpec> {
+    let spec: TfSpec = serde_json::from_slice(bytes)?;
+    if spec.version != "0.1" {
+        return Err(anyhow!("E_SPEC_VERSION"));
+    }
+    Ok(spec)
+}
+
+pub fn serialize_spec(spec: &TfSpec) -> Result<Vec<u8>> {
+    let value = serde_json::to_value(spec)?;
+    canonical_json_bytes(&value)
+}

--- a/packages/tf-lang-l0-rs/src/spec/mod.rs
+++ b/packages/tf-lang-l0-rs/src/spec/mod.rs
@@ -1,0 +1,1 @@
+pub mod adapter;

--- a/packages/tf-lang-l0-rs/tests/spec_adapter.rs
+++ b/packages/tf-lang-l0-rs/tests/spec_adapter.rs
@@ -1,0 +1,35 @@
+use std::fs;
+use std::path::Path;
+use tflang_l0::spec::adapter::{parse_spec, serialize_spec};
+use tflang_l0::canon::json::canonical_json_bytes;
+use serde_json::Value;
+
+#[test]
+fn round_trip_examples() -> anyhow::Result<()> {
+    let dir = Path::new("../../examples/specs");
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let data = fs::read(&path)?;
+        let spec = parse_spec(&data)?;
+        let out = serialize_spec(&spec)?;
+        let expected = canonical_json_bytes(&serde_json::from_slice::<Value>(&data)?)?;
+        assert_eq!(out, expected);
+    }
+    Ok(())
+}
+
+#[test]
+fn parse_rejects_unknown_op() {
+    let bad = br#"{"version":"0.1","name":"bad","steps":[{"op":"nope","params":{}}]}"#;
+    assert!(parse_spec(bad).is_err());
+}
+
+#[test]
+fn parse_rejects_missing_param() {
+    let bad = br#"{"version":"0.1","name":"bad","steps":[{"op":"copy","params":{"src":"a"}}]}"#;
+    assert!(parse_spec(bad).is_err());
+}

--- a/packages/tf-lang-l0-ts/src/spec/adapter.ts
+++ b/packages/tf-lang-l0-ts/src/spec/adapter.ts
@@ -1,0 +1,65 @@
+import { canonicalJsonBytes } from "../canon/json.js";
+
+export interface Step {
+  op: string;
+  params: Record<string, unknown>;
+}
+
+export interface TfSpec {
+  version: string;
+  name: string;
+  steps: Step[];
+}
+
+const decoder = new TextDecoder();
+
+export function parseSpec(input: string | Uint8Array | object): TfSpec {
+  let obj: unknown;
+  if (typeof input === "string") {
+    obj = JSON.parse(input);
+  } else if (input instanceof Uint8Array) {
+    obj = JSON.parse(decoder.decode(input));
+  } else {
+    obj = input;
+  }
+  if (typeof obj !== "object" || obj === null) throw new Error("E_SPEC_TYPE");
+  const root = obj as Record<string, unknown>;
+  if (root.version !== "0.1") throw new Error("E_SPEC_VERSION");
+  if (typeof root.name !== "string") throw new Error("E_SPEC_NAME");
+  if (!Array.isArray(root.steps)) throw new Error("E_SPEC_STEPS");
+  const steps: Step[] = [];
+  for (const s of root.steps as unknown[]) {
+    if (typeof s !== "object" || s === null) throw new Error("E_SPEC_STEP");
+    const step = s as Record<string, unknown>;
+    if (typeof step.op !== "string") throw new Error("E_SPEC_OP");
+    if (typeof step.params !== "object" || step.params === null) {
+      throw new Error("E_SPEC_PARAMS");
+    }
+    const params = step.params as Record<string, unknown>;
+    switch (step.op) {
+      case "copy":
+        if (typeof params.src !== "string" || typeof params.dest !== "string") {
+          throw new Error("E_SPEC_PARAM");
+        }
+        break;
+      case "create_vm":
+        if (typeof params.image !== "string" || !Number.isInteger(params.cpus)) {
+          throw new Error("E_SPEC_PARAM");
+        }
+        break;
+      case "create_network":
+        if (typeof params.cidr !== "string") {
+          throw new Error("E_SPEC_PARAM");
+        }
+        break;
+      default:
+        throw new Error("E_SPEC_OP_UNKNOWN");
+    }
+    steps.push({ op: step.op, params });
+  }
+  return { version: root.version as string, name: root.name as string, steps };
+}
+
+export function serializeSpec(spec: TfSpec): Uint8Array {
+  return canonicalJsonBytes(spec);
+}

--- a/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
+++ b/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+import { parseSpec, serializeSpec } from "../src/spec/adapter.js";
+import { canonicalJsonBytes } from "../src/canon/json.js";
+import { describe, it, expect } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const examplesDir = path.resolve(__dirname, "../../../examples/specs");
+
+const files = readdirSync(examplesDir).filter(f => f.endsWith(".json"));
+
+describe("tf-spec examples", () => {
+  for (const file of files) {
+    it(file, () => {
+      const data = readFileSync(path.join(examplesDir, file));
+      const spec = parseSpec(data);
+      const out = serializeSpec(spec);
+      const expected = canonicalJsonBytes(JSON.parse(data.toString()));
+      expect(Buffer.from(out)).toStrictEqual(Buffer.from(expected));
+    });
+  }
+});
+
+describe("tf-spec validation", () => {
+  it("rejects unknown op", () => {
+    const bad = {
+      version: "0.1",
+      name: "bad",
+      steps: [{ op: "nope", params: {} }]
+    };
+    expect(() => parseSpec(bad)).toThrow("E_SPEC_OP_UNKNOWN");
+  });
+
+  it("rejects missing params", () => {
+    const bad = {
+      version: "0.1",
+      name: "bad",
+      steps: [{ op: "copy", params: { src: "a" } }]
+    };
+    expect(() => parseSpec(bad)).toThrow("E_SPEC_PARAM");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
       typescript:
         specifier: 5.9.2
         version: 5.9.2

--- a/schema/tf-spec.schema.json
+++ b/schema/tf-spec.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tf-spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "name", "steps"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "name": {
+      "type": "string"
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "copy" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["src", "dest"],
+                "properties": {
+                  "src": { "type": "string" },
+                  "dest": { "type": "string" }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "create_vm" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["image", "cpus"],
+                "properties": {
+                  "image": { "type": "string" },
+                  "cpus": { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "create_network" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["cidr"],
+                "properties": {
+                  "cidr": { "type": "string" }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/validate-tf-spec
+++ b/scripts/validate-tf-spec
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+node .codex/scripts/validate-tf-spec.mjs "$@"


### PR DESCRIPTION
# T1_1 — Pass 1 — Run auto

## Summary (≤ 3 bullets)
- Constrained tf-spec schema and docs to explicit ops with param checks, leaving broader op support for future cards
- Refactored TS adapter and added runtime validation; Rust adapter now uses typed steps with negative tests covering error paths
- Validation script moved under .codex with thin wrapper; no new runtime deps introduced

## End Goal → Evidence
- EG-1: [schema/tf-spec.schema.json](schema/tf-spec.schema.json)
- EG-2: [docs/specs/tf-spec.md](docs/specs/tf-spec.md) & [examples/specs/](examples/specs)
- EG-3: [TS adapter](packages/tf-lang-l0-ts/src/spec/adapter.ts) / [tests](packages/tf-lang-l0-ts/tests/spec.adapter.test.ts)
- EG-4: [Rust adapter](packages/tf-lang-l0-rs/src/spec/adapter.rs) / [tests](packages/tf-lang-l0-rs/tests/spec_adapter.rs)

## Blockers honored (must all be ✅)
- B-1: ✅ dev-only Ajv in [package.json](package.json)
- B-2: ✅ ESM imports with `.js` in [adapter.ts](packages/tf-lang-l0-ts/src/spec/adapter.ts)

## Determinism & Hygiene
- Byte-identical outputs across repeats: ✅
- SQL-only / no JS slicing (if applicable): ✅
- ESM `.js`, no deep imports, no `as any`: ✅

## Self-review checklist (must be all ✅)
- [x] Production code changed (tests only ≠ pass)
- [x] Inputs validated; 4xx on bad shapes
- [x] No new runtime deps (unless allowed)
- [x] CI gauntlet green

## Delta since previous pass (≤ 5 bullets)
- Enumerated supported ops with parameter schemas
- Added runtime validation and typed Rust steps
- Exercised error paths with new negative tests
- Moved tf-spec validator under .codex with wrapper

## Review Focus
```yaml
areas:
  - schema
  - adapters
```


------
https://chatgpt.com/codex/tasks/task_e_68c7676eb3488320942d12ab8d4768dc