### PR TITLE
ci: install workspace deps before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
-      - run: pnpm -r install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - run: pnpm -r --filter "./packages/tf-lang-l0-ts" test
 
   rust:
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
-      - run: pnpm -r install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - run: ./scripts/validate-tf-spec
       - run: cp tf-spec/validation.txt tf-spec/validation-run1.txt
       - run: ./scripts/validate-tf-spec
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
-      - run: pnpm -r install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - run: pnpm -C packages/oracles-core-ts build
       - run: pnpm -C packages/oracles-core-ts test
       - run: ./scripts/oracle-core-results

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -112,3 +112,8 @@
 - [F7] Updated PR_REPORT summary to capture final review fixes.
 - Commands: n/a (documentation only).
 - Notes: Highlights Ajv migration, BTreeMap canon, Map/Set semantics, and scoped stubs.
+
+## 2025-09-16T02:58:39Z
+- [F8] Adjusted CI installs to use workspace root for pnpm.
+- Commands: n/a (workflow-only change).
+- Notes: Ensures devDependencies (vitest) are available during CI test runs.


### PR DESCRIPTION
# T2 Runtime & Tooling Epic — PR Report

## Summary
- Scope: CI maintenance
- Key outcomes in this PR:
  - [ ] tf-check CLI help + result.json
  - [ ] Adapters (TS/Rust) + tests
  - [ ] trace-tags.json
  - [ ] coverage.(json|html)

## Evidence (artifacts)
- [ ] `out/t2/tf-check/help.txt` (attached by CI)
- [ ] `out/t2/tf-check/result.json`
- [ ] `out/t2/trace-tags.json`
- [ ] `out/t2/coverage.json`
- [ ] `out/t2/coverage.html`
- [ ] *(optional)* `out/t2/adapter-parity.json`

## Determinism & Seeds
- Repeats: n/a (workflow-only change)
- Seeds file(s): n/a
- Notes: No determinism-affecting code paths touched.

## Tests & CI
- TS tests: not run locally (workflow-only change)
- Rust tests: not run locally (workflow-only change)
- CI jobs: adjusted installs to provision workspace devDependencies.

## Implementation Notes
- ABI / paths unchanged? Yes
- Runtime deps added? No
- Policy compliance: no code changes; workflows now install via `pnpm install --frozen-lockfile`.

## Hurdles / Follow-ups
- Known gaps: T2 deliverables remain outstanding.
- Suggested next steps: Run CI to confirm vitest resolution on hosted runners.


------
https://chatgpt.com/codex/tasks/task_e_68c8d20570f0832090da7678b9f287af