### PR TITLE
feat: add tf-plan core and scoring packages

### DIFF
--- a/packages/tf-plan-core/package.json
+++ b/packages/tf-plan-core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tf-lang/tf-plan-core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@types/json-schema": "^7.0.15"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.1",
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-core/src/helpers.ts
+++ b/packages/tf-plan-core/src/helpers.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+
+export interface StableIdInput {
+  readonly scope?: string;
+  readonly specId: string;
+  readonly component: string;
+  readonly choice: string;
+  readonly seed?: number | string;
+  readonly version?: string;
+  readonly extra?: readonly (string | number)[];
+}
+
+export interface StableIdOptions {
+  readonly length?: number;
+}
+
+const DEFAULT_STABLE_SCOPE = "plan";
+const DEFAULT_VERSION = "1.0.0";
+
+export function stableId(input: StableIdInput, options: StableIdOptions = {}): string {
+  const scope = input.scope ?? DEFAULT_STABLE_SCOPE;
+  const seedValue = normalizeSeed(input.seed ?? 0);
+  const version = input.version ?? DEFAULT_VERSION;
+  const payload = [scope, `${input.specId}|${input.component}|${input.choice}|${seedValue}|${version}`];
+  if (input.extra && input.extra.length > 0) {
+    payload.push(...input.extra.map((value) => String(value)));
+  }
+  const hash = createHash("sha256");
+  hash.update(payload.join(":"));
+  const digest = hash.digest("hex");
+  if (options.length && options.length > 0) {
+    return digest.slice(0, options.length);
+  }
+  return digest;
+}
+
+export type DeepReadonly<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends Array<infer U>
+  ? ReadonlyArray<DeepReadonly<U>>
+  : T extends object
+  ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+  : T;
+
+export function deepFreeze<T>(value: T): DeepReadonly<T> {
+  if (typeof value !== "object" || value === null) {
+    return value as DeepReadonly<T>;
+  }
+  const object = value as Record<PropertyKey, unknown>;
+  for (const key of Reflect.ownKeys(object)) {
+    const nested = object[key as keyof typeof object];
+    if (typeof nested === "object" && nested !== null) {
+      deepFreeze(nested);
+    }
+  }
+  return Object.freeze(value) as DeepReadonly<T>;
+}
+
+export function stableSort<T>(values: readonly T[], compare: (left: T, right: T) => number): T[] {
+  return values
+    .map((value, index) => ({ value, index }))
+    .sort((left, right) => {
+      const order = compare(left.value, right.value);
+      if (order !== 0) {
+        return order;
+      }
+      return left.index - right.index;
+    })
+    .map((entry) => entry.value);
+}
+
+export type Rng = () => number;
+
+const UINT32_MAX = 0xffffffff;
+
+function normalizeSeed(seed: number | string): number {
+  if (typeof seed === "number" && Number.isFinite(seed)) {
+    return seed >>> 0;
+  }
+  const hash = createHash("sha256");
+  hash.update(String(seed));
+  const buffer = hash.digest();
+  return buffer.readUInt32BE(0);
+}
+
+export function seedRng(seed: number | string): Rng {
+  let state = normalizeSeed(seed) || 1;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / (UINT32_MAX + 1);
+  };
+}
+
+export function seededShuffle<T>(values: readonly T[], rng: Rng): T[] {
+  const result = [...values];
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const temp = result[i];
+    result[i] = result[j];
+    result[j] = temp;
+  }
+  return result;
+}

--- a/packages/tf-plan-core/src/index.ts
+++ b/packages/tf-plan-core/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./helpers.js";
+
+export { planGraphSchema, planNodeSchema, planCompareSchema } from "./schema.js";

--- a/packages/tf-plan-core/src/schema.ts
+++ b/packages/tf-plan-core/src/schema.ts
@@ -1,0 +1,175 @@
+import type { JSONSchema7 } from "json-schema";
+
+const idPattern = "^[0-9a-f]{12,64}$";
+
+const scoreBreakdownSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["metric", "value", "rationale"],
+  properties: {
+    metric: { type: "string", minLength: 1 },
+    value: { type: "number" },
+    weight: { type: "number" },
+    rationale: { type: "string", minLength: 1 }
+  }
+};
+
+const scoreSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["total", "complexity", "risk", "perf", "devTime", "depsReady", "explain"],
+  properties: {
+    total: { type: "number" },
+    complexity: { type: "number" },
+    risk: { type: "number" },
+    perf: { type: "number" },
+    devTime: { type: "number" },
+    depsReady: { type: "number" },
+    explain: {
+      type: "array",
+      items: scoreBreakdownSchema,
+      minItems: 0
+    }
+  }
+};
+
+export const planNodeSchema: JSONSchema7 = {
+  $id: "https://tf-lang.dev/schema/tf-branch.schema.json",
+  type: "object",
+  additionalProperties: false,
+  required: ["nodeId", "specId", "component", "choice", "deps", "rationale", "score"],
+  properties: {
+    nodeId: { type: "string", pattern: idPattern },
+    specId: { type: "string", minLength: 1 },
+    component: { type: "string", minLength: 1 },
+    choice: { type: "string", minLength: 1 },
+    deps: {
+      type: "array",
+      items: { type: "string", pattern: idPattern },
+      uniqueItems: true
+    },
+    rationale: { type: "string", minLength: 1 },
+    score: scoreSchema
+  }
+};
+
+const planEdgeSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["from", "to", "kind"],
+  properties: {
+    from: { type: "string", pattern: idPattern },
+    to: { type: "string", pattern: idPattern },
+    kind: { enum: ["dependency", "conflict", "composes"] }
+  }
+};
+
+const planMetaSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["seed", "specHash", "version", "generatedAt"],
+  properties: {
+    seed: { type: "integer" },
+    specHash: { type: "string", pattern: "^[0-9a-f]{64}$" },
+    version: { type: "string", minLength: 1 },
+    generatedAt: { type: "string", format: "date-time" }
+  }
+};
+
+export const planGraphSchema: JSONSchema7 = {
+  $id: "https://tf-lang.dev/schema/tf-plan.schema.json",
+  type: "object",
+  additionalProperties: false,
+  required: ["nodes", "edges", "meta"],
+  properties: {
+    nodes: {
+      type: "array",
+      items: planNodeSchema,
+      minItems: 1
+    },
+    edges: {
+      type: "array",
+      items: planEdgeSchema,
+      minItems: 0
+    },
+    meta: planMetaSchema
+  }
+};
+
+const compareScoreSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["score", "weight", "label", "explain"],
+  properties: {
+    label: { type: "string", minLength: 1 },
+    score: { type: "number" },
+    weight: { type: "number" },
+    explain: { type: "string", minLength: 1 }
+  }
+};
+
+const artifactRefSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["label", "path"],
+  properties: {
+    label: { type: "string", minLength: 1 },
+    path: { type: "string", minLength: 1 },
+    type: { enum: ["json", "html", "log", "other"] }
+  }
+};
+
+export const planCompareSchema: JSONSchema7 = {
+  $id: "https://tf-lang.dev/schema/tf-compare.schema.json",
+  type: "object",
+  additionalProperties: false,
+  required: ["meta", "branches", "recommended"],
+  properties: {
+    meta: {
+      type: "object",
+      additionalProperties: false,
+      required: ["seed", "generatedAt", "version"],
+      properties: {
+        seed: { type: "integer" },
+        generatedAt: { type: "string", format: "date-time" },
+        version: { type: "string", minLength: 1 },
+        inputs: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            plan: { type: "string", minLength: 1 },
+            scaffold: { type: "string", minLength: 1 },
+            oracles: {
+              type: "array",
+              items: { type: "string", minLength: 1 }
+            }
+          }
+        }
+      }
+    },
+    branches: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["nodeId", "rank", "score", "scores", "summary"],
+        properties: {
+          nodeId: { type: "string", pattern: idPattern },
+          rank: { type: "integer", minimum: 1 },
+          score: { type: "number" },
+          scores: {
+            type: "array",
+            items: compareScoreSchema
+          },
+          summary: { type: "string", minLength: 1 },
+          artifacts: {
+            type: "array",
+            items: artifactRefSchema
+          }
+        }
+      }
+    },
+    recommended: { type: "string", pattern: idPattern }
+  }
+};

--- a/packages/tf-plan-core/src/types.ts
+++ b/packages/tf-plan-core/src/types.ts
@@ -1,0 +1,54 @@
+export interface ScoreBreakdown {
+  readonly metric: string;
+  readonly value: number;
+  readonly weight?: number;
+  readonly rationale: string;
+}
+
+export interface Score {
+  readonly total: number;
+  readonly complexity: number;
+  readonly risk: number;
+  readonly perf: number;
+  readonly devTime: number;
+  readonly depsReady: number;
+  readonly explain: readonly ScoreBreakdown[];
+}
+
+export interface PlanNode {
+  readonly nodeId: string;
+  readonly specId: string;
+  readonly component: string;
+  readonly choice: string;
+  readonly deps: readonly string[];
+  readonly rationale: string;
+  readonly score: Score;
+}
+
+export type PlanEdgeKind = "dependency" | "conflict" | "composes";
+
+export interface PlanEdge {
+  readonly from: string;
+  readonly to: string;
+  readonly kind: PlanEdgeKind;
+}
+
+export interface PlanMeta {
+  readonly seed: number;
+  readonly specHash: string;
+  readonly version: string;
+  readonly generatedAt: string;
+}
+
+export interface PlanGraph {
+  readonly nodes: readonly PlanNode[];
+  readonly edges: readonly PlanEdge[];
+  readonly meta: PlanMeta;
+}
+
+export interface BranchSummary {
+  readonly node: PlanNode;
+  readonly position: number;
+}
+
+export const PLAN_SCHEMA_VERSION = "1.0.0" as const;

--- a/packages/tf-plan-core/tests/helpers.test.ts
+++ b/packages/tf-plan-core/tests/helpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deepFreeze,
+  seedRng,
+  seededShuffle,
+  stableId,
+  stableSort
+} from "../src/index.js";
+
+describe("stableId", () => {
+  it("produces deterministic identifiers", () => {
+    const first = stableId({
+      specId: "spec",
+      component: "frontend",
+      choice: "react",
+      seed: 42
+    });
+    const second = stableId({
+      specId: "spec",
+      component: "frontend",
+      choice: "react",
+      seed: 42
+    });
+    expect(second).toBe(first);
+  });
+
+  it("varies when any field changes", () => {
+    const base = stableId({ specId: "spec", component: "a", choice: "x", seed: 42 });
+    const diff = stableId({ specId: "spec", component: "b", choice: "x", seed: 42 });
+    expect(diff).not.toBe(base);
+  });
+});
+
+describe("seedRng", () => {
+  it("returns reproducible random numbers", () => {
+    const rngA = seedRng(123);
+    const rngB = seedRng(123);
+    const sequenceA = Array.from({ length: 5 }, () => rngA());
+    const sequenceB = Array.from({ length: 5 }, () => rngB());
+    expect(sequenceB).toEqual(sequenceA);
+  });
+});
+
+describe("seededShuffle", () => {
+  it("shuffles arrays in a deterministic manner", () => {
+    const values = ["a", "b", "c", "d"];
+    const rng = seedRng(5);
+    const shuffled = seededShuffle(values, rng);
+    expect(shuffled).toEqual(["b", "a", "d", "c"]);
+    // original remains untouched
+    expect(values).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("deepFreeze", () => {
+  it("freezes nested objects", () => {
+    const nested = deepFreeze({ a: { b: 1 } });
+    expect(Object.isFrozen(nested)).toBe(true);
+    expect(Object.isFrozen(nested.a)).toBe(true);
+  });
+});
+
+describe("stableSort", () => {
+  it("keeps equal items in original order", () => {
+    const input = [
+      { key: 1, order: "first" },
+      { key: 1, order: "second" },
+      { key: 0, order: "third" }
+    ];
+    const sorted = stableSort(input, (left, right) => left.key - right.key);
+    expect(sorted.map((item) => item.order)).toEqual(["third", "first", "second"]);
+  });
+});

--- a/packages/tf-plan-core/tsconfig.json
+++ b/packages/tf-plan-core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "esModuleInterop": false
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-scoring/package.json
+++ b/packages/tf-plan-scoring/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tf-lang/tf-plan-scoring",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "pretest": "pnpm --filter @tf-lang/tf-plan-core build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "workspace:^0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.1",
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-scoring/src/index.ts
+++ b/packages/tf-plan-scoring/src/index.ts
@@ -1,0 +1,3 @@
+export { complexity, risk, perf, devTime, depsReady, metricWeight } from "./metrics.js";
+export type { ChoiceMetadata, RepoSignals, ScoreContext, ScoreResult, MetricResult, MetricName } from "./types.js";
+export { scorePlanNode } from "./score-plan-node.js";

--- a/packages/tf-plan-scoring/src/metrics.ts
+++ b/packages/tf-plan-scoring/src/metrics.ts
@@ -1,0 +1,242 @@
+import type { MetricResult, MetricName, ScoreContext } from "./types.js";
+
+const METRIC_WEIGHTS: Record<MetricName, number> = {
+  complexity: 0.2,
+  risk: 0.25,
+  perf: 0.2,
+  devTime: 0.2,
+  depsReady: 0.15
+};
+
+export function metricWeight(metric: MetricName): number {
+  return METRIC_WEIGHTS[metric];
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(" ")
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function gatherKeywords(context: ScoreContext): Set<string> {
+  const keywords = new Set<string>();
+  for (const part of [context.component, context.choice]) {
+    tokenize(part).forEach((token) => keywords.add(token));
+  }
+  const metaKeywords = context.metadata?.keywords ?? [];
+  metaKeywords.forEach((token) => keywords.add(token.toLowerCase()));
+  return keywords;
+}
+
+function hasKeyword(keywords: Set<string>, targets: readonly string[]): boolean {
+  for (const target of targets) {
+    if (keywords.has(target)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function keywordCount(keywords: Set<string>, targets: readonly string[]): number {
+  let count = 0;
+  for (const target of targets) {
+    if (keywords.has(target)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function complexity(context: ScoreContext): MetricResult {
+  const keywords = gatherKeywords(context);
+  const baseLoad = clamp01(context.metadata?.effort ?? Math.max(0, keywords.size - 2) / 6);
+  const adjustments: string[] = [];
+  let load = baseLoad;
+
+  if (context.metadata?.maturity !== undefined) {
+    const maturity = clamp01(context.metadata.maturity);
+    const delta = maturity * 0.2;
+    load = clamp01(load - delta);
+    adjustments.push(`maturity ${maturity.toFixed(2)} reduces load by ${delta.toFixed(2)}`);
+  }
+
+  if (hasKeyword(keywords, ["simple", "basic", "starter"])) {
+    load = clamp01(load - 0.15);
+    adjustments.push("keyword simple/basic/starter implies lower complexity");
+  }
+
+  const heavyKeywords = keywordCount(keywords, ["distributed", "cluster", "microservices", "orchestration", "rewrite"]);
+  if (heavyKeywords > 0) {
+    const delta = Math.min(0.3, heavyKeywords * 0.12);
+    load = clamp01(load + delta);
+    adjustments.push(`architectural keywords add ${delta.toFixed(2)} to complexity load`);
+  }
+
+  const value = clamp01(1 - load);
+  const rationale = [`baseline load ${baseLoad.toFixed(2)}`, ...adjustments].join("; ");
+  return {
+    metric: "complexity",
+    value,
+    weight: metricWeight("complexity"),
+    rationale
+  };
+}
+
+export function risk(context: ScoreContext): MetricResult {
+  const keywords = gatherKeywords(context);
+  const baseRisk = clamp01(context.metadata?.risk ?? 0.4);
+  const adjustments: string[] = [];
+  let riskScore = baseRisk;
+
+  if (hasKeyword(keywords, ["experimental", "beta", "preview"])) {
+    riskScore = clamp01(riskScore + 0.25);
+    adjustments.push("keyword experimental/beta/preview increases risk");
+  }
+
+  if (hasKeyword(keywords, ["legacy", "rewrite", "migration"])) {
+    riskScore = clamp01(riskScore + 0.2);
+    adjustments.push("keyword legacy/rewrite/migration increases risk");
+  }
+
+  if (hasKeyword(keywords, ["safe", "battle", "proven", "stable"])) {
+    riskScore = clamp01(riskScore - 0.15);
+    adjustments.push("keyword safe/battle/proven/stable lowers risk");
+  }
+
+  const incidents = context.repoSignals?.incidentHistory ?? [];
+  const relevant = incidents.filter((incident) => incident.component === context.component);
+  if (relevant.length > 0) {
+    const incidentPenalty = clamp01(
+      Math.min(0.3, relevant.reduce((sum, entry) => sum + clamp01(entry.severity) * 0.1, 0))
+    );
+    riskScore = clamp01(riskScore + incidentPenalty);
+    adjustments.push(`recent incidents add ${incidentPenalty.toFixed(2)} risk`);
+  }
+
+  const adoptionTrend = context.repoSignals?.adoptionTrend?.[context.choice];
+  if (typeof adoptionTrend === "number" && !Number.isNaN(adoptionTrend)) {
+    const delta = -0.1 * adoptionTrend;
+    riskScore = clamp01(riskScore + delta);
+    adjustments.push(`adoption trend ${adoptionTrend.toFixed(2)} adjusts risk by ${delta.toFixed(2)}`);
+  }
+
+  const value = clamp01(1 - riskScore);
+  const rationale = [`baseline risk ${baseRisk.toFixed(2)}`, ...adjustments].join("; ");
+  return {
+    metric: "risk",
+    value,
+    weight: metricWeight("risk"),
+    rationale
+  };
+}
+
+export function perf(context: ScoreContext): MetricResult {
+  const keywords = gatherKeywords(context);
+  const basePerf = clamp01(context.metadata?.performance ?? 0.55);
+  const adjustments: string[] = [];
+  let perfScore = basePerf;
+
+  if (hasKeyword(keywords, ["fast", "vector", "async", "batch", "parallel"])) {
+    perfScore = clamp01(perfScore + 0.2);
+    adjustments.push("keywords fast/vector/async/batch/parallel boost perf");
+  }
+
+  if (hasKeyword(keywords, ["cache", "optimize", "accelerated"])) {
+    perfScore = clamp01(perfScore + 0.15);
+    adjustments.push("keywords cache/optimize/accelerated boost perf");
+  }
+
+  if (hasKeyword(keywords, ["basic", "simple", "prototype", "mock"])) {
+    perfScore = clamp01(perfScore - 0.1);
+    adjustments.push("keywords basic/simple/prototype/mock reduce perf expectations");
+  }
+
+  const value = clamp01(perfScore);
+  const rationale = [`baseline perf ${basePerf.toFixed(2)}`, ...adjustments].join("; ");
+  return {
+    metric: "perf",
+    value,
+    weight: metricWeight("perf"),
+    rationale
+  };
+}
+
+export function devTime(context: ScoreContext): MetricResult {
+  const keywords = gatherKeywords(context);
+  const velocity = clamp01(context.repoSignals?.componentVelocity?.[context.component] ?? 0.5);
+  const baseTime = clamp01(context.metadata?.timeToDeliver ?? (1 - velocity));
+  const adjustments: string[] = [];
+  let deliveryTime = baseTime;
+
+  if (hasKeyword(keywords, ["quick", "rapid", "starter", "template"])) {
+    deliveryTime = clamp01(deliveryTime - 0.2);
+    adjustments.push("keywords quick/rapid/starter/template reduce delivery time");
+  }
+
+  if (hasKeyword(keywords, ["rewrite", "migration", "greenfield"])) {
+    deliveryTime = clamp01(deliveryTime + 0.25);
+    adjustments.push("keywords rewrite/migration/greenfield increase delivery time");
+  }
+
+  if (context.metadata?.effort !== undefined) {
+    const delta = clamp01(context.metadata.effort) * 0.3;
+    deliveryTime = clamp01(deliveryTime + delta);
+    adjustments.push(`effort signal adds ${delta.toFixed(2)} delivery time`);
+  }
+
+  const value = clamp01(1 - deliveryTime);
+  const rationale = [`baseline delivery time ${baseTime.toFixed(2)}`, ...adjustments].join("; ");
+  return {
+    metric: "devTime",
+    value,
+    weight: metricWeight("devTime"),
+    rationale
+  };
+}
+
+export function depsReady(context: ScoreContext): MetricResult {
+  const dependencies = context.metadata?.dependencies ?? [];
+  const signals = context.repoSignals?.dependencyHealth ?? {};
+  const base = dependencies.length === 0 ? 0.75 : 0.5;
+  let readiness = base;
+  const adjustments: string[] = [];
+
+  if (dependencies.length > 0) {
+    const scores = dependencies.map((dep) => clamp01(signals[dep] ?? 0.5));
+    const avg = scores.reduce((sum, value) => sum + value, 0) / scores.length;
+    readiness = clamp01((readiness + avg) / 2);
+    adjustments.push(`dependency readiness average ${avg.toFixed(2)}`);
+  }
+
+  const adoptionTrend = context.repoSignals?.adoptionTrend?.[context.choice];
+  if (typeof adoptionTrend === "number") {
+    const delta = adoptionTrend * 0.1;
+    readiness = clamp01(readiness + delta);
+    adjustments.push(`adoption trend ${adoptionTrend.toFixed(2)} shifts readiness by ${delta.toFixed(2)}`);
+  }
+
+  if (context.metadata?.maturity !== undefined) {
+    const delta = clamp01(context.metadata.maturity) * 0.1;
+    readiness = clamp01(readiness + delta);
+    adjustments.push(`maturity contributes ${delta.toFixed(2)} readiness`);
+  }
+
+  const value = clamp01(readiness);
+  const rationale = [`baseline readiness ${base.toFixed(2)}`, ...adjustments].join("; ");
+  return {
+    metric: "depsReady",
+    value,
+    weight: metricWeight("depsReady"),
+    rationale
+  };
+}

--- a/packages/tf-plan-scoring/src/score-plan-node.ts
+++ b/packages/tf-plan-scoring/src/score-plan-node.ts
@@ -1,0 +1,46 @@
+import type { Score } from "@tf-lang/tf-plan-core";
+import { stableSort } from "@tf-lang/tf-plan-core";
+
+import { complexity, depsReady, devTime, metricWeight, perf, risk } from "./metrics.js";
+import type { MetricResult, ScoreContext, ScoreResult } from "./types.js";
+
+const SCALE = 100;
+
+function round(value: number, decimals = 2): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function scorePlanNode(context: ScoreContext): ScoreResult {
+  const metrics: MetricResult[] = [
+    complexity(context),
+    risk(context),
+    perf(context),
+    devTime(context),
+    depsReady(context)
+  ];
+
+  const weightedSum = metrics.reduce((total, metric) => total + metric.value * metric.weight, 0);
+  const totalScore = round(weightedSum * SCALE, 2);
+
+  const explain = stableSort(metrics, (left, right) => left.metric.localeCompare(right.metric)).map((metric) => ({
+    metric: metric.metric,
+    value: round(metric.value * SCALE, 2),
+    weight: metric.weight,
+    rationale: metric.rationale
+  }));
+
+  const score: Score = {
+    total: totalScore,
+    complexity: round(metrics.find((metric) => metric.metric === "complexity")!.value * SCALE, 2),
+    risk: round(metrics.find((metric) => metric.metric === "risk")!.value * SCALE, 2),
+    perf: round(metrics.find((metric) => metric.metric === "perf")!.value * SCALE, 2),
+    devTime: round(metrics.find((metric) => metric.metric === "devTime")!.value * SCALE, 2),
+    depsReady: round(metrics.find((metric) => metric.metric === "depsReady")!.value * SCALE, 2),
+    explain
+  };
+
+  return { score, metrics };
+}
+
+export { metricWeight } from "./metrics.js";

--- a/packages/tf-plan-scoring/src/types.ts
+++ b/packages/tf-plan-scoring/src/types.ts
@@ -1,0 +1,39 @@
+import type { Score } from "@tf-lang/tf-plan-core";
+
+export type MetricName = "complexity" | "risk" | "perf" | "devTime" | "depsReady";
+
+export interface ChoiceMetadata {
+  readonly keywords?: readonly string[];
+  readonly maturity?: number; // 0 (immature) .. 1 (battle tested)
+  readonly effort?: number; // 0 (trivial) .. 1 (very complex)
+  readonly performance?: number; // 0 (slow) .. 1 (fast)
+  readonly risk?: number; // 0 (safe) .. 1 (risky)
+  readonly timeToDeliver?: number; // 0 (immediate) .. 1 (long)
+  readonly dependencies?: readonly string[];
+}
+
+export interface RepoSignals {
+  readonly dependencyHealth?: Record<string, number>; // nodeId/dep -> 0..1 readiness
+  readonly componentVelocity?: Record<string, number>; // component -> 0..1 (higher faster delivery)
+  readonly incidentHistory?: readonly { component: string; severity: number }[];
+  readonly adoptionTrend?: Record<string, number>; // choice -> -1..1 sentiment
+}
+
+export interface ScoreContext {
+  readonly component: string;
+  readonly choice: string;
+  readonly metadata?: ChoiceMetadata;
+  readonly repoSignals?: RepoSignals;
+}
+
+export interface MetricResult {
+  readonly metric: MetricName;
+  readonly value: number;
+  readonly weight: number;
+  readonly rationale: string;
+}
+
+export interface ScoreResult {
+  readonly score: Score;
+  readonly metrics: readonly MetricResult[];
+}

--- a/packages/tf-plan-scoring/tests/score.test.ts
+++ b/packages/tf-plan-scoring/tests/score.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { scorePlanNode } from "../src/score-plan-node.js";
+
+const context = {
+  component: "frontend",
+  choice: "react-fast-refresh",
+  metadata: {
+    keywords: ["fast", "refresh"],
+    maturity: 0.8,
+    effort: 0.3,
+    performance: 0.7,
+    timeToDeliver: 0.4,
+    dependencies: ["design-system"],
+    risk: 0.35
+  },
+  repoSignals: {
+    dependencyHealth: {
+      "design-system": 0.9
+    },
+    componentVelocity: {
+      frontend: 0.6
+    },
+    incidentHistory: [
+      { component: "backend", severity: 0.4 }
+    ],
+    adoptionTrend: {
+      "react-fast-refresh": 0.5
+    }
+  }
+} as const;
+
+describe("scorePlanNode", () => {
+  it("produces a score with explain breakdown", () => {
+    const result = scorePlanNode(context);
+    expect(result.score.total).toBeGreaterThan(0);
+    expect(result.score.explain).toHaveLength(5);
+    expect(result.score.explain[0].metric <= result.score.explain[4].metric).toBe(true);
+    expect(result.metrics[0].rationale.length).toBeGreaterThan(0);
+  });
+
+  it("is deterministic for the same input", () => {
+    const first = scorePlanNode(context);
+    const second = scorePlanNode(context);
+    expect(second.score).toEqual(first.score);
+  });
+
+  it("penalizes high-risk scenarios", () => {
+    const risky = scorePlanNode({
+      component: "frontend",
+      choice: "experimental-rewrite",
+      repoSignals: {
+        incidentHistory: [{ component: "frontend", severity: 0.9 }]
+      }
+    });
+    const safe = scorePlanNode({ component: "frontend", choice: "stable-release" });
+    expect(risky.score.risk).toBeLessThan(safe.score.risk);
+  });
+});

--- a/packages/tf-plan-scoring/tsconfig.json
+++ b/packages/tf-plan-scoring/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "esModuleInterop": false
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,38 @@ importers:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
 
+  packages/tf-plan-core:
+    dependencies:
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.1
+        version: 24.3.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
+
+  packages/tf-plan-scoring:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: workspace:^0.1.0
+        version: link:../tf-plan-core
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.1
+        version: 24.3.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
+
   packages/utils:
     devDependencies:
       '@types/node':
@@ -618,6 +650,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@20.19.17':
     resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
@@ -1646,6 +1681,8 @@ snapshots:
   '@sinclair/typebox@0.27.8': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@20.19.17':
     dependencies:

--- a/schema/tf-branch.schema.json
+++ b/schema/tf-branch.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tf-lang.dev/schema/tf-branch.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["nodeId", "specId", "component", "choice", "deps", "rationale", "score"],
+  "properties": {
+    "nodeId": { "type": "string", "pattern": "^[0-9a-f]{12,64}$" },
+    "specId": { "type": "string", "minLength": 1 },
+    "component": { "type": "string", "minLength": 1 },
+    "choice": { "type": "string", "minLength": 1 },
+    "deps": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[0-9a-f]{12,64}$" }
+    },
+    "rationale": { "type": "string", "minLength": 1 },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "complexity", "risk", "perf", "devTime", "depsReady", "explain"],
+      "properties": {
+        "total": { "type": "number" },
+        "complexity": { "type": "number" },
+        "risk": { "type": "number" },
+        "perf": { "type": "number" },
+        "devTime": { "type": "number" },
+        "depsReady": { "type": "number" },
+        "explain": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["metric", "value", "rationale"],
+            "properties": {
+              "metric": { "type": "string", "minLength": 1 },
+              "value": { "type": "number" },
+              "weight": { "type": "number" },
+              "rationale": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/tf-compare.schema.json
+++ b/schema/tf-compare.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tf-lang.dev/schema/tf-compare.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["meta", "branches", "recommended"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["seed", "generatedAt", "version"],
+      "properties": {
+        "seed": { "type": "integer" },
+        "generatedAt": { "type": "string", "format": "date-time" },
+        "version": { "type": "string", "minLength": 1 },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "plan": { "type": "string", "minLength": 1 },
+            "scaffold": { "type": "string", "minLength": 1 },
+            "oracles": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "branches": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["nodeId", "rank", "score", "scores", "summary"],
+        "properties": {
+          "nodeId": { "type": "string", "pattern": "^[0-9a-f]{12,64}$" },
+          "rank": { "type": "integer", "minimum": 1 },
+          "score": { "type": "number" },
+          "scores": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["score", "weight", "label", "explain"],
+              "properties": {
+                "label": { "type": "string", "minLength": 1 },
+                "score": { "type": "number" },
+                "weight": { "type": "number" },
+                "explain": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "summary": { "type": "string", "minLength": 1 },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["label", "path"],
+              "properties": {
+                "label": { "type": "string", "minLength": 1 },
+                "path": { "type": "string", "minLength": 1 },
+                "type": { "enum": ["json", "html", "log", "other"] }
+              }
+            }
+          }
+        }
+      }
+    },
+    "recommended": { "type": "string", "pattern": "^[0-9a-f]{12,64}$" }
+  }
+}

--- a/schema/tf-plan.schema.json
+++ b/schema/tf-plan.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tf-lang.dev/schema/tf-plan.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["nodes", "edges", "meta"],
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "./tf-branch.schema.json" }
+    },
+    "edges": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to", "kind"],
+        "properties": {
+          "from": { "type": "string", "pattern": "^[0-9a-f]{12,64}$" },
+          "to": { "type": "string", "pattern": "^[0-9a-f]{12,64}$" },
+          "kind": { "enum": ["dependency", "conflict", "composes"] }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["seed", "specHash", "version", "generatedAt"],
+      "properties": {
+        "seed": { "type": "integer" },
+        "specHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "version": { "type": "string", "minLength": 1 },
+        "generatedAt": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `@tf-lang/tf-plan-core` with shared plan/score types, helpers, and JSON schema exports
- add repository-level JSON schema files for plan graphs, branch nodes, and compare reports
- create `@tf-lang/tf-plan-scoring` with deterministic metric plugins and a composite scorer

## Evidence
- [ ] out/t4/plan/plan.json
- [ ] out/t4/plan/plan.ndjson
- [ ] out/t4/scaffold/index.json
- [ ] out/t4/compare/report.json
- [ ] out/t4/compare/report.md
- [ ] out/t4/compare/index.html

## Determinism & Seeds
- scoring metrics rely on deterministic keyword heuristics and repo signals; no runtime randomness
- core helper `stableId` derives ids from hashed spec/component/choice/seed tuples; `seedRng` controls future randomness

## Tests & CI
- `pnpm --filter @tf-lang/tf-plan-core test`
- `pnpm --filter @tf-lang/tf-plan-scoring test`

## Implementation Notes
- score totals are 0-100 weighted sums with individual metric explanations kept in sorted order
- JSON schemas align with TypeScript definitions and export through the core package for reuse

## Hurdles / Follow-ups
- enumerator, CLI layers, scaffolder, and compare workflows still need to be wired on top of the new core packages

------
https://chatgpt.com/codex/tasks/task_e_68cd3bbd69d48320b9b40df727d50c63