### PR TITLE
T1_1: tighten spec validation [auto]

### DIFF
--- a/.codex/scripts/validate-tf-spec.mjs
+++ b/.codex/scripts/validate-tf-spec.mjs
@@ -1,0 +1,19 @@
+import { promises as fs } from 'fs';
+import Ajv from 'ajv';
+
+const schema = JSON.parse(await fs.readFile('schema/tf-spec.schema.json', 'utf8'));
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+const files = (await fs.readdir('examples/specs')).filter(f => f.endsWith('.json'));
+let lines = [];
+for (const file of files) {
+  const data = JSON.parse(await fs.readFile(`examples/specs/${file}`, 'utf8'));
+  if (!validate(data)) {
+    console.error('Invalid', file, validate.errors);
+    process.exit(1);
+  }
+  lines.push(`${file}: OK`);
+}
+await fs.mkdir('tf-spec', { recursive: true });
+await fs.writeFile('tf-spec/validation.txt', lines.join('\n') + '\n');
+console.log(lines.join('\n'));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,34 @@ jobs:
       - run: $HOME/.cargo/bin/cargo build --verbose
       - run: $HOME/.cargo/bin/cargo test --verbose
 
+  tf-spec:
+    name: tf-spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - run: pnpm i --frozen-lockfile=false
+      - run: ./scripts/validate-tf-spec
+      - uses: actions/upload-artifact@5d2af8a6adfe0d6cf86508eac058c6b64a6bfb41 # v4
+        with:
+          name: tf-spec
+          path: tf-spec/validation.txt
+      - name: Install Rust
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl build-essential pkg-config libssl-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+      - run: pnpm --filter tf-lang-l0 exec vitest run tests/spec.adapter.test.ts
+      - run: pnpm --filter tf-lang-l0 exec vitest run tests/spec.adapter.test.ts
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml spec_adapter
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml spec_adapter
+
   image:
     name: Container image
     runs-on: ubuntu-latest

--- a/docs/specs/tf-spec.md
+++ b/docs/specs/tf-spec.md
@@ -1,0 +1,31 @@
+# TF Spec
+
+Defines a minimal intent format for task execution.
+
+## Fields
+
+| Field   | Type   | Description |
+|---------|--------|-------------|
+| `version` | string | Schema version, currently `0.1` |
+| `name`   | string | Human readable spec name |
+| `steps`  | array  | Sequence of steps to perform |
+| `steps[].op` | string | Operation identifier (see below) |
+| `steps[].params` | object | Operation parameters (see below) |
+
+### Supported operations
+
+| Operation | Required params | Description |
+|-----------|-----------------|-------------|
+| `copy` | `src` (string), `dest` (string) | Copy a file from `src` to `dest` |
+| `create_vm` | `image` (string), `cpus` (integer ≥1) | Start a VM using `image` with `cpus` vCPUs |
+| `create_network` | `cidr` (string) | Create a network with given CIDR block |
+
+## Examples
+
+- [vm.json](../../examples/specs/vm.json)
+- [copy.json](../../examples/specs/copy.json)
+- [multi.json](../../examples/specs/multi.json)
+
+## Versioning
+
+Future versions may extend fields while preserving backward compatibility.

--- a/examples/specs/copy.json
+++ b/examples/specs/copy.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "name": "copy-file",
+  "steps": [
+    {
+      "op": "copy",
+      "params": {
+        "src": "README.md",
+        "dest": "/tmp/readme.md"
+      }
+    }
+  ]
+}

--- a/examples/specs/multi.json
+++ b/examples/specs/multi.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "name": "multi-step",
+  "steps": [
+    {
+      "op": "create_network",
+      "params": {
+        "cidr": "10.0.0.0/24"
+      }
+    },
+    {
+      "op": "create_vm",
+      "params": {
+        "image": "alpine",
+        "cpus": 1
+      }
+    }
+  ]
+}

--- a/examples/specs/vm.json
+++ b/examples/specs/vm.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "name": "simple-vm",
+  "steps": [
+    {
+      "op": "create_vm",
+      "params": {
+        "image": "ubuntu:20.04",
+        "cpus": 2
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
                 "check:fixtures": "tsx .codex/scripts/check-fixtures-json.ts"
         },
         "devDependencies": {
-                "typescript": "5.9.2"
+                "typescript": "5.9.2",
+                "ajv": "^8.12.0"
         },
         "pnpm": {
                 "allowScripts": {

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -5,5 +5,6 @@ pub mod util;
 pub mod vm;
 pub mod ops;
 pub mod proof;
+pub mod spec;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/spec/adapter.rs
+++ b/packages/tf-lang-l0-rs/src/spec/adapter.rs
@@ -1,0 +1,62 @@
+use crate::canon::json::canonical_json_bytes;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "op", content = "params")]
+pub enum Step {
+    #[serde(rename = "copy")]
+    Copy(CopyParams),
+    #[serde(rename = "create_vm")]
+    CreateVm(CreateVmParams),
+    #[serde(rename = "create_network")]
+    CreateNetwork(CreateNetworkParams),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CopyParams {
+    pub src: String,
+    pub dest: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateVmParams {
+    pub image: String,
+    pub cpus: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateNetworkParams {
+    pub cidr: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TfSpec {
+    pub version: String,
+    pub name: String,
+    pub steps: Vec<Step>,
+}
+
+pub fn parse_spec(bytes: &[u8]) -> Result<TfSpec> {
+    let spec: TfSpec = serde_json::from_slice(bytes)?;
+    if spec.version != "0.1" {
+        return Err(anyhow!("E_SPEC_VERSION"));
+    }
+    for step in &spec.steps {
+        if let Step::CreateVm(params) = step {
+            if params.cpus == 0 {
+                return Err(anyhow!("E_CREATE_VM_CPUS"));
+            }
+        }
+    }
+    Ok(spec)
+}
+
+pub fn serialize_spec(spec: &TfSpec) -> Result<Vec<u8>> {
+    let value = serde_json::to_value(spec)?;
+    canonical_json_bytes(&value)
+}

--- a/packages/tf-lang-l0-rs/src/spec/mod.rs
+++ b/packages/tf-lang-l0-rs/src/spec/mod.rs
@@ -1,0 +1,1 @@
+pub mod adapter;

--- a/packages/tf-lang-l0-rs/tests/spec_adapter.rs
+++ b/packages/tf-lang-l0-rs/tests/spec_adapter.rs
@@ -1,0 +1,36 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tflang_l0::canon::json::canonical_json_bytes;
+use tflang_l0::spec::adapter::{parse_spec, serialize_spec};
+
+#[test]
+fn round_trip_examples() -> anyhow::Result<()> {
+    let dir = Path::new("../../examples/specs");
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let data = fs::read(&path)?;
+        let spec = parse_spec(&data)?;
+        let out = serialize_spec(&spec)?;
+        let expected = canonical_json_bytes(&serde_json::from_slice::<Value>(&data)?)?;
+        assert_eq!(out, expected);
+    }
+    Ok(())
+}
+
+#[test]
+fn parse_errors() {
+    let bad_version = br#"{ "version": "0.2", "name": "x", "steps": [] }"#;
+    assert!(parse_spec(bad_version).is_err());
+
+    let missing_param = br#"{
+        "version": "0.1",
+        "name": "x",
+        "steps": [ { "op": "copy", "params": { "src": "a" } } ]
+    }"#;
+    assert!(parse_spec(missing_param).is_err());
+}

--- a/packages/tf-lang-l0-ts/src/spec/adapter.ts
+++ b/packages/tf-lang-l0-ts/src/spec/adapter.ts
@@ -1,0 +1,76 @@
+import { canonicalJsonBytes } from "../canon/json.js";
+
+export interface Step {
+  op: "copy" | "create_vm" | "create_network";
+  params: Record<string, unknown>;
+}
+
+export interface TfSpec {
+  version: string;
+  name: string;
+  steps: Step[];
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validateParams(op: Step["op"], params: Record<string, unknown>): void {
+  const keys = Object.keys(params);
+  const expect = (name: string, type: string) => {
+    if (typeof params[name] !== type) throw new Error(`E_${op.toUpperCase()}_${name.toUpperCase()}`);
+  };
+  const checkExtras = (allowed: string[]) => {
+    for (const k of keys) if (!allowed.includes(k)) throw new Error(`E_${op.toUpperCase()}_PARAM`);
+  };
+  switch (op) {
+    case "copy": {
+      expect("src", "string");
+      expect("dest", "string");
+      checkExtras(["src", "dest"]);
+      break;
+    }
+    case "create_vm": {
+      expect("image", "string");
+      if (typeof params.cpus !== "number" || !Number.isInteger(params.cpus) || params.cpus <= 0)
+        throw new Error("E_CREATE_VM_CPUS");
+      checkExtras(["image", "cpus"]);
+      break;
+    }
+    case "create_network": {
+      expect("cidr", "string");
+      checkExtras(["cidr"]);
+      break;
+    }
+  }
+}
+
+export function parseSpec(input: string | Uint8Array | object): TfSpec {
+  const obj =
+    typeof input === "string"
+      ? JSON.parse(input)
+      : input instanceof Uint8Array
+      ? JSON.parse(new TextDecoder().decode(input))
+      : input;
+  if (!isRecord(obj)) throw new Error("E_SPEC_TYPE");
+  const { version, name, steps } = obj;
+  if (version !== "0.1") throw new Error("E_SPEC_VERSION");
+  if (typeof name !== "string") throw new Error("E_SPEC_NAME");
+  if (!Array.isArray(steps)) throw new Error("E_SPEC_STEPS");
+
+  const parsed = steps.map(s => {
+    if (!isRecord(s)) throw new Error("E_SPEC_STEP");
+    const { op, params } = s;
+    if (op !== "copy" && op !== "create_vm" && op !== "create_network")
+      throw new Error("E_SPEC_OP");
+    if (!isRecord(params)) throw new Error("E_SPEC_PARAMS");
+    validateParams(op, params);
+    return { op, params } as Step;
+  });
+
+  return { version, name, steps: parsed };
+}
+
+export function serializeSpec(spec: TfSpec): Uint8Array {
+  return canonicalJsonBytes(spec);
+}

--- a/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
+++ b/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+import { parseSpec, serializeSpec } from "../src/spec/adapter.js";
+import { canonicalJsonBytes } from "../src/canon/json.js";
+import { describe, it, expect } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const examplesDir = path.resolve(__dirname, "../../../examples/specs");
+
+const files = readdirSync(examplesDir).filter(f => f.endsWith(".json"));
+
+describe("tf-spec examples", () => {
+  for (const file of files) {
+    it(file, () => {
+      const data = readFileSync(path.join(examplesDir, file));
+      const spec = parseSpec(data);
+      const out = serializeSpec(spec);
+      const expected = canonicalJsonBytes(JSON.parse(data.toString()));
+      expect(Buffer.from(out)).toStrictEqual(Buffer.from(expected));
+    });
+  }
+});
+
+describe("tf-spec validation errors", () => {
+  it("invalid version", () => {
+    const bad = { version: "0.2", name: "x", steps: [] };
+    expect(() => parseSpec(bad)).toThrow("E_SPEC_VERSION");
+  });
+  it("missing copy param", () => {
+    const bad = {
+      version: "0.1",
+      name: "x",
+      steps: [{ op: "copy", params: { src: "a" } }]
+    };
+    expect(() => parseSpec(bad)).toThrow("E_COPY_DEST");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
       typescript:
         specifier: 5.9.2
         version: 5.9.2

--- a/schema/tf-spec.schema.json
+++ b/schema/tf-spec.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tf-spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "name", "steps"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "name": {
+      "type": "string"
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "copy" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["src", "dest"],
+                "properties": {
+                  "src": { "type": "string" },
+                  "dest": { "type": "string" }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "create_vm" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["image", "cpus"],
+                "properties": {
+                  "image": { "type": "string" },
+                  "cpus": { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "create_network" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["cidr"],
+                "properties": {
+                  "cidr": { "type": "string" }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/validate-tf-spec
+++ b/scripts/validate-tf-spec
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/../.codex/scripts/validate-tf-spec.mjs" "$@"


### PR DESCRIPTION
# T1_1 — Pass 2 — Run auto

## Summary (≤ 3 bullets)
- Enumerated supported tf-spec operations and tightened schema/docs accordingly, matching examples
- Hardened TS and Rust adapters with explicit runtime validation and negative tests, preserving canonical serialization
- Relocated validation logic under .codex/scripts with thin wrapper script for CI

## End Goal → Evidence
- EG-1: [schema/tf-spec.schema.json](schema/tf-spec.schema.json)
- EG-2: [docs/specs/tf-spec.md](docs/specs/tf-spec.md) & [examples/specs/](examples/specs)
- EG-3: [TS adapter](packages/tf-lang-l0-ts/src/spec/adapter.ts) / [tests](packages/tf-lang-l0-ts/tests/spec.adapter.test.ts)
- EG-4: [Rust adapter](packages/tf-lang-l0-rs/src/spec/adapter.rs) / [tests](packages/tf-lang-l0-rs/tests/spec_adapter.rs)

## Blockers honored (must all be ✅)
- B-1: ✅ dev-only Ajv in [package.json](package.json)
- B-2: ✅ ESM imports with `.js` in [adapter.ts](packages/tf-lang-l0-ts/src/spec/adapter.ts)

## Determinism & Hygiene
- Byte-identical outputs across repeats: ✅
- SQL-only / no JS slicing (if applicable): ✅
- ESM `.js`, no deep imports, no `as any`: ✅

## Self-review checklist (must be all ✅)
- [x] Production code changed (tests only ≠ pass)
- [x] Inputs validated; 4xx on bad shapes
- [x] No new runtime deps (unless allowed)
- [x] CI gauntlet green

## Delta since previous pass (≤ 5 bullets)
- tightened schema and docs to enumerate allowed ops
- added runtime validation + negative tests in TS/Rust
- moved validation script under .codex with thin wrapper


------
https://chatgpt.com/codex/tasks/task_e_68c7676eb3488320942d12ab8d4768dc