### PR TITLE
Add TypeScript idempotence oracle harness and utilities

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -149,3 +149,9 @@
 - [tf-lang-l0] version 0.1.1 with prepublish build and @noble/hashes dependency.
 - [CI] tf-check smoke packs tf-lang-l0 + tf-check tarballs locally; no registry use.
 - Commands: `pnpm -r --filter ./packages/tf-lang-l0-ts run build`, `pnpm -r --filter ./packages/tf-check run build`.
+
+## 2025-09-18T17:01:05+00:00
+- [T3] Planned sprints: S1 idempotence/harness, S2 conservation, S3 transport/parity.
+
+## 2025-09-18T17:14:36+00:00
+- [T3] Planned sprints: S1 finish idempotence/harness cleanup, S2 conservation oracle, S3 transport/parity scaffold.

--- a/packages/oracles/core/src/canonical.d.ts
+++ b/packages/oracles/core/src/canonical.d.ts
@@ -1,0 +1,3 @@
+export type Canonicalizer = <T>(value: T) => T;
+export declare const defaultCanonicalize: Canonicalizer;
+export declare function canonicalStringify(value: unknown): string;

--- a/packages/oracles/core/src/canonical.js
+++ b/packages/oracles/core/src/canonical.js
@@ -1,0 +1,72 @@
+export const defaultCanonicalize = (value) => {
+    return canonicalizeValue(value);
+};
+export function canonicalStringify(value) {
+    return JSON.stringify(canonicalizeValue(value));
+}
+function canonicalizeValue(value) {
+    if (value === null) {
+        return null;
+    }
+    const valueType = typeof value;
+    if (valueType === "number") {
+        return canonicalizeNumber(value);
+    }
+    if (valueType === "string" || valueType === "boolean") {
+        return value;
+    }
+    if (valueType === "bigint") {
+        return value.toString(10);
+    }
+    if (valueType === "symbol") {
+        return String(value);
+    }
+    if (valueType === "function") {
+        return `[fn ${String(value.name || "anonymous")}]`;
+    }
+    if (Array.isArray(value)) {
+        return value.map((entry) => canonicalizeValue(entry ?? null));
+    }
+    if (value instanceof Set) {
+        const canonicalItems = Array.from(value).map((entry) => canonicalizeValue(entry ?? null));
+        canonicalItems.sort((left, right) => {
+            const a = JSON.stringify(left);
+            const b = JSON.stringify(right);
+            if (a < b) {
+                return -1;
+            }
+            if (a > b) {
+                return 1;
+            }
+            return 0;
+        });
+        return canonicalItems;
+    }
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    if (value && typeof value.toJSON === "function") {
+        return canonicalizeValue(value.toJSON());
+    }
+    if (value && valueType === "object") {
+        const input = value;
+        const entries = Object.entries(input)
+            .filter(([, entryValue]) => entryValue !== undefined)
+            .map(([key, entryValue]) => [key, canonicalizeValue(entryValue)])
+            .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+        const result = {};
+        for (const [key, entryValue] of entries) {
+            result[key] = entryValue;
+        }
+        return result;
+    }
+    return value;
+}
+function canonicalizeNumber(value) {
+    if (!Number.isFinite(value)) {
+        return value.toString();
+    }
+    const formatted = value.toFixed(12);
+    const numeric = Number.parseFloat(formatted);
+    return Object.is(numeric, -0) ? 0 : numeric;
+}

--- a/packages/oracles/core/src/context.d.ts
+++ b/packages/oracles/core/src/context.d.ts
@@ -1,0 +1,7 @@
+import type { Canonicalizer } from "./canonical.js";
+import type { OracleCtx } from "./result.js";
+export interface OracleCtxInit {
+    readonly now?: number;
+    readonly canonicalize?: Canonicalizer;
+}
+export declare function createOracleCtx(seed: string, init?: OracleCtxInit): OracleCtx;

--- a/packages/oracles/core/src/context.js
+++ b/packages/oracles/core/src/context.js
@@ -1,0 +1,8 @@
+import { defaultCanonicalize } from "./canonical.js";
+export function createOracleCtx(seed, init = {}) {
+    return {
+        seed,
+        now: init.now ?? 0,
+        canonicalize: init.canonicalize ?? defaultCanonicalize,
+    };
+}

--- a/packages/oracles/core/src/index.d.ts
+++ b/packages/oracles/core/src/index.d.ts
@@ -1,0 +1,6 @@
+export type { Canonicalizer } from "./canonical.js";
+export { canonicalStringify, defaultCanonicalize } from "./canonical.js";
+export type { Oracle, OracleCtx, OracleError, OracleFailure, OracleResult, OracleSuccess, } from "./result.js";
+export { err, ok, withTrace } from "./result.js";
+export type { OracleCtxInit } from "./context.js";
+export { createOracleCtx } from "./context.js";

--- a/packages/oracles/core/src/index.js
+++ b/packages/oracles/core/src/index.js
@@ -1,0 +1,3 @@
+export { canonicalStringify, defaultCanonicalize } from "./canonical.js";
+export { err, ok, withTrace } from "./result.js";
+export { createOracleCtx } from "./context.js";

--- a/packages/oracles/core/src/result.d.ts
+++ b/packages/oracles/core/src/result.d.ts
@@ -1,0 +1,28 @@
+import type { Canonicalizer } from "./canonical.js";
+export interface OracleError {
+    readonly code: string;
+    readonly explain: string;
+    readonly details?: unknown;
+}
+export interface OracleFailure {
+    readonly ok: false;
+    readonly error: OracleError;
+    readonly trace?: readonly string[];
+}
+export interface OracleSuccess<T> {
+    readonly ok: true;
+    readonly value: T;
+    readonly warnings?: readonly string[];
+}
+export type OracleResult<T> = OracleSuccess<T> | OracleFailure;
+export interface OracleCtx {
+    readonly seed: string;
+    readonly now: number;
+    readonly canonicalize: Canonicalizer;
+}
+export type Oracle<I, O> = {
+    check(input: I, ctx: OracleCtx): Promise<OracleResult<O>> | OracleResult<O>;
+};
+export declare function ok<T>(value: T, warnings?: Iterable<string>): OracleSuccess<T>;
+export declare function err(code: string, explain: string, details?: unknown): OracleFailure;
+export declare function withTrace(base: OracleFailure, trace: Iterable<string>): OracleFailure;

--- a/packages/oracles/core/src/result.js
+++ b/packages/oracles/core/src/result.js
@@ -1,0 +1,53 @@
+export function ok(value, warnings) {
+    return {
+        ok: true,
+        value,
+        ...(warnings ? { warnings: normalizeWarnings(warnings) } : {}),
+    };
+}
+export function err(code, explain, details) {
+    return {
+        ok: false,
+        error: {
+            code: normalizeCode(code),
+            explain: explain.trim(),
+            ...(details === undefined ? {} : { details }),
+        },
+    };
+}
+export function withTrace(base, trace) {
+    const existing = base.trace ?? [];
+    const merged = normalizeWarnings([...existing, ...trace]);
+    if (merged.length === 0) {
+        return { ...base, trace: undefined };
+    }
+    return {
+        ...base,
+        trace: merged,
+    };
+}
+function normalizeWarnings(source) {
+    const set = new Set();
+    for (const entry of source) {
+        const normalized = entry.trim();
+        if (normalized.length > 0) {
+            set.add(normalized);
+        }
+    }
+    return Array.from(set.values()).sort((a, b) => {
+        if (a < b) {
+            return -1;
+        }
+        if (a > b) {
+            return 1;
+        }
+        return 0;
+    });
+}
+function normalizeCode(code) {
+    const normalized = code.trim();
+    if (!normalized) {
+        return "E_UNKNOWN";
+    }
+    return normalized.toUpperCase();
+}

--- a/packages/oracles/harness/README.md
+++ b/packages/oracles/harness/README.md
@@ -1,0 +1,9 @@
+# @tf/oracles-harness
+
+Deterministic harness for running TF-Lang oracle suites and emitting canonical reports under `out/t3/`.
+
+## Usage
+
+```sh
+pnpm -C packages/oracles/harness run build-reports
+```

--- a/packages/oracles/harness/package.json
+++ b/packages/oracles/harness/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tf/oracles-harness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": "./dist/index.js",
+  "license": "MIT",
+  "description": "Harness for running TF-Lang T3 oracle suites and emitting deterministic reports.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "build-reports": "pnpm run build && node dist/src/build-reports.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/utils": "workspace:*",
+    "@tf/oracles-core": "workspace:*",
+    "@tf/oracles-idempotence": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/oracles/harness/src/build-reports.ts
+++ b/packages/oracles/harness/src/build-reports.ts
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { promisify } from "node:util";
+
+import { createOracleCtx } from "@tf/oracles-core";
+import { checkIdempotence } from "@tf/oracles-idempotence";
+import type { IdempotenceInput } from "@tf/oracles-idempotence";
+import { findRepoRoot } from "@tf-lang/utils";
+
+const execFileAsync = promisify(execFile);
+
+interface HarnessSeedEntry {
+  readonly seed: string;
+  readonly now: string;
+  readonly case: string;
+  readonly runtime: number;
+}
+
+interface OracleReportSummary {
+  readonly total: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly firstFail?: {
+    readonly pointer: string;
+    readonly once: unknown;
+    readonly twice: unknown;
+  };
+}
+
+async function main(): Promise<void> {
+  const repoRoot = findRepoRoot();
+  const outDir = path.join(repoRoot, "out", "t3");
+  const idempotenceOutDir = path.join(outDir, "idempotence");
+  await mkdir(idempotenceOutDir, { recursive: true });
+
+  const start = performance.now();
+  const idempotenceReport = await runIdempotence(repoRoot);
+  const seedEntry: HarnessSeedEntry = {
+    seed: "0x5eed-idem-0001",
+    now: new Date().toISOString(),
+    case: "idempotence-fixtures",
+    runtime: Number((performance.now() - start).toFixed(3)),
+  };
+
+  const seedsPath = path.join(outDir, "harness-seeds.jsonl");
+  await writeFile(seedsPath, `${JSON.stringify(seedEntry)}\n`, { encoding: "utf-8" });
+
+  const idempotenceReportPath = path.join(idempotenceOutDir, "report.json");
+  await writeJson(idempotenceReportPath, idempotenceReport);
+  await writeSha256(idempotenceReportPath);
+
+  const gitCommit = await resolveGitCommit(repoRoot);
+  const generated = new Date().toISOString();
+
+  const rollupPath = path.join(outDir, "oracles-report.json");
+  const rollup = {
+    summary: { generated, git: gitCommit },
+    oracles: { idempotence: idempotenceReport },
+    seeds: { total: 1, entries: [seedEntry] },
+  };
+  await writeJson(rollupPath, rollup);
+  await writeSha256(rollupPath);
+
+  const certificatePath = path.join(outDir, "certificate.json");
+  const certificate = {
+    generated,
+    git: gitCommit,
+    reports: [
+      { path: relativePath(repoRoot, idempotenceReportPath), sha256: await readSha(idempotenceReportPath) },
+      { path: relativePath(repoRoot, rollupPath), sha256: await readSha(rollupPath) },
+    ],
+  };
+  await writeJson(certificatePath, certificate);
+}
+
+async function runIdempotence(repoRoot: string): Promise<OracleReportSummary> {
+  const fixturesDir = path.join(repoRoot, "packages", "oracles", "idempotence", "fixtures");
+  const entries = (await readdir(fixturesDir)).filter((file) => file.endsWith(".json")).sort();
+  const ctx = createOracleCtx("0xfeed", { now: 0 });
+
+  let passed = 0;
+  let failed = 0;
+  let firstFail: OracleReportSummary["firstFail"] = undefined;
+
+  for (const file of entries) {
+    const payload = JSON.parse(await readFile(path.join(fixturesDir, file), "utf-8")) as {
+      readonly input: IdempotenceInput;
+    };
+    const result = await checkIdempotence(payload.input, ctx);
+    if (result.ok) {
+      passed += 1;
+      continue;
+    }
+
+    failed += 1;
+    if (!firstFail) {
+      const details = result.error.details as { mismatches?: ReadonlyArray<{ pointer: string; once: unknown; twice: unknown }> } | undefined;
+      const first = details?.mismatches?.[0];
+      if (first) {
+        firstFail = { pointer: first.pointer, once: first.once, twice: first.twice };
+      }
+    }
+  }
+
+  return { total: entries.length, passed, failed, ...(firstFail ? { firstFail } : {}) };
+}
+
+async function writeJson(filePath: string, data: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, { encoding: "utf-8" });
+}
+
+async function writeSha256(filePath: string): Promise<void> {
+  const hash = await readSha(filePath);
+  await writeFile(`${filePath}.sha256`, `${hash}\n`, { encoding: "utf-8" });
+}
+
+async function readSha(filePath: string): Promise<string> {
+  const buffer = await readFile(filePath);
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function resolveGitCommit(repoRoot: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: repoRoot });
+    return stdout.trim();
+  } catch (error) {
+    return "unknown";
+  }
+}
+
+function relativePath(root: string, target: string): string {
+  return path.relative(root, target) || path.basename(target);
+}
+
+void main();
+
+export {
+  runIdempotence,
+  writeJson,
+  writeSha256,
+  readSha,
+  relativePath,
+};
+
+export type { OracleReportSummary };

--- a/packages/oracles/harness/tests/harness.spec.ts
+++ b/packages/oracles/harness/tests/harness.spec.ts
@@ -1,0 +1,60 @@
+import { mkdtemp } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { findRepoRoot } from "@tf-lang/utils";
+
+import {
+  readSha,
+  relativePath,
+  runIdempotence,
+  writeJson,
+  writeSha256,
+} from "../src/build-reports.js";
+
+const createTempDir = () => mkdtemp(path.join(tmpdir(), "harness-spec-"));
+
+describe("build-reports helpers", () => {
+  it("writes canonical JSON with a trailing newline", async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, "report.json");
+    await writeJson(filePath, { alpha: 1, beta: [2, 3] });
+    const contents = await readFile(filePath, "utf-8");
+    expect(contents.endsWith("\n")).toBe(true);
+    expect(JSON.parse(contents)).toEqual({ alpha: 1, beta: [2, 3] });
+  });
+
+  it("writes deterministic SHA256 sidecars", async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, "payload.json");
+    await writeJson(filePath, { foo: "bar" });
+    await writeSha256(filePath);
+    const digestPayload = await readFile(`${filePath}.sha256`, "utf-8");
+    expect(digestPayload.endsWith("\n")).toBe(true);
+    const digest = digestPayload.trim();
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    await expect(readSha(filePath)).resolves.toBe(digest);
+  });
+
+  it("computes stable relative paths", () => {
+    const repoRoot = "/repo";
+    expect(relativePath(repoRoot, "/repo/out/t3/report.json")).toBe("out/t3/report.json");
+    expect(relativePath(repoRoot, "/repo")).toBe("repo");
+  });
+});
+
+describe("runIdempotence", () => {
+  it("summarizes the checked fixtures", async () => {
+    const summary = await runIdempotence(findRepoRoot());
+    expect(summary).toMatchObject({
+      total: 2,
+      passed: 1,
+      failed: 1,
+      firstFail: { pointer: "/data/3" },
+    });
+    expect(summary.total).toBe(summary.passed + summary.failed);
+  });
+});

--- a/packages/oracles/harness/tsconfig.json
+++ b/packages/oracles/harness/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "@tf/oracles-core": [
+        "./node_modules/@tf/oracles-core/index.d.ts"
+      ],
+      "@tf/oracles-core/*": [
+        "./node_modules/@tf/oracles-core/*"
+      ],
+      "@tf/oracles-idempotence": [
+        "./node_modules/@tf/oracles-idempotence/index.d.ts"
+      ],
+      "@tf/oracles-idempotence/*": [
+        "./node_modules/@tf/oracles-idempotence/*"
+      ],
+      "@tf-lang/utils": [
+        "./node_modules/@tf-lang/utils/index.d.ts"
+      ],
+      "@tf-lang/utils/*": [
+        "./node_modules/@tf-lang/utils/*"
+      ]
+    }
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/oracles/idempotence/README.md
+++ b/packages/oracles/idempotence/README.md
@@ -1,0 +1,10 @@
+# @tf/oracles-idempotence
+
+Idempotence oracle for TF-Lang runtimes. Ensures that applying a transformation twice yields the same canonical result as applying it once.
+
+## Development
+
+```sh
+pnpm install
+pnpm -C packages/oracles/idempotence test
+```

--- a/packages/oracles/idempotence/fixtures/happy.json
+++ b/packages/oracles/idempotence/fixtures/happy.json
@@ -1,1 +1,16 @@
-{"version":"0.1.0","subject":"idempotence","input":{"v":[1,2,3]}}
+{
+  "description": "Idempotent case keeps canonical result stable.",
+  "input": {
+    "cases": [
+      {
+        "name": "array-identity",
+        "once": { "data": [1, 2, 3] },
+        "twice": { "data": [1, 2, 3] }
+      }
+    ]
+  },
+  "expect": {
+    "ok": true,
+    "casesChecked": 1
+  }
+}

--- a/packages/oracles/idempotence/fixtures/mismatch.json
+++ b/packages/oracles/idempotence/fixtures/mismatch.json
@@ -1,1 +1,17 @@
-{"version":"0.1.0","subject":"idempotence","input":{"v":[1,2,3,4]}}
+{
+  "description": "Second application drifts from the first.",
+  "input": {
+    "cases": [
+      {
+        "name": "array-mutation",
+        "once": { "data": [1, 2, 3, 4] },
+        "twice": { "data": [1, 2, 3, 5] }
+      }
+    ]
+  },
+  "expect": {
+    "ok": false,
+    "casesChecked": 1,
+    "pointer": "/data/3"
+  }
+}

--- a/packages/oracles/idempotence/package.json
+++ b/packages/oracles/idempotence/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tf/oracles-idempotence",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": "./dist/index.js",
+  "license": "MIT",
+  "description": "Idempotence oracle ensuring applying an operation twice matches the first result.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@tf/oracles-core": "workspace:*"
+  },
+  "devDependencies": {
+    "fast-check": "^3.19.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.5"
+  }
+}

--- a/packages/oracles/idempotence/src/index.ts
+++ b/packages/oracles/idempotence/src/index.ts
@@ -1,0 +1,149 @@
+import { err, ok, withTrace } from "@tf/oracles-core";
+import { canonicalStringify } from "@tf/oracles-core";
+import type { Oracle, OracleCtx, OracleResult } from "@tf/oracles-core";
+
+import type { IdempotenceInput, IdempotenceMismatch, IdempotenceReport } from "./types.js";
+
+export type { IdempotenceCase, IdempotenceInput, IdempotenceReport } from "./types.js";
+
+const FAILURE_CODE = "E_NON_IDEMPOTENT";
+
+export function createIdempotenceOracle(): Oracle<IdempotenceInput, IdempotenceReport> {
+  return {
+    async check(input: IdempotenceInput, ctx: OracleCtx) {
+      return checkIdempotence(input, ctx);
+    },
+  };
+}
+
+export async function checkIdempotence(
+  input: IdempotenceInput,
+  ctx: OracleCtx,
+): Promise<OracleResult<IdempotenceReport>> {
+  const cases = input.cases ?? [];
+  let casesChecked = 0;
+  const mismatches: IdempotenceMismatch[] = [];
+
+  for (const idempotenceCase of cases) {
+    casesChecked += 1;
+    const canonicalOnce = ctx.canonicalize(idempotenceCase.once ?? null);
+    const canonicalTwice = ctx.canonicalize(idempotenceCase.twice ?? null);
+
+    const mismatch = findFirstMismatch(canonicalOnce, canonicalTwice);
+    if (mismatch) {
+      mismatches.push({
+        case: idempotenceCase.name,
+        pointer: mismatch.pointer,
+        once: mismatch.once,
+        twice: mismatch.twice,
+      });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    const failure = err(FAILURE_CODE, "Idempotence violations detected", { mismatches });
+    const trace = mismatches
+      .slice(0, 5)
+      .map((entry) => `case:${entry.case}${entry.pointer}`);
+    return withTrace(failure, trace);
+  }
+
+  return ok({ casesChecked, mismatches: [] });
+}
+
+interface MismatchDetail {
+  readonly pointer: string;
+  readonly once: unknown;
+  readonly twice: unknown;
+}
+
+function findFirstMismatch(left: unknown, right: unknown): MismatchDetail | undefined {
+  if (canonicalStringify(left) === canonicalStringify(right)) {
+    return undefined;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    const maxLength = Math.max(left.length, right.length);
+    for (let index = 0; index < maxLength; index += 1) {
+      if (index >= left.length) {
+        return {
+          pointer: pointerFromSegments([index]),
+          once: undefined,
+          twice: right[index],
+        };
+      }
+      if (index >= right.length) {
+        return {
+          pointer: pointerFromSegments([index]),
+          once: left[index],
+          twice: undefined,
+        };
+      }
+      const nested = findFirstMismatch(left[index], right[index]);
+      if (nested) {
+        return {
+          pointer: pointerFromSegments([index, ...segmentsFromPointer(nested.pointer)]),
+          once: nested.once,
+          twice: nested.twice,
+        };
+      }
+    }
+    return undefined;
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const keys = new Set<string>([...Object.keys(left), ...Object.keys(right)]);
+    const sorted = Array.from(keys).sort();
+    for (const key of sorted) {
+      if (!(key in left)) {
+        return {
+          pointer: pointerFromSegments([key]),
+          once: undefined,
+          twice: right[key],
+        };
+      }
+      if (!(key in right)) {
+        return {
+          pointer: pointerFromSegments([key]),
+          once: left[key],
+          twice: undefined,
+        };
+      }
+      const nested = findFirstMismatch(left[key], right[key]);
+      if (nested) {
+        return {
+          pointer: pointerFromSegments([key, ...segmentsFromPointer(nested.pointer)]),
+          once: nested.once,
+          twice: nested.twice,
+        };
+      }
+    }
+    return undefined;
+  }
+
+  return { pointer: pointerFromSegments([]), once: left, twice: right };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pointerFromSegments(segments: ReadonlyArray<string | number>): string {
+  if (segments.length === 0) {
+    return "/";
+  }
+  const encoded = segments.map((segment) => encodePointerSegment(String(segment)));
+  return `/${encoded.join("/")}`;
+}
+
+function encodePointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function segmentsFromPointer(pointer: string): ReadonlyArray<string | number> {
+  if (pointer === "/" || pointer === "") {
+    return [];
+  }
+  const segments = pointer.split("/").slice(1);
+  return segments.map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"));
+}

--- a/packages/oracles/idempotence/src/types.ts
+++ b/packages/oracles/idempotence/src/types.ts
@@ -1,0 +1,22 @@
+export interface IdempotenceInput {
+  readonly cases?: ReadonlyArray<IdempotenceCase>;
+}
+
+export interface IdempotenceCase {
+  readonly name: string;
+  readonly description?: string;
+  readonly once: unknown;
+  readonly twice: unknown;
+}
+
+export interface IdempotenceReport {
+  readonly casesChecked: number;
+  readonly mismatches: ReadonlyArray<IdempotenceMismatch>;
+}
+
+export interface IdempotenceMismatch {
+  readonly case: string;
+  readonly pointer: string;
+  readonly once: unknown;
+  readonly twice: unknown;
+}

--- a/packages/oracles/idempotence/tests/oracle.spec.ts
+++ b/packages/oracles/idempotence/tests/oracle.spec.ts
@@ -1,0 +1,211 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import * as fc from "fast-check";
+
+import { createOracleCtx } from "@tf/oracles-core";
+import { checkIdempotence } from "../src/index.js";
+import type { IdempotenceInput } from "../src/types.js";
+
+interface SeedsFile {
+  readonly ts: {
+    readonly passProperty: string;
+    readonly failProperty: string;
+  };
+}
+
+interface FixtureExpectation {
+  readonly ok: boolean;
+  readonly casesChecked: number;
+  readonly pointer?: string;
+}
+
+interface IdempotenceFixture {
+  readonly description: string;
+  readonly input: IdempotenceInput;
+  readonly expect: FixtureExpectation;
+}
+
+interface LoadedFixture {
+  readonly file: string;
+  readonly data: IdempotenceFixture;
+}
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const seedsPath = join(thisDir, "seeds.json");
+const fixturesDir = join(thisDir, "..", "fixtures");
+
+const seedsFile = JSON.parse(readFileSync(seedsPath, "utf-8")) as SeedsFile;
+const PASS_SEED = parseSeed(seedsFile.ts.passProperty);
+const FAIL_SEED = parseSeed(seedsFile.ts.failProperty);
+const FIXTURES = loadFixtures();
+
+const jsonValue = () => fc.jsonValue({ maxDepth: 3 });
+
+describe("idempotence oracle", () => {
+  const ctx = createOracleCtx("0xfeed", { now: 0 });
+
+  it("passes when once and twice are canonical equivalents", async () => {
+    await fc.assert(
+      fc.asyncProperty(jsonValue(), async (value) => {
+        const input: IdempotenceInput = {
+          cases: [
+            {
+              name: "canonical",
+              once: clone(value),
+              twice: clone(value),
+            },
+          ],
+        };
+        const result = await checkIdempotence(input, ctx);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.casesChecked).toBe(1);
+          expect(result.value.mismatches).toHaveLength(0);
+        }
+      }),
+      { numRuns: 64, seed: PASS_SEED },
+    );
+  });
+
+  it("fails when the second run diverges", async () => {
+    await fc.assert(
+      fc.asyncProperty(jsonValue(), async (value) => {
+        const input: IdempotenceInput = {
+          cases: [
+            {
+              name: "mutated",
+              once: clone(value),
+              twice: perturb(value),
+            },
+          ],
+        };
+        const result = await checkIdempotence(input, ctx);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("E_NON_IDEMPOTENT");
+        }
+      }),
+      { numRuns: 32, seed: FAIL_SEED },
+    );
+  });
+
+  it("reports the deepest pointer on nested mismatches", async () => {
+    const input: IdempotenceInput = {
+      cases: [
+        {
+          name: "nested",
+          once: { nested: { value: 1, meta: { hint: true } } },
+          twice: { nested: { value: 2, meta: { hint: true } } },
+        },
+      ],
+    };
+    const result = await checkIdempotence(input, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("E_NON_IDEMPOTENT");
+      const details = result.error.details as { mismatches?: IdempotenceMismatch[] } | undefined;
+      const pointer = details?.mismatches?.[0]?.pointer;
+      expect(pointer).toBe("/nested/value");
+    }
+  });
+
+  it("detects null versus missing properties", async () => {
+    const input: IdempotenceInput = {
+      cases: [
+        {
+          name: "null-vs-missing",
+          once: { value: null, other: 1 },
+          twice: { other: 1 },
+        },
+      ],
+    };
+    const result = await checkIdempotence(input, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("E_NON_IDEMPOTENT");
+      const details = result.error.details as { mismatches?: IdempotenceMismatch[] } | undefined;
+      const pointer = details?.mismatches?.[0]?.pointer;
+      expect(pointer).toBe("/value");
+    }
+  });
+});
+
+describe("idempotence fixtures", () => {
+  for (const fixture of FIXTURES) {
+    it(`matches ${fixture.file}`, async () => {
+      const ctx = createOracleCtx("0xfeed", { now: 0 });
+      const { input, expect: expectation } = fixture.data;
+      const result = await checkIdempotence(input, ctx);
+      if (expectation.ok) {
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.casesChecked).toBe(expectation.casesChecked);
+        }
+        return;
+      }
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("E_NON_IDEMPOTENT");
+        const details = result.error.details as { mismatches?: IdempotenceMismatch[] } | undefined;
+        const mismatches = details?.mismatches ?? [];
+        expect(mismatches).toHaveLength(1);
+        if (mismatches.length > 0) {
+          expect(mismatches[0].pointer).toBe(expectation.pointer);
+        }
+      }
+    });
+  }
+});
+
+interface IdempotenceMismatch {
+  readonly pointer: string;
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function perturb(value: unknown): unknown {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return `${value}`;
+    }
+    if (!Number.isSafeInteger(value)) {
+      return `${value}__mutated`;
+    }
+    return value + 1;
+  }
+  if (typeof value === "string") {
+    return `${value}__mutated`;
+  }
+  if (Array.isArray(value)) {
+    return [...value, "__mutated__"];
+  }
+  if (value && typeof value === "object") {
+    return { ...(value as Record<string, unknown>), __mutated__: true };
+  }
+  if (typeof value === "boolean") {
+    return !value;
+  }
+  return { __mutated__: value };
+}
+
+function parseSeed(value: string): number {
+  const parsed = Number.parseInt(value, 16);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid seed: ${value}`);
+  }
+  return parsed;
+}
+
+function loadFixtures(): LoadedFixture[] {
+  const entries = readdirSync(fixturesDir).filter((file) => file.endsWith(".json"));
+  return entries.sort().map((file) => {
+    const payload = JSON.parse(readFileSync(join(fixturesDir, file), "utf-8")) as IdempotenceFixture;
+    return { file, data: payload };
+  });
+}

--- a/packages/oracles/idempotence/tests/seeds.json
+++ b/packages/oracles/idempotence/tests/seeds.json
@@ -1,0 +1,6 @@
+{
+  "ts": {
+    "passProperty": "0x5eed1",
+    "failProperty": "0x5eed2"
+  }
+}

--- a/packages/oracles/idempotence/tsconfig.json
+++ b/packages/oracles/idempotence/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "@tf/oracles-core": [
+        "./node_modules/@tf/oracles-core/index.d.ts"
+      ],
+      "@tf/oracles-core/*": [
+        "./node_modules/@tf/oracles-core/*"
+      ]
+    }
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/oracles/idempotence/vitest.config.ts
+++ b/packages/oracles/idempotence/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@tf/oracles-core": path.resolve(thisDir, "../core/src/index.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,38 @@ importers:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
 
+  packages/oracles/harness:
+    dependencies:
+      '@tf-lang/utils':
+        specifier: workspace:*
+        version: link:../../utils
+      '@tf/oracles-core':
+        specifier: workspace:*
+        version: link:../core
+      '@tf/oracles-idempotence':
+        specifier: workspace:*
+        version: link:../idempotence
+    devDependencies:
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.2
+
+  packages/oracles/idempotence:
+    dependencies:
+      '@tf/oracles-core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      fast-check:
+        specifier: ^3.19.0
+        version: 3.23.2
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.2
+      vitest:
+        specifier: ^2.0.5
+        version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
+
   packages/tf-check:
     dependencies:
       '@tf-lang/utils':


### PR DESCRIPTION
## Summary
* add the shared `@tf/oracles-core` helpers for canonicalization, oracle contexts, and normalized success/failure envelopes. 
* ship the TypeScript idempotence oracle package with fixtures, seeds, and richer property/fixture coverage for nested and null edge cases. 
* wire up an initial harness package that runs the idempotence fixtures, exports reusable helpers, and emits deterministic report + certificate artifacts.

## Evidence
- [x] out/t3/idempotence/report.json
- [x] out/t3/oracles-report.json
- [x] out/t3/oracles-report.json.sha256
- [x] out/t3/certificate.json
- [x] out/t3/harness-seeds.jsonl
- [x] out/t3/_status.json
- [x] out/t3/_progress.log
- [x] out/t3/_pause_summary.json

## Determinism & Seeds
* Seeds: 0x5eed-idem-0001 (fixtures harness)
* Repeats: 1 per fixture (downshifted per brief)
* Fixtures: packages/oracles/idempotence/fixtures/{happy,mismatch}.json

## Tests & CI
* ✅ `pnpm --reporter=append-only -C packages/oracles/core test`
* ✅ `pnpm --reporter=append-only -C packages/oracles/idempotence test`
* ✅ `pnpm --reporter=append-only -C packages/oracles/harness test`
* ✅ `pnpm -C packages/oracles/harness run build-reports`

## Implementation Notes
* Harness exports (`runIdempotence`, `writeJson`, `writeSha256`, `readSha`, `relativePath`) are reused in Vitest for deterministic newline/SHA coverage.
* Property-based tests extend the oracle coverage to nested pointers and null-vs-missing divergences while keeping seeds fixed via `tests/seeds.json`.
* Shared canonical helpers drop `undefined`, normalize `Set`, `Date`, non-finite numbers, and trace/warning dedupe for consistent JSON pointers.
* Produced `_pause_summary.json` manually because the stock analyzer script targets T1 paths.

## Hurdles/Follow-ups
* Next sprints: implement conservation/transport oracles plus parity harness (per roadmap).
* Consider generalizing pause-analysis tooling to T3 paths for future runs.


------
https://chatgpt.com/codex/tasks/task_e_68cc3931275883209233b54d5fe15f6a