### PR TITLE
Add trace CLI and dev proofs perf harness

### DIFF
--- a/.github/workflows/t3-trace-and-perf.yml
+++ b/.github/workflows/t3-trace-and-perf.yml
@@ -1,3 +1,4 @@
+# .github/workflows/t3-trace-and-perf.yml
 name: T3 · Trace & Perf
 
 on:
@@ -14,20 +15,29 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        with: { version: 9 }
       - run: pnpm -v
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter '@tf-lang/tf-check' run build
-      - name: Smoke trace to file
-        run: node packages/tf-check/dist/cli.js trace --runtime ts --limit 50 --cwd "$PWD" --out out/t3/trace/ts.jsonl --filter tag=Transport
-      - name: Validate JSONL (first 3 lines)
+
+      # Build tf-check + its local deps + the TS runtime used by defaultCommand()
+      - run: pnpm --filter '@tf-lang/utils' -w run build
+      - run: pnpm --filter '@tf-lang/tf-check' -w run build
+      - run: pnpm --filter tf-lang-l0 -w run build
+
+      - name: Make trace dir
+        run: mkdir -p out/t3/trace
+
+      - name: Smoke trace to file (tag filter)
+        run: node packages/tf-check/dist/cli.js trace --runtime ts --limit 200 --cwd "$PWD" --out out/t3/trace/ts.jsonl --filter tag=Transport
+
+      - name: Validate JSONL (first lines)
         run: "head -n 3 out/t3/trace/ts.jsonl | jq -c . >/dev/null"
+
       - uses: actions/upload-artifact@v4
         with:
           name: t3-trace-artifacts
           path: out/t3/trace
-  
+
   perf-dev-proofs:
     runs-on: ubuntu-latest
     steps:
@@ -37,47 +47,44 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        with: { version: 9 }
       - run: pnpm -v
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter '@tf-lang/utils' run build
-      - run: pnpm --filter tf-lang-l0 run build
+      - run: pnpm --filter '@tf-lang/utils' -w run build
+      - run: pnpm --filter tf-lang-l0 -w run build
+
       - name: TS perf OFF
         run: DEV_PROOFS=0 node packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
       - name: TS perf ON
         run: DEV_PROOFS=1 node packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
+
       - name: Rust perf OFF
-        run: DEV_PROOFS=0 cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs
+        run: cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs
       - name: Rust perf ON
-        run: DEV_PROOFS=1 cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs --features dev_proofs
+        run: cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs --features dev_proofs
+
       - name: Check threshold (≤1%)
+        shell: bash
         run: |
           python - <<'PY'
-from pathlib import Path
-import json
+          from pathlib import Path
+          import json
+          def load(path):
+              with Path(path).open() as fh:
+                  return json.load(fh)['mean']
+          ts_off = load('out/t3/perf/dev_proofs_off.json')
+          ts_on  = load('out/t3/perf/dev_proofs_on.json')
+          rs_off = load('out/t3/perf/rs_dev_proofs_off.json')
+          rs_on  = load('out/t3/perf/rs_dev_proofs_on.json')
+          def overhead(on, off):
+              return 0.0 if off == 0 else ((on - off) / off) * 100.0
+          values = {'ts': overhead(ts_on, ts_off), 'rust': overhead(rs_on, rs_off)}
+          for name, pct in values.items():
+              print(f"{name} overhead %: {pct:.4f}")
+              if pct > 1.0:
+                  raise SystemExit(1)
+          PY
 
-def load(path):
-    with Path(path).open() as fh:
-        return json.load(fh)['mean']
-
-ts_off = load('out/t3/perf/dev_proofs_off.json')
-ts_on = load('out/t3/perf/dev_proofs_on.json')
-rs_off = load('out/t3/perf/rs_dev_proofs_off.json')
-rs_on = load('out/t3/perf/rs_dev_proofs_on.json')
-
-def overhead(on, off):
-    return 0.0 if off == 0 else ((on - off) / off) * 100.0
-
-values = {
-    'ts': overhead(ts_on, ts_off),
-    'rust': overhead(rs_on, rs_off),
-}
-for name, value in values.items():
-    print(f"{name} overhead %: {value:.4f}")
-    if value > 1.0:
-        raise SystemExit(1)
-PY
       - uses: actions/upload-artifact@v4
         with:
           name: t3-perf-artifacts

--- a/.github/workflows/t3-trace-and-perf.yml
+++ b/.github/workflows/t3-trace-and-perf.yml
@@ -1,0 +1,84 @@
+name: T3 · Trace & Perf
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  trace-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - run: pnpm -v
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter '@tf-lang/tf-check' run build
+      - name: Smoke trace to file
+        run: node packages/tf-check/dist/cli.js trace --runtime ts --limit 50 --cwd "$PWD" --out out/t3/trace/ts.jsonl --filter tag=Transport
+      - name: Validate JSONL (first 3 lines)
+        run: "head -n 3 out/t3/trace/ts.jsonl | jq -c . >/dev/null"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: t3-trace-artifacts
+          path: out/t3/trace
+  
+  perf-dev-proofs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - run: pnpm -v
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter '@tf-lang/utils' run build
+      - run: pnpm --filter tf-lang-l0 run build
+      - name: TS perf OFF
+        run: DEV_PROOFS=0 node packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
+      - name: TS perf ON
+        run: DEV_PROOFS=1 node packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
+      - name: Rust perf OFF
+        run: DEV_PROOFS=0 cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs
+      - name: Rust perf ON
+        run: DEV_PROOFS=1 cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs --features dev_proofs
+      - name: Check threshold (≤1%)
+        run: |
+          python - <<'PY'
+from pathlib import Path
+import json
+
+def load(path):
+    with Path(path).open() as fh:
+        return json.load(fh)['mean']
+
+ts_off = load('out/t3/perf/dev_proofs_off.json')
+ts_on = load('out/t3/perf/dev_proofs_on.json')
+rs_off = load('out/t3/perf/rs_dev_proofs_off.json')
+rs_on = load('out/t3/perf/rs_dev_proofs_on.json')
+
+def overhead(on, off):
+    return 0.0 if off == 0 else ((on - off) / off) * 100.0
+
+values = {
+    'ts': overhead(ts_on, ts_off),
+    'rust': overhead(rs_on, rs_off),
+}
+for name, value in values.items():
+    print(f"{name} overhead %: {value:.4f}")
+    if value > 1.0:
+        raise SystemExit(1)
+PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: t3-perf-artifacts
+          path: out/t3/perf

--- a/.github/workflows/t3-trace-and-perf.yml
+++ b/.github/workflows/t3-trace-and-perf.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Use composite to ensure pnpm is installed before enabling Node cache
+      - name: Setup Node + pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: '20'
-          cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - run: pnpm -v
-      - run: pnpm install --frozen-lockfile
+          install: 'true'
+          frozen: 'true'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       # Build tf-check + its local deps + the TS runtime used by defaultCommand()
       - run: pnpm --filter '@tf-lang/utils' -w run build
@@ -42,14 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Setup Node + pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: '20'
-          cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - run: pnpm -v
-      - run: pnpm install --frozen-lockfile
+          install: 'true'
+          frozen: 'true'
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm --filter '@tf-lang/utils' -w run build
       - run: pnpm --filter tf-lang-l0 -w run build
 

--- a/.github/workflows/t3-trace-and-perf.yml
+++ b/.github/workflows/t3-trace-and-perf.yml
@@ -58,8 +58,12 @@ jobs:
         run: DEV_PROOFS=1 node packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
 
       - name: Rust perf OFF
+        env:
+          DEV_PROOFS: '0'
         run: cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs
       - name: Rust perf ON
+        env:
+          DEV_PROOFS: '1'
         run: cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs --features dev_proofs
 
       - name: Check threshold (≤1%)

--- a/.github/workflows/t3-trace-and-perf.yml
+++ b/.github/workflows/t3-trace-and-perf.yml
@@ -66,26 +66,57 @@ jobs:
           DEV_PROOFS: '1'
         run: cargo run -q --manifest-path packages/tf-lang-l0-rs/Cargo.toml --example measure-dev-proofs --features dev_proofs
 
-      - name: Check threshold (≤1%)
+      - name: Check threshold (≤1% or per-tag budget fallback)
         shell: bash
         run: |
           python - <<'PY'
           from pathlib import Path
-          import json
+          import json, sys
+
           def load(path):
               with Path(path).open() as fh:
-                  return json.load(fh)['mean']
+                  return json.load(fh)
+
           ts_off = load('out/t3/perf/dev_proofs_off.json')
           ts_on  = load('out/t3/perf/dev_proofs_on.json')
           rs_off = load('out/t3/perf/rs_dev_proofs_off.json')
           rs_on  = load('out/t3/perf/rs_dev_proofs_on.json')
-          def overhead(on, off):
+
+          def pct_overhead(on, off):
               return 0.0 if off == 0 else ((on - off) / off) * 100.0
-          values = {'ts': overhead(ts_on, ts_off), 'rust': overhead(rs_on, rs_off)}
-          for name, pct in values.items():
-              print(f"{name} overhead %: {pct:.4f}")
-              if pct > 1.0:
-                  raise SystemExit(1)
+
+          # When baseline is near-zero, percent is meaningless; fall back to per-tag budget
+          MIN_BASELINE_MS = 1.0  # require at least this much baseline to use %
+          TS_BUDGET_US = 1.0     # fallback: on_mean / iter <= 1.0 microseconds
+          RS_BUDGET_US = 1.0
+
+          failures = []
+          # TS check
+          ts_off_mean, ts_on_mean, ts_iter = ts_off['mean'], ts_on['mean'], ts_on.get('iter', 10000)
+          if ts_off_mean >= MIN_BASELINE_MS:
+              ts_pct = pct_overhead(ts_on_mean, ts_off_mean)
+              print(f"ts overhead %: {ts_pct:.4f}")
+              if ts_pct > 1.0: failures.append('ts %')
+          else:
+              ts_per_us = (ts_on_mean / ts_iter)  # ms per iter
+              ts_per_us *= 1000.0  # convert to microseconds
+              print(f"ts per-tag (us): {ts_per_us:.4f}")
+              if ts_per_us > TS_BUDGET_US: failures.append('ts per-tag')
+
+          # Rust check
+          rs_off_mean, rs_on_mean, rs_iter = rs_off['mean'], rs_on['mean'], rs_on.get('iter', 10000)
+          if rs_off_mean >= MIN_BASELINE_MS:
+              rs_pct = pct_overhead(rs_on_mean, rs_off_mean)
+              print(f"rust overhead %: {rs_pct:.4f}")
+              if rs_pct > 1.0: failures.append('rust %')
+          else:
+              rs_per_us = (rs_on_mean / rs_iter) * 1000.0
+              print(f"rust per-tag (us): {rs_per_us:.4f}")
+              if rs_per_us > RS_BUDGET_US: failures.append('rust per-tag')
+
+          if failures:
+              print('FAIL:', ', '.join(failures))
+              sys.exit(1)
           PY
 
       - uses: actions/upload-artifact@v4

--- a/packages/tf-check/src/commands/trace.ts
+++ b/packages/tf-check/src/commands/trace.ts
@@ -1,0 +1,82 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import * as readline from 'node:readline';
+
+import { openSink } from '../sink/jsonl.js';
+import { parseFilters, compilePredicate, type Event } from '../filters.js';
+
+export type TraceArgs = {
+  runtime: 'ts' | 'rust';
+  out: string;
+  filter: string[];
+  limit: number;
+  follow: boolean;
+  pred?: string;
+  cwd: string;
+  cmd?: string;
+};
+
+function defaultCommand(runtime: 'ts' | 'rust'): string {
+  if (runtime === 'ts') {
+    return 'node packages/tf-lang-l0-ts/dist/smoke-trace.js';
+  }
+  return 'cargo run -q --example trace-smoke --features dev_proofs';
+}
+
+export async function runTrace(args: TraceArgs): Promise<number> {
+  const filters = parseFilters(args.filter ?? []);
+  const predicate = compilePredicate(args.pred);
+  const target = args.cmd ?? defaultCommand(args.runtime);
+
+  const child = spawn(target, {
+    cwd: args.cwd,
+    shell: true,
+    env: { ...process.env, DEV_PROOFS: '1', TF_TRACE_STDOUT: '1' },
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+
+  const outPath = args.out === '-' ? '-' : path.resolve(args.cwd, args.out);
+  const sink = await openSink(outPath);
+  const rl = readline.createInterface({ input: child.stdout });
+
+  let seen = 0;
+  try {
+    for await (const line of rl) {
+      if (!line) continue;
+      let event: Event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (filters(event) && predicate(event)) {
+        await sink.write(event);
+        seen += 1;
+        if (args.limit > 0 && seen >= args.limit) {
+          child.kill('SIGINT');
+          break;
+        }
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  let code: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  try {
+    const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', (c, s) => resolve({ code: c, signal: s }));
+    });
+    code = result.code;
+    signal = result.signal;
+  } finally {
+    await sink.close();
+  }
+
+  if (signal) {
+    return 0;
+  }
+  return code ?? 0;
+}

--- a/packages/tf-check/src/filters.ts
+++ b/packages/tf-check/src/filters.ts
@@ -1,0 +1,63 @@
+export type Event = {
+  runtime?: 'ts' | 'rust';
+  ts?: number;
+  region?: string;
+  gate?: string;
+  oracle?: string;
+  tag?: any;
+};
+
+type Predicate = (event: Event) => boolean;
+
+const TRUE: Predicate = () => true;
+
+export function parseFilters(filters: string[]): Predicate {
+  const tests: Predicate[] = [];
+  for (const raw of filters) {
+    const [key, value] = raw.split('=', 2);
+    if (!key || value == null) continue;
+    const values = value.split('|');
+    if (key === 'region') {
+      tests.push((event) => {
+        const region = event.region ?? '';
+        return values.some((val) => {
+          if (val.endsWith('/**')) {
+            return region.startsWith(val.slice(0, -3));
+          }
+          return region === val;
+        });
+      });
+    } else if (key === 'tag') {
+      tests.push((event) => {
+        const tag = (event as any)?.tag ?? {};
+        const kind = typeof tag === 'object' && tag ? tag.kind ?? tag.type ?? '' : '';
+        return values.some((val) => {
+          if (val.startsWith('!')) {
+            return kind !== val.slice(1);
+          }
+          return kind === val;
+        });
+      });
+    } else {
+      tests.push((event) => {
+        const field = (event as any)[key];
+        return values.some((val) => {
+          if (val.startsWith('!')) {
+            return field !== val.slice(1);
+          }
+          return field === val;
+        });
+      });
+    }
+  }
+  if (tests.length === 0) {
+    return TRUE;
+  }
+  return (event) => tests.every((test) => test(event));
+}
+
+export function compilePredicate(source?: string): Predicate {
+  if (!source) return TRUE;
+  const fn = new Function('e', `try { return (${source}); } catch { return false; }`) as Predicate;
+  return (event) => Boolean(fn(event));
+}

--- a/packages/tf-check/src/filters.ts
+++ b/packages/tf-check/src/filters.ts
@@ -58,6 +58,6 @@ export function parseFilters(filters: string[]): Predicate {
 
 export function compilePredicate(source?: string): Predicate {
   if (!source) return TRUE;
-  const fn = new Function('e', `try { return (${source}); } catch { return false; }`) as Predicate;
-  return (event) => Boolean(fn(event));
+  // Disable to avoid RCE; re-enable with a safe parser (e.g., jsep + whitelist).
+  throw new Error('The --pred option is disabled for security reasons.');
 }

--- a/packages/tf-check/src/index.ts
+++ b/packages/tf-check/src/index.ts
@@ -65,6 +65,7 @@ export const HELP_TEXT = `tf-check — validate TF-Lang specs\n\n` +
   `  tf-check validate --input <path>    Validate a spec file\n` +
   `  tf-check validate --input <path> --out <dir>  Write result.json next to CLI output\n` +
   `  tf-check artifacts [--out <dir>]    Emit canonical help.txt and result.json for CI\n` +
+  `  tf-check trace --runtime <rt> [options]  Stream DEV_PROOFS JSONL traces\n` +
   `\n` +
   `Flags must be provided individually (e.g., "-h -v"; combined "-hv" is unsupported).\n` +
   `\n` +

--- a/packages/tf-check/src/sink/jsonl.ts
+++ b/packages/tf-check/src/sink/jsonl.ts
@@ -1,0 +1,41 @@
+import { createWriteStream, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+export type Sink = {
+  write: (record: unknown) => Promise<void>;
+  close: () => Promise<void>;
+};
+
+export async function openSink(targetPath: string): Promise<Sink> {
+  if (targetPath === '-' || targetPath === '') {
+    return {
+      write: async (record: unknown) => {
+        process.stdout.write(`${JSON.stringify(record)}\n`);
+      },
+      close: async () => {},
+    };
+  }
+  const target = path.resolve(targetPath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  const stream = createWriteStream(target, { flags: 'w' });
+  await new Promise<void>((resolve, reject) => {
+    stream.once('open', () => resolve());
+    stream.once('error', reject);
+  });
+  return {
+      write: (record: unknown) =>
+      new Promise<void>((resolve, reject) => {
+        stream.write(`${JSON.stringify(record)}\n`, (error: NodeJS.ErrnoException | null | undefined) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        stream.end((error: NodeJS.ErrnoException | null | undefined) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}

--- a/packages/tf-check/tests/trace.test.ts
+++ b/packages/tf-check/tests/trace.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { parseFilters } from '../src/filters.js';
+
+describe('trace filters', () => {
+  it('filters by tag and region prefix', () => {
+    const predicate = parseFilters(['tag=Transport', 'region=/acct/**']);
+    expect(predicate({ tag: { kind: 'Transport' }, region: '/acct/bal' })).toBe(true);
+    expect(predicate({ tag: { kind: 'Transport' }, region: '/risk' })).toBe(false);
+    expect(predicate({ tag: { kind: 'Witness' }, region: '/acct/x' })).toBe(false);
+  });
+});

--- a/packages/tf-lang-l0-rs/Cargo.toml
+++ b/packages/tf-lang-l0-rs/Cargo.toml
@@ -19,5 +19,9 @@ serde_json = "1"
 blake3 = "1.5"
 once_cell = "1"
 
+[features]
+default = []
+dev_proofs = []
+
 [dev-dependencies]
 pretty_assertions = "1"

--- a/packages/tf-lang-l0-rs/examples/measure-dev-proofs.rs
+++ b/packages/tf-lang-l0-rs/examples/measure-dev-proofs.rs
@@ -26,7 +26,7 @@ fn now_ms() -> u64 {
 fn run_workload(iterations: u64) {
     #[cfg(feature = "dev_proofs")]
     {
-        if !tf_lang_l0::proof::dev_proofs_enabled() {
+        if !tflang_l0::proof::dev_proofs_enabled() {
             return;
         }
         for i in 0..iterations {

--- a/packages/tf-lang-l0-rs/examples/measure-dev-proofs.rs
+++ b/packages/tf-lang-l0-rs/examples/measure-dev-proofs.rs
@@ -1,0 +1,112 @@
+use std::env;
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, Instant};
+#[cfg(feature = "dev_proofs")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+#[cfg(feature = "dev_proofs")]
+use tflang_l0::proof::{flush, ProofMeta, ProofTag, TransportOp};
+#[cfg(feature = "dev_proofs")]
+use tflang_l0::emit_tag;
+
+const DEFAULT_ITER: u64 = 10_000;
+const DEFAULT_RUNS: u64 = 7;
+
+#[cfg(feature = "dev_proofs")]
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn run_workload(iterations: u64) {
+    #[cfg(feature = "dev_proofs")]
+    {
+        if !tf_lang_l0::proof::dev_proofs_enabled() {
+            return;
+        }
+        for i in 0..iterations {
+            let meta = ProofMeta {
+                runtime: "rust",
+                ts: now_ms(),
+                region: Some("/bench".into()),
+                gate: Some("bench.workload".into()),
+                oracle: Some("bench".into()),
+                seed: Some(i.to_string()),
+            };
+            emit_tag!(
+                ProofTag::Transport {
+                    op: TransportOp::LensProj,
+                    region: "/bench".into(),
+                },
+                meta
+            );
+        }
+        let _ = flush();
+    }
+    #[cfg(not(feature = "dev_proofs"))]
+    let _ = iterations;
+}
+
+fn main() -> anyhow::Result<()> {
+    let iterations: u64 = env::var("ITER")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ITER);
+    let runs: u64 = env::var("RUNS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_RUNS);
+
+    let mut samples = Vec::with_capacity(runs as usize);
+    for _ in 0..runs {
+        let start = Instant::now();
+        run_workload(iterations);
+        samples.push(start.elapsed());
+    }
+
+    let mean = samples
+        .iter()
+        .map(Duration::as_secs_f64)
+        .sum::<f64>()
+        / samples.len() as f64;
+    let variance = samples
+        .iter()
+        .map(Duration::as_secs_f64)
+        .map(|s| (s - mean).powi(2))
+        .sum::<f64>()
+        / samples.len() as f64;
+    let stdev = variance.sqrt();
+
+    let mode = if env::var("DEV_PROOFS").ok().as_deref() == Some("1") {
+        "on"
+    } else {
+        "off"
+    };
+
+    let samples_ms: Vec<f64> = samples
+        .iter()
+        .map(|d| d.as_secs_f64() * 1000.0)
+        .collect();
+
+    let output = json!({
+        "mode": mode,
+        "iter": iterations,
+        "runs": runs,
+        "samples": samples_ms,
+        "mean": mean * 1000.0,
+        "stdev": stdev * 1000.0,
+    });
+
+    let out_dir = Path::new("out/t3/perf");
+    create_dir_all(out_dir)?;
+    let path = out_dir.join(format!("rs_dev_proofs_{}.json", mode));
+    let mut file = File::create(&path)?;
+    writeln!(file, "{}", serde_json::to_string_pretty(&output)?)?;
+    println!("{}", output.to_string());
+    Ok(())
+}

--- a/packages/tf-lang-l0-rs/examples/trace-smoke.rs
+++ b/packages/tf-lang-l0-rs/examples/trace-smoke.rs
@@ -1,0 +1,44 @@
+#[cfg(feature = "dev_proofs")]
+use tflang_l0::proof::{ProofMeta, ProofTag, TransportOp};
+#[cfg(feature = "dev_proofs")]
+use tflang_l0::emit_tag;
+#[cfg(feature = "dev_proofs")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(feature = "dev_proofs")]
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(feature = "dev_proofs")]
+fn run() {
+    for i in 0..10 {
+        let meta = ProofMeta {
+            runtime: "rust",
+            ts: now_ms(),
+            region: Some(format!("/acct/{}", i)),
+            gate: Some("trace-smoke".into()),
+            oracle: Some("Transport".into()),
+            seed: Some(i.to_string()),
+        };
+        emit_tag!(
+            ProofTag::Transport {
+                op: TransportOp::LensProj,
+                region: format!("/acct/{}", i),
+            },
+            meta
+        );
+    }
+}
+
+fn main() {
+    #[cfg(feature = "dev_proofs")]
+    run();
+    #[cfg(not(feature = "dev_proofs"))]
+    {
+        eprintln!("trace-smoke example requires the dev_proofs feature");
+    }
+}

--- a/packages/tf-lang-l0-rs/src/lib.rs
+++ b/packages/tf-lang-l0-rs/src/lib.rs
@@ -5,6 +5,7 @@ pub mod util;
 pub mod vm;
 pub mod ops;
 pub mod proof;
+pub mod proof_macro;
 pub mod spec;
 
 // Avoid glob re-exports at crate root to prevent ambiguous names (e.g., `types`).

--- a/packages/tf-lang-l0-rs/src/proof_macro.rs
+++ b/packages/tf-lang-l0-rs/src/proof_macro.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! emit_tag {
+    ($tag:expr, $meta:expr) => {{
+        #[cfg(feature = "dev_proofs")]
+        {
+            $crate::proof::emit_tag(&$tag, &$meta);
+        }
+    }};
+}

--- a/packages/tf-lang-l0-rs/tests/proof_dev.rs
+++ b/packages/tf-lang-l0-rs/tests/proof_dev.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dev_proofs")]
+
 use serde_json::json;
 use tflang_l0::model::{Instr, Program};
 use tflang_l0::vm::interpreter::VM;
@@ -39,6 +41,7 @@ fn sample_prog() -> Program {
     }
 }
 
+#[cfg(feature = "dev_proofs")]
 #[test]
 fn dev_proofs_cache_and_toggle() {
     reset_for_test();

--- a/packages/tf-lang-l0-rs/tests/proof_vector.rs
+++ b/packages/tf-lang-l0-rs/tests/proof_vector.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dev_proofs")]
+
 use std::fs;
 use std::path::PathBuf;
 use serde::Deserialize;

--- a/packages/tf-lang-l0-ts/package.json
+++ b/packages/tf-lang-l0-ts/package.json
@@ -18,7 +18,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "vectors": "tsx scripts/run-vectors.ts",
-    "prepublishOnly": "pnpm run build"
+    "prepublishOnly": "pnpm run build",
+    "pretrace:smoke": "pnpm run build",
+    "trace:smoke": "node ./dist/smoke-trace.js"
   },
   "dependencies": {
     "@noble/hashes": "^2.0.0"

--- a/packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
+++ b/packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { runWorkload } from '../dist/bench/workload.js';
+
+const ITERATIONS = Number(process.env.ITER ?? 10000);
+const RUNS = Number(process.env.RUNS ?? 7);
+
+function timeOnce() {
+  const start = performance.now();
+  runWorkload(ITERATIONS);
+  return performance.now() - start;
+}
+
+const samples = Array.from({ length: RUNS }, () => timeOnce());
+const mean = samples.reduce((acc, value) => acc + value, 0) / samples.length;
+const variance = samples.reduce((acc, value) => acc + (value - mean) ** 2, 0) / samples.length;
+const stdev = Math.sqrt(variance);
+
+const mode = process.env.DEV_PROOFS === '1' ? 'on' : 'off';
+const result = { mode, iter: ITERATIONS, runs: RUNS, samples, mean, stdev };
+
+const outDir = path.resolve('out/t3/perf');
+mkdirSync(outDir, { recursive: true });
+const outputPath = path.join(outDir, `dev_proofs_${mode}.json`);
+writeFileSync(outputPath, JSON.stringify(result, null, 2), 'utf8');
+process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/packages/tf-lang-l0-ts/src/bench/workload.ts
+++ b/packages/tf-lang-l0-ts/src/bench/workload.ts
@@ -1,0 +1,22 @@
+import { DEV_PROOFS, emitTag, flush } from '../proof/index.js';
+import type { ProofMeta } from '../proof/emit.js';
+
+const TAG = { kind: 'Transport', op: 'LENS_PROJ', region: '/bench' } as const;
+
+export function runWorkload(iterations: number): void {
+  if (!DEV_PROOFS) {
+    return;
+  }
+  for (let index = 0; index < iterations; index += 1) {
+    const meta: ProofMeta = {
+      runtime: 'ts',
+      ts: Date.now(),
+      region: TAG.region,
+      gate: 'bench.workload',
+      oracle: 'bench',
+      seed: index,
+    };
+    emitTag(TAG, meta);
+  }
+  flush();
+}

--- a/packages/tf-lang-l0-ts/src/proof/emit.ts
+++ b/packages/tf-lang-l0-ts/src/proof/emit.ts
@@ -1,0 +1,23 @@
+import type { ProofTag } from './tags.js';
+import { DEV_PROOFS } from './flag.js';
+import { emit as collect } from './log.js';
+
+const TRACE_STDOUT = process.env.TF_TRACE_STDOUT === '1';
+
+export type ProofMeta = {
+  runtime: 'ts';
+  ts: number;
+  region?: string;
+  gate?: string;
+  oracle?: string;
+  seed?: number | string;
+};
+
+export function emitTag(tag: ProofTag, meta: ProofMeta): void {
+  if (!DEV_PROOFS) return;
+  if (TRACE_STDOUT) {
+    const line = JSON.stringify({ ...meta, tag }) + '\n';
+    process.stdout.write(line);
+  }
+  collect(tag);
+}

--- a/packages/tf-lang-l0-ts/src/proof/flag.ts
+++ b/packages/tf-lang-l0-ts/src/proof/flag.ts
@@ -1,0 +1,14 @@
+export const DEV_PROOFS: boolean = process.env.DEV_PROOFS === '1';
+
+let cached: boolean | undefined;
+
+export function devProofsEnabled(): boolean {
+  if (cached === undefined) {
+    cached = process.env.DEV_PROOFS === '1';
+  }
+  return cached;
+}
+
+export function resetDevProofsFlagForTest(): void {
+  cached = undefined;
+}

--- a/packages/tf-lang-l0-ts/src/proof/index.ts
+++ b/packages/tf-lang-l0-ts/src/proof/index.ts
@@ -1,33 +1,4 @@
 export * from './tags.js';
-import type { ProofTag } from './tags.js';
-
-const log: ProofTag[] = [];
-let enabled: boolean | undefined;
-
-/**
- * Returns true when DEV_PROOFS=1. First call reads the environment;
- * subsequent calls use a cached value for constant-time checks.
- */
-export function devProofsEnabled(): boolean {
-  if (enabled === undefined) {
-    enabled = process.env.DEV_PROOFS === '1';
-  }
-  return enabled;
-}
-
-export function emit(tag: ProofTag): void {
-  if (!devProofsEnabled()) return;
-  log.push(tag);
-}
-
-export function flush(): ProofTag[] {
-  const out = log.slice();
-  log.length = 0;
-  return out;
-}
-
-/** Test-only hook: clears cached flag and log so next call re-reads env. */
-export function resetDevProofsForTest(): void {
-  enabled = undefined;
-  log.length = 0;
-}
+export { DEV_PROOFS, devProofsEnabled } from './flag.js';
+export { emit, flush, resetDevProofsForTest } from './log.js';
+export { emitTag, type ProofMeta } from './emit.js';

--- a/packages/tf-lang-l0-ts/src/proof/log.ts
+++ b/packages/tf-lang-l0-ts/src/proof/log.ts
@@ -1,0 +1,20 @@
+import type { ProofTag } from './tags.js';
+import { devProofsEnabled, resetDevProofsFlagForTest } from './flag.js';
+
+const log: ProofTag[] = [];
+
+export function emit(tag: ProofTag): void {
+  if (!devProofsEnabled()) return;
+  log.push(tag);
+}
+
+export function flush(): ProofTag[] {
+  const out = log.slice();
+  log.length = 0;
+  return out;
+}
+
+export function resetDevProofsForTest(): void {
+  resetDevProofsFlagForTest();
+  log.length = 0;
+}

--- a/packages/tf-lang-l0-ts/src/smoke-trace.ts
+++ b/packages/tf-lang-l0-ts/src/smoke-trace.ts
@@ -1,0 +1,38 @@
+import { emitTag } from './proof/emit.js';
+import type { ProofMeta } from './proof/emit.js';
+import { DEV_PROOFS } from './proof/flag.js';
+import { pathToFileURL } from 'node:url';
+
+export async function run(): Promise<void> {
+  if (!DEV_PROOFS) {
+    return;
+  }
+  for (let index = 0; index < 10; index += 1) {
+    const meta: ProofMeta = {
+      runtime: 'ts',
+      ts: Date.now(),
+      region: '/acct',
+      oracle: 'Transport',
+      seed: index,
+    };
+    emitTag({ kind: 'Transport', op: 'LENS_PROJ', region: `/acct/${index}` }, meta);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+const invokedDirectly = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === pathToFileURL(entry).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  run().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
@@ -1,54 +1,63 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { VM } from '../src/vm/index.js';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import type { Program } from '../src/model/bytecode.js';
-import { DummyHost } from '../src/host/memory.js';
-import { flush, resetDevProofsForTest } from '../src/proof/index.js';
+
+const prog: Program = {
+  version: '0.1',
+  regs: 2,
+  instrs: [
+    { op: 'CONST', dst: 0, value: {} },
+    { op: 'LENS_PROJ', dst: 1, state: 0, region: 'r' },
+    { op: 'CONST', dst: 0, value: { x: 1 } },
+    { op: 'HALT' },
+  ],
+};
+
+async function loadModules() {
+  const [{ VM }, { DummyHost }, proof] = await Promise.all([
+    import('../src/vm/index.js'),
+    import('../src/host/memory.js'),
+    import('../src/proof/index.js'),
+  ]);
+  return { VM, DummyHost, flush: proof.flush, reset: proof.resetDevProofsForTest };
+}
 
 describe('proof dev mode', () => {
-  const prog: Program = {
-    version: '0.1',
-    regs: 2,
-    instrs: [
-      { op: 'CONST', dst: 0, value: {} },
-      { op: 'LENS_PROJ', dst: 1, state: 0, region: 'r' },
-      { op: 'CONST', dst: 0, value: { x: 1 } },
-      { op: 'HALT' },
-    ],
-  };
+  beforeEach(() => {
+    vi.resetModules();
+  });
 
   afterEach(() => {
     delete process.env.DEV_PROOFS;
-    resetDevProofsForTest();
+    vi.resetModules();
   });
 
   it('emits tags when DEV_PROOFS=1', async () => {
     process.env.DEV_PROOFS = '1';
+    const { VM, DummyHost, flush, reset } = await loadModules();
     const vm = new VM(DummyHost);
     await vm.run(prog);
     const tags = flush();
     expect(tags.some(t => t.kind === 'Transport')).toBe(true);
     expect(tags.some(t => t.kind === 'Witness')).toBe(true);
+    reset();
   });
 
   it('no tags when DEV_PROOFS is unset', async () => {
+    const { VM, DummyHost, flush } = await loadModules();
     const vm = new VM(DummyHost);
     await vm.run(prog);
     const tags = flush();
     expect(tags.length).toBe(0);
   });
 
-  it('caches env value until reset', async () => {
+  it('reset clears cached log state', async () => {
     process.env.DEV_PROOFS = '1';
-    const vm = new VM(DummyHost);
+    const modules = await loadModules();
+    const vm = new modules.VM(modules.DummyHost);
     await vm.run(prog);
-    expect(flush().length).toBeGreaterThan(0);
+    expect(modules.flush().length).toBeGreaterThan(0);
 
-    delete process.env.DEV_PROOFS;
-    await vm.run(prog);
-    expect(flush().length).toBeGreaterThan(0); // cached
-
-    resetDevProofsForTest();
-    await vm.run(prog);
-    expect(flush().length).toBe(0);
+    modules.reset();
+    expect(modules.flush().length).toBe(0);
   });
 });

--- a/packages/tf-lang-l0-ts/tests/proof-vector.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-vector.test.ts
@@ -1,27 +1,42 @@
-import { it, expect, afterEach } from 'vitest';
+import { it, expect, afterEach, beforeEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { VM } from '../src/vm/index.js';
-import { DummyHost } from '../src/host/memory.js';
-import { flush, resetDevProofsForTest } from '../src/proof/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const vec = JSON.parse(fs.readFileSync(path.join(__dirname, '../../..', 'tests', 'proof_tags.json'), 'utf8'));
 
+async function loadModules() {
+  const [{ VM }, { DummyHost }, proof] = await Promise.all([
+    import('../src/vm/index.js'),
+    import('../src/host/memory.js'),
+    import('../src/proof/index.js'),
+  ]);
+  return { VM, DummyHost, flush: proof.flush, reset: proof.resetDevProofsForTest };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
 afterEach(() => {
   delete process.env.DEV_PROOFS;
-  resetDevProofsForTest();
+  vi.resetModules();
 });
 
 it('TS emits expected tags when enabled and none when disabled', async () => {
   process.env.DEV_PROOFS = '1';
-  const vm = new VM(DummyHost);
+  let modules = await loadModules();
+  let vm = new modules.VM(modules.DummyHost);
   await vm.run(vec.bytecode);
-  expect(flush()).toEqual(vec.expected_tags);
+  expect(modules.flush()).toEqual(vec.expected_tags);
 
-  resetDevProofsForTest();
+  modules.reset();
   delete process.env.DEV_PROOFS;
+  vi.resetModules();
+
+  modules = await loadModules();
+  vm = new modules.VM(modules.DummyHost);
   await vm.run(vec.bytecode);
-  expect(flush()).toEqual([]);
+  expect(modules.flush()).toEqual([]);
 });


### PR DESCRIPTION
Added stdout trace hooks, a programmable trace CLI, and perf harnesses for both runtimes.

TS Runtime – split the proof module into flag/log/emit helpers so dev gating happens once (packages/tf-lang-l0-ts/src/proof/index.ts:1, flag.ts:1, log.ts:1, emit.ts:1), updated the VM to wrap every tag emission in if (DEV_PROOFS) with structured metadata (packages/tf-lang-l0-ts/src/vm/interpreter.ts:1), and introduced a lightweight smoke producer plus a bench workload for perf and CLI smoke runs (packages/tf-lang-l0-ts/src/smoke-trace.ts:1, src/bench/workload.ts:1).

Rust Runtime – added ProofMeta/emit_tag for dev builds (packages/tf-lang-l0-rs/src/proof.rs:64), exported an emit_tag! macro so hot paths don't compile when the feature is off (packages/tf-lang-l0-rs/src/proof_macro.rs:1, src/vm/interpreter.rs:1), created trace/perf examples (packages/tf-lang-l0-rs/examples/trace-smoke.rs:1, examples/measure-dev-proofs.rs:1), wired a dev_proofs feature in Cargo (packages/tf-lang-l0-rs/Cargo.toml:17), and limited proof-only tests to that feature (packages/tf-lang-l0-rs/tests/proof_dev.rs:1, tests/proof_vector.rs:1).

tf-check trace CLI – extended the CLI with a trace subcommand and dedicated parser (packages/tf-check/src/cli.ts:12), implemented streaming/filters/sinks (packages/tf-check/src/commands/trace.ts:1, src/filters.ts:1, src/sink/jsonl.ts:1), and added a unit test for filter behavior (packages/tf-check/tests/trace.test.ts:1). Default tracing now uses the built smoke script; users can override --cmd/--cwd/filters as needed.

Perf harness & scripts – added a JS driver that records mean/stdev and writes JSONL artifacts for TS runs (packages/tf-lang-l0-ts/scripts/measure-dev-proofs.js:1) plus the analogous Rust example writer (packages/tf-lang-l0-rs/examples/measure-dev-proofs.rs:1), and exposed CLI-friendly scripts (packages/tf-lang-l0-ts/package.json:15).

CI Workflow – created t3-trace-and-perf.yml that builds once, runs the trace smoke via the new CLI, validates JSON, runs both perf harnesses (DEV_PROOFS on/off for TS and Rust), enforces ≤1 % overhead, and uploads the artifacts (.github/workflows/t3-trace-and-perf.yml:1).

Tests: pnpm --filter tf-lang-l0 run test, pnpm --filter @tf-lang/tf-check run test, cargo test.