### PR TITLE
T1_1: tf-spec polish (validator UX, TS/Rust negatives, docs) [auto]

### DIFF
--- a/.codex/scripts/validate-tf-spec.mjs
+++ b/.codex/scripts/validate-tf-spec.mjs
@@ -1,0 +1,27 @@
+import { promises as fs } from 'fs';
+import Ajv from 'ajv';
+
+const schema = JSON.parse(await fs.readFile('schema/tf-spec.schema.json', 'utf8'));
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+const files = (await fs.readdir('examples/specs'))
+  .filter(f => f.endsWith('.json'))
+  .sort();
+const lines = [];
+let failed = false;
+for (const file of files) {
+  const data = JSON.parse(await fs.readFile(`examples/specs/${file}`, 'utf8'));
+  if (!validate(data)) {
+    const errs = (validate.errors ?? [])
+      .map(e => `${e.instancePath || '/'} ${e.message}`)
+      .join('; ');
+    lines.push(`${file}: ${errs}`);
+    failed = true;
+    continue;
+  }
+  lines.push(`${file}: OK`);
+}
+await fs.mkdir('tf-spec', { recursive: true });
+await fs.writeFile('tf-spec/validation.txt', lines.join('\n') + '\n');
+console.log(lines.join('\n'));
+if (failed) process.exit(1);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,37 @@ jobs:
       - run: $HOME/.cargo/bin/cargo build --verbose
       - run: $HOME/.cargo/bin/cargo test --verbose
 
+  tf-spec:
+    name: tf-spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - run: pnpm i --frozen-lockfile=false
+      - run: ./scripts/validate-tf-spec
+      - run: cp tf-spec/validation.txt tf-spec/validation.prev
+      - uses: actions/upload-artifact@5d2af8a6adfe0d6cf86508eac058c6b64a6bfb41 # v4
+        with:
+          name: tf-spec
+          path: tf-spec/validation.txt
+      - name: Install Rust
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl build-essential pkg-config libssl-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+      - run: pnpm --filter tf-lang-l0 exec vitest run tests/spec.adapter.test.ts
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml spec_adapter
+      - run: ./scripts/validate-tf-spec
+      - run: diff tf-spec/validation.txt tf-spec/validation.prev
+      - run: pnpm --filter tf-lang-l0 exec vitest run tests/spec.adapter.test.ts
+      - run: $HOME/.cargo/bin/cargo test --manifest-path packages/tf-lang-l0-rs/Cargo.toml spec_adapter
+
   image:
     name: Container image
     runs-on: ubuntu-latest

--- a/docs/specs/tf-spec.md
+++ b/docs/specs/tf-spec.md
@@ -1,0 +1,32 @@
+# TF Spec
+
+Defines a minimal intent format for task execution.
+
+## Fields
+
+| Field   | Type   | Description |
+|---------|--------|-------------|
+| `version` | string | Schema version, currently `0.1` |
+| `name`   | string | Human readable spec name |
+| `steps`  | array  | Sequence of steps to perform |
+| `steps[].op` | string | Operation identifier |
+| `steps[].params` | object | Operation parameters |
+
+## Examples
+
+- [examples/specs](../../examples/specs/) directory
+- [vm.json](../../examples/specs/vm.json)
+- [copy.json](../../examples/specs/copy.json)
+- [multi.json](../../examples/specs/multi.json)
+
+## Versioning
+
+Future versions may extend fields while preserving backward compatibility.
+
+## Allowed operations
+
+| Operation | Required params |
+|-----------|-----------------|
+| `copy` | `src`, `dest` (strings) |
+| `create_vm` | `image` (string), `cpus` (integer ≥1) |
+| `create_network` | `cidr` (string) |

--- a/examples/specs/copy.json
+++ b/examples/specs/copy.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "name": "copy-file",
+  "steps": [
+    {
+      "op": "copy",
+      "params": {
+        "src": "README.md",
+        "dest": "/tmp/readme.md"
+      }
+    }
+  ]
+}

--- a/examples/specs/multi.json
+++ b/examples/specs/multi.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "name": "multi-step",
+  "steps": [
+    {
+      "op": "create_network",
+      "params": {
+        "cidr": "10.0.0.0/24"
+      }
+    },
+    {
+      "op": "create_vm",
+      "params": {
+        "image": "alpine",
+        "cpus": 1
+      }
+    }
+  ]
+}

--- a/examples/specs/vm.json
+++ b/examples/specs/vm.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "name": "simple-vm",
+  "steps": [
+    {
+      "op": "create_vm",
+      "params": {
+        "image": "ubuntu:20.04",
+        "cpus": 2
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
                 "check:fixtures": "tsx .codex/scripts/check-fixtures-json.ts"
         },
         "devDependencies": {
-                "typescript": "5.9.2"
+                "typescript": "5.9.2",
+                "ajv": "^8.12.0"
         },
         "pnpm": {
                 "allowScripts": {

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -5,5 +5,6 @@ pub mod util;
 pub mod vm;
 pub mod ops;
 pub mod proof;
+pub mod spec;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/spec/adapter.rs
+++ b/packages/tf-lang-l0-rs/src/spec/adapter.rs
@@ -1,0 +1,153 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use crate::canon::json::canonical_json_bytes;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "op", content = "params")]
+pub enum Step {
+    #[serde(rename = "copy")]
+    Copy(CopyParams),
+    #[serde(rename = "create_vm")]
+    CreateVm(CreateVmParams),
+    #[serde(rename = "create_network")]
+    CreateNetwork(CreateNetworkParams),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CopyParams {
+    pub src: String,
+    pub dest: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateVmParams {
+    pub image: String,
+    pub cpus: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateNetworkParams {
+    pub cidr: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct TfSpec {
+    pub version: String,
+    pub name: String,
+    pub steps: Vec<Step>,
+}
+
+pub fn parse_spec(bytes: &[u8]) -> Result<TfSpec> {
+    let v: Value = serde_json::from_slice(bytes)?;
+    let root = v.as_object().ok_or_else(|| anyhow!("E_SPEC_TYPE"))?;
+    for k in root.keys() {
+        match k.as_str() {
+            "version" | "name" | "steps" => {}
+            other => return Err(anyhow!("E_SPEC_FIELD: {}", other)),
+        }
+    }
+    let version = root
+        .get("version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("E_SPEC_VERSION"))?;
+    if version != "0.1" {
+        return Err(anyhow!("E_SPEC_VERSION"));
+    }
+    let name = root
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("E_SPEC_NAME"))?;
+    let steps_v = root
+        .get("steps")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("E_SPEC_STEPS"))?;
+    let mut steps: Vec<Step> = Vec::new();
+    for (i, step_v) in steps_v.iter().enumerate() {
+        let step_obj = step_v
+            .as_object()
+            .ok_or_else(|| anyhow!("E_SPEC_STEP: steps[{}]", i))?;
+        for k in step_obj.keys() {
+            match k.as_str() {
+                "op" | "params" => {}
+                other => {
+                    return Err(anyhow!(
+                        "E_SPEC_STEP_FIELD: steps[{}].{}",
+                        i, other
+                    ))
+                }
+            }
+        }
+        let op = step_obj
+            .get("op")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("E_SPEC_OP: steps[{}]", i))?;
+        let params_v = step_obj
+            .get("params")
+            .ok_or_else(|| anyhow!("E_SPEC_PARAMS: steps[{}]", i))?;
+        match op {
+            "copy" => {
+                let params: CopyParams = serde_json::from_value(params_v.clone()).map_err(|e| {
+                    let msg = e.to_string();
+                    let code = if msg.contains("missing field") {
+                        "E_SPEC_PARAM_MISSING"
+                    } else if msg.contains("unknown field") {
+                        "E_SPEC_PARAM_EXTRA"
+                    } else {
+                        "E_SPEC_PARAM"
+                    };
+                    anyhow!("{}: steps[{}].{}", code, i, msg)
+                })?;
+                steps.push(Step::Copy(params));
+            }
+            "create_vm" => {
+                let params: CreateVmParams = serde_json::from_value(params_v.clone()).map_err(|e| {
+                    let msg = e.to_string();
+                    let code = if msg.contains("missing field") {
+                        "E_SPEC_PARAM_MISSING"
+                    } else if msg.contains("unknown field") {
+                        "E_SPEC_PARAM_EXTRA"
+                    } else {
+                        "E_SPEC_PARAM"
+                    };
+                    anyhow!("{}: steps[{}].{}", code, i, msg)
+                })?;
+                if params.cpus < 1 {
+                    return Err(anyhow!(
+                        "E_SPEC_PARAM_INVALID: steps[{}].params.cpus",
+                        i
+                    ));
+                }
+                steps.push(Step::CreateVm(params));
+            }
+            "create_network" => {
+                let params: CreateNetworkParams = serde_json::from_value(params_v.clone()).map_err(|e| {
+                    let msg = e.to_string();
+                    let code = if msg.contains("missing field") {
+                        "E_SPEC_PARAM_MISSING"
+                    } else if msg.contains("unknown field") {
+                        "E_SPEC_PARAM_EXTRA"
+                    } else {
+                        "E_SPEC_PARAM"
+                    };
+                    anyhow!("{}: steps[{}].{}", code, i, msg)
+                })?;
+                steps.push(Step::CreateNetwork(params));
+            }
+            other => return Err(anyhow!("E_SPEC_OP_UNKNOWN: {}", other)),
+        }
+    }
+    Ok(TfSpec {
+        version: version.to_string(),
+        name: name.to_string(),
+        steps,
+    })
+}
+
+pub fn serialize_spec(spec: &TfSpec) -> Result<Vec<u8>> {
+    let value = serde_json::to_value(spec)?;
+    canonical_json_bytes(&value)
+}

--- a/packages/tf-lang-l0-rs/src/spec/mod.rs
+++ b/packages/tf-lang-l0-rs/src/spec/mod.rs
@@ -1,0 +1,1 @@
+pub mod adapter;

--- a/packages/tf-lang-l0-rs/tests/spec_adapter.rs
+++ b/packages/tf-lang-l0-rs/tests/spec_adapter.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::Path;
+use tflang_l0::spec::adapter::{parse_spec, serialize_spec};
+use tflang_l0::canon::json::canonical_json_bytes;
+use serde_json::Value;
+
+#[test]
+fn round_trip_examples() -> anyhow::Result<()> {
+    let dir = Path::new("../../examples/specs");
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let data = fs::read(&path)?;
+        let spec = parse_spec(&data)?;
+        let out = serialize_spec(&spec)?;
+        let expected = canonical_json_bytes(&serde_json::from_slice::<Value>(&data)?)?;
+        assert_eq!(out, expected);
+    }
+    Ok(())
+}
+
+#[test]
+fn parse_rejects_unknown_op() {
+    let bad = br#"{"version":"0.1","name":"bad","steps":[{"op":"nope","params":{}}]}"#;
+    let err = parse_spec(bad).unwrap_err().to_string();
+    assert!(err.contains("E_SPEC_OP_UNKNOWN"));
+}
+
+#[test]
+fn parse_rejects_missing_param() {
+    let bad = br#"{"version":"0.1","name":"bad","steps":[{"op":"copy","params":{"src":"a"}}]}"#;
+    let err = parse_spec(bad).unwrap_err().to_string();
+    assert!(err.contains("E_SPEC_PARAM_MISSING"));
+    assert!(err.contains("steps[0]"));
+}
+
+#[test]
+fn parse_rejects_extra_param() {
+    let bad = br#"{"version":"0.1","name":"bad","steps":[{"op":"copy","params":{"src":"a","dest":"b","extra":1}}]}"#;
+    let err = parse_spec(bad).unwrap_err().to_string();
+    assert!(err.contains("E_SPEC_PARAM_EXTRA"));
+    assert!(err.contains("steps[0]"));
+}
+
+#[test]
+fn parse_rejects_cpus_lt_one() {
+    let bad = br#"{"version":"0.1","name":"bad","steps":[{"op":"create_vm","params":{"image":"img","cpus":0}}]}"#;
+    let err = parse_spec(bad).unwrap_err().to_string();
+    assert!(err.contains("E_SPEC_PARAM_INVALID"));
+    assert!(err.contains("steps[0]") && err.contains("cpus"));
+}

--- a/packages/tf-lang-l0-ts/src/spec/adapter.ts
+++ b/packages/tf-lang-l0-ts/src/spec/adapter.ts
@@ -1,0 +1,96 @@
+import { canonicalJsonBytes } from "../canon/json.js";
+
+export interface Step {
+  op: string;
+  params: Record<string, unknown>;
+}
+
+export interface TfSpec {
+  version: string;
+  name: string;
+  steps: Step[];
+}
+
+const decoder = new TextDecoder();
+
+export function parseSpec(input: string | Uint8Array | object): TfSpec {
+  let obj: unknown;
+  if (typeof input === "string") {
+    obj = JSON.parse(input);
+  } else if (input instanceof Uint8Array) {
+    obj = JSON.parse(decoder.decode(input));
+  } else {
+    obj = input;
+  }
+  if (typeof obj !== "object" || obj === null) throw new Error("E_SPEC_TYPE");
+  const root = obj as Record<string, unknown>;
+  const allowedRoot = ["version", "name", "steps"];
+  for (const k of Object.keys(root)) {
+    if (!allowedRoot.includes(k)) throw new Error(`E_SPEC_FIELD: ${k}`);
+  }
+  if (root.version !== "0.1") throw new Error("E_SPEC_VERSION");
+  if (typeof root.name !== "string") throw new Error("E_SPEC_NAME");
+  if (!Array.isArray(root.steps)) throw new Error("E_SPEC_STEPS");
+  const steps: Step[] = [];
+  for (const [i, s] of (root.steps as unknown[]).entries()) {
+    if (typeof s !== "object" || s === null) throw new Error(`E_SPEC_STEP: steps[${i}]`);
+    const step = s as Record<string, unknown>;
+    for (const k of Object.keys(step)) {
+      if (!["op", "params"].includes(k)) {
+        throw new Error(`E_SPEC_STEP_FIELD: steps[${i}].${k}`);
+      }
+    }
+    if (typeof step.op !== "string") throw new Error(`E_SPEC_OP: steps[${i}]`);
+    if (typeof step.params !== "object" || step.params === null) {
+      throw new Error(`E_SPEC_PARAMS: steps[${i}]`);
+    }
+    const params = step.params as Record<string, unknown>;
+    const checkParams = (required: string[]) => {
+      for (const r of required) {
+        if (!(r in params)) {
+          throw new Error(`E_SPEC_PARAM_MISSING: steps[${i}].params.${r}`);
+        }
+      }
+      for (const k of Object.keys(params)) {
+        if (!required.includes(k)) {
+          throw new Error(`E_SPEC_PARAM_EXTRA: steps[${i}].params.${k}`);
+        }
+      }
+    };
+    switch (step.op) {
+      case "copy": {
+        checkParams(["src", "dest"]);
+        if (typeof params.src !== "string" || typeof params.dest !== "string") {
+          throw new Error(`E_SPEC_PARAM_INVALID: steps[${i}]`);
+        }
+        break;
+      }
+      case "create_vm": {
+        checkParams(["image", "cpus"]);
+        if (
+          typeof params.image !== "string" ||
+          !Number.isInteger(params.cpus) ||
+          (params.cpus as number) < 1
+        ) {
+          throw new Error(`E_SPEC_PARAM_INVALID: steps[${i}].params.cpus`);
+        }
+        break;
+      }
+      case "create_network": {
+        checkParams(["cidr"]);
+        if (typeof params.cidr !== "string") {
+          throw new Error(`E_SPEC_PARAM_INVALID: steps[${i}]`);
+        }
+        break;
+      }
+      default:
+        throw new Error(`E_SPEC_OP_UNKNOWN: ${step.op}`);
+    }
+    steps.push({ op: step.op, params });
+  }
+  return { version: root.version as string, name: root.name as string, steps };
+}
+
+export function serializeSpec(spec: TfSpec): Uint8Array {
+  return canonicalJsonBytes(spec);
+}

--- a/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
+++ b/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+import { parseSpec, serializeSpec } from "../src/spec/adapter.js";
+import { canonicalJsonBytes } from "../src/canon/json.js";
+import { describe, it, expect } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const examplesDir = path.resolve(__dirname, "../../../examples/specs");
+
+const files = readdirSync(examplesDir).filter(f => f.endsWith(".json"));
+
+describe("tf-spec examples", () => {
+  for (const file of files) {
+    it(file, () => {
+      const data = readFileSync(path.join(examplesDir, file));
+      const spec = parseSpec(data);
+      const out = serializeSpec(spec);
+      const expected = canonicalJsonBytes(JSON.parse(data.toString()));
+      expect(Buffer.from(out)).toStrictEqual(Buffer.from(expected));
+    });
+  }
+});
+
+describe("tf-spec validation", () => {
+  it("rejects unknown op", () => {
+    const bad = {
+      version: "0.1",
+      name: "bad",
+      steps: [{ op: "nope", params: {} }]
+    };
+    expect(() => parseSpec(bad)).toThrow("E_SPEC_OP_UNKNOWN: nope");
+  });
+
+  it("rejects missing params", () => {
+    const bad = {
+      version: "0.1",
+      name: "bad",
+      steps: [{ op: "copy", params: { src: "a" } }]
+    };
+    expect(() => parseSpec(bad)).toThrow(
+      "E_SPEC_PARAM_MISSING: steps[0].params.dest"
+    );
+  });
+
+  it("rejects extra params", () => {
+    const bad = {
+      version: "0.1",
+      name: "bad",
+      steps: [{ op: "copy", params: { src: "a", dest: "b", extra: 1 } }]
+    };
+    expect(() => parseSpec(bad)).toThrow(
+      "E_SPEC_PARAM_EXTRA: steps[0].params.extra"
+    );
+  });
+
+  it("rejects cpus < 1", () => {
+    const bad = {
+      version: "0.1",
+      name: "bad",
+      steps: [{ op: "create_vm", params: { image: "img", cpus: 0 } }]
+    };
+    expect(() => parseSpec(bad)).toThrow(
+      "E_SPEC_PARAM_INVALID: steps[0].params.cpus"
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
       typescript:
         specifier: 5.9.2
         version: 5.9.2

--- a/schema/tf-spec.schema.json
+++ b/schema/tf-spec.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tf-spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "name", "steps"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "name": {
+      "type": "string"
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "copy" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["src", "dest"],
+                "properties": {
+                  "src": { "type": "string" },
+                  "dest": { "type": "string" }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "create_vm" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["image", "cpus"],
+                "properties": {
+                  "image": { "type": "string" },
+                  "cpus": { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["op", "params"],
+            "properties": {
+              "op": { "const": "create_network" },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["cidr"],
+                "properties": {
+                  "cidr": { "type": "string" }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/validate-tf-spec
+++ b/scripts/validate-tf-spec
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec node .codex/scripts/validate-tf-spec.mjs "$@"


### PR DESCRIPTION
# T1_1 — Pass 3 — Run auto

## Summary (≤ 3 bullets)
- Aggregated tf-spec validator errors and printed one summary; wrapper simply execs the impl
- Strengthened TS and Rust adapters with explicit param checks and mirrored negative tests
- Updated spec docs with allowed ops table and link to the examples directory

## End Goal → Evidence
- EG-1: [.codex/scripts/validate-tf-spec.mjs](.codex/scripts/validate-tf-spec.mjs) & [.github/workflows/ci.yml](.github/workflows/ci.yml)
- EG-2: [packages/tf-lang-l0-ts/src/spec/adapter.ts](packages/tf-lang-l0-ts/src/spec/adapter.ts) / [packages/tf-lang-l0-ts/tests/spec.adapter.test.ts](packages/tf-lang-l0-ts/tests/spec.adapter.test.ts)
- EG-3: [packages/tf-lang-l0-rs/src/spec/adapter.rs](packages/tf-lang-l0-rs/src/spec/adapter.rs) / [packages/tf-lang-l0-rs/tests/spec_adapter.rs](packages/tf-lang-l0-rs/tests/spec_adapter.rs)
- EG-4: [docs/specs/tf-spec.md](docs/specs/tf-spec.md)

## Blockers honored (must all be ✅)
- B-1: ✅ [implementation under `.codex/scripts/validate-tf-spec.mjs`](.codex/scripts/validate-tf-spec.mjs)
- B-2: ✅ [wrapper `scripts/validate-tf-spec` uses `exec`](scripts/validate-tf-spec)

## Determinism & Hygiene
- Byte-identical outputs across repeats: ✅
- SQL-only / no JS slicing (if applicable): ✅
- ESM `.js`, no deep imports, no `as any`: ✅

## Self-review checklist (must be all ✅)
- [x] Production code changed (tests only ≠ pass)
- [x] Inputs validated; 4xx on bad shapes
- [x] No new runtime deps (unless allowed)
- [x] CI gauntlet green

## Delta since previous pass (≤ 5 bullets)
- Aggregated validator errors and diffed outputs for determinism
- Tightened TS adapter with explicit param checks and messages
- Added Rust parity validation with path-aware error codes
- Expanded negative test coverage for TS and Rust adapters
- Linked examples directory and allowed ops table in docs

## Review Focus
```yaml
task: T1_1
pass: 3
focus:
  - validator UX: aggregated errors & single exit status
  - scripts policy: .codex impl + /scripts wrapper only
  - TS validation/messages tightened to schema (no as any)
  - Rust negative tests: specific error codes/paths
  - determinism: double-run equality
tripwires:
  esm_dot_js: true
  no_deep_imports: true
  scripts_wrappers_only: true
  no_new_runtime_deps: true
```


------
https://chatgpt.com/codex/tasks/task_e_68c7676eb3488320942d12ab8d4768dc