### PR TITLE
Finalize T4 CLI schema loading

### DIFF
--- a/.github/workflows/reusable-tf-check.yml
+++ b/.github/workflows/reusable-tf-check.yml
@@ -1,0 +1,31 @@
+name: reusable-tf-check
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+      upload:
+        required: false
+        type: boolean
+        default: false
+jobs:
+  tf-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.16.1
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run tf-check
+        run: pnpm tf-check run --mode=ci
+      - name: Upload artifacts
+        if: ${{ inputs.upload }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tf-check-report
+          path: out/t4/compare

--- a/.github/workflows/t4-plan-scaffold-compare.yml
+++ b/.github/workflows/t4-plan-scaffold-compare.yml
@@ -1,0 +1,75 @@
+name: T4 Plan Scaffold Compare
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.16.1
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Build packages
+        run: pnpm -r build
+      - name: Enumerate plan
+        run: pnpm exec tf-plan enumerate --spec tests/specs/demo.json --seed 42 --beam 3 --out out/t4/plan
+      - uses: actions/upload-artifact@v4
+        with:
+          name: t4-plan
+          path: out/t4/plan
+  scaffold:
+    runs-on: ubuntu-latest
+    needs: plan
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.16.1
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Build packages
+        run: pnpm -r build
+      - name: Download plan
+        uses: actions/download-artifact@v4
+        with:
+          name: t4-plan
+          path: out/t4/plan
+      - name: Scaffold dry-run
+        run: pnpm exec tf-plan-scaffold scaffold --plan out/t4/plan/plan.ndjson --graph out/t4/plan/plan.json --top 3 --template dual-stack --out out/t4/scaffold/index.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: t4-scaffold
+          path: out/t4/scaffold/index.json
+  compare:
+    runs-on: ubuntu-latest
+    needs: plan
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.16.1
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Build packages
+        run: pnpm -r build
+      - name: Download plan
+        uses: actions/download-artifact@v4
+        with:
+          name: t4-plan
+          path: out/t4/plan
+      - name: Download scaffold
+        uses: actions/download-artifact@v4
+        with:
+          name: t4-scaffold
+          path: out/t4/scaffold
+      - name: Compare branches
+        run: pnpm exec tf-plan-compare compare --plan out/t4/plan/plan.ndjson --inputs out/t4/scaffold/index.json --out out/t4/compare
+      - uses: actions/upload-artifact@v4
+        with:
+          name: t4-compare
+          path: out/t4/compare

--- a/docs/t4/plan.md
+++ b/docs/t4/plan.md
@@ -1,0 +1,16 @@
+# T4 Plan Explorer
+
+The T4 Plan Explorer enumerates design branches from a Terraform spec, scores them with deterministic heuristics, and provides tooling to scaffold comparison workstreams.
+
+## Quick start
+
+```bash
+pnpm -r build
+pnpm exec tf-plan enumerate --spec tests/specs/demo.json --seed 42 --beam 3 --out out/t4/plan
+pnpm exec tf-plan-scaffold scaffold --plan out/t4/plan/plan.ndjson --graph out/t4/plan/plan.json --top 3 --template dual-stack --out out/t4/scaffold/index.json
+pnpm exec tf-plan-compare compare --plan out/t4/plan/plan.ndjson --inputs out/t4/scaffold/index.json --out out/t4/compare
+```
+
+## Adding scoring plugins
+
+Extend `@tf-lang/tf-plan-scoring` with new dimension helpers and wire them into `scorePlanNode`. Each helper should return both a numeric score and a textual explanation to maintain deterministic rationales. Update tests to assert deterministic totals and regenerate any golden fixtures.

--- a/packages/tf-plan-compare-core/package.json
+++ b/packages/tf-plan-compare-core/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tf-lang/tf-plan-compare-core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "0.1.0",
+    "@tf-lang/tf-plan-scaffold-core": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-compare-core/src/index.ts
+++ b/packages/tf-plan-compare-core/src/index.ts
@@ -1,0 +1,144 @@
+import { PlanNode, stableSort } from '@tf-lang/tf-plan-core';
+import { ScaffoldBranch, ScaffoldPlan } from '@tf-lang/tf-plan-scaffold-core';
+
+export const COMPARE_VERSION = '0.1.0';
+
+export type OracleStatus = 'pass' | 'fail' | 'unknown';
+
+export interface OracleSummary {
+  readonly branchName: string;
+  readonly oracle: string;
+  readonly status: OracleStatus;
+  readonly details?: string;
+  readonly artifact?: string;
+}
+
+export interface CompareScore {
+  readonly total: number;
+  readonly risk: number;
+  readonly complexity: number;
+  readonly perf: number;
+  readonly devTime: number;
+  readonly depsReady: number;
+}
+
+export interface CompareBranch {
+  readonly nodeId: string;
+  readonly branchName: string;
+  readonly planChoice: string;
+  readonly rank: number;
+  readonly score: CompareScore;
+  readonly summary: string;
+  readonly oracles: readonly {
+    readonly name: string;
+    readonly status: OracleStatus;
+    readonly details?: string;
+    readonly artifact?: string;
+  }[];
+}
+
+export interface CompareReport {
+  readonly version: string;
+  readonly meta: {
+    readonly seed: number;
+    readonly planVersion: string;
+    readonly generatedAt: string;
+    readonly notes: readonly string[];
+  };
+  readonly branches: readonly CompareBranch[];
+}
+
+export interface CompareOptions {
+  readonly seed?: number;
+  readonly oracles?: readonly OracleSummary[];
+}
+
+function selectNode(nodes: readonly PlanNode[], branch: ScaffoldBranch): PlanNode | undefined {
+  return nodes.find((node) => node.nodeId === branch.nodeId);
+}
+
+function mapOracles(summaries: readonly OracleSummary[] | undefined, branchName: string): CompareBranch['oracles'] {
+  if (!summaries) {
+    return [];
+  }
+  return summaries
+    .filter((summary) => summary.branchName === branchName)
+    .map((summary) => ({
+      name: summary.oracle,
+      status: summary.status,
+      details: summary.details,
+      artifact: summary.artifact,
+    }));
+}
+
+function toCompareBranch(node: PlanNode, branch: ScaffoldBranch, rank: number, oracles: CompareBranch['oracles']): CompareBranch {
+  return {
+    nodeId: node.nodeId,
+    branchName: branch.branchName,
+    planChoice: node.choice,
+    rank,
+    score: {
+      total: node.score.total,
+      risk: node.score.risk,
+      complexity: node.score.complexity,
+      perf: node.score.perf,
+      devTime: node.score.devTime,
+      depsReady: node.score.depsReady,
+    },
+    summary: `${branch.branchName} ranks #${rank} with total ${node.score.total.toFixed(2)} (risk ${node.score.risk.toFixed(2)})`,
+    oracles,
+  };
+}
+
+export function buildCompareReport(
+  nodes: readonly PlanNode[],
+  scaffold: ScaffoldPlan,
+  options: CompareOptions = {},
+): CompareReport {
+  const seed = options.seed ?? scaffold.meta.seed ?? 42;
+  const candidates = scaffold.branches
+    .map((branch) => {
+      const node = selectNode(nodes, branch);
+      if (!node) {
+        return undefined;
+      }
+      return { branch, node };
+    })
+    .filter((entry): entry is { branch: ScaffoldBranch; node: PlanNode } => entry !== undefined);
+
+  if (candidates.length === 0) {
+    throw new Error('No matching branches found between scaffold plan and plan nodes.');
+  }
+
+  const ranked = stableSort(candidates, (left, right) => {
+    const totalDiff = right.node.score.total - left.node.score.total;
+    if (totalDiff !== 0) {
+      return totalDiff;
+    }
+    const riskDiff = left.node.score.risk - right.node.score.risk;
+    if (riskDiff !== 0) {
+      return riskDiff;
+    }
+    return left.node.nodeId.localeCompare(right.node.nodeId);
+  });
+
+  const branches = ranked.map((entry, index) =>
+    toCompareBranch(
+      entry.node,
+      entry.branch,
+      index + 1,
+      mapOracles(options.oracles, entry.branch.branchName),
+    ),
+  );
+
+  return {
+    version: COMPARE_VERSION,
+    meta: {
+      seed,
+      planVersion: scaffold.meta.version,
+      generatedAt: '1970-01-01T00:00:00.000Z',
+      notes: [`branches=${branches.length}`],
+    },
+    branches,
+  };
+}

--- a/packages/tf-plan-compare-core/tests/index.test.ts
+++ b/packages/tf-plan-compare-core/tests/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { PlanNode } from '@tf-lang/tf-plan-core';
+import { ScaffoldPlan } from '@tf-lang/tf-plan-scaffold-core';
+import { buildCompareReport } from '../src/index.js';
+
+const node = (id: string, total: number, risk: number): PlanNode => ({
+  nodeId: id,
+  specId: 'spec',
+  component: 'branch:spec',
+  choice: `choice-${id}`,
+  deps: [],
+  rationale: 'demo',
+  score: {
+    total,
+    complexity: 4,
+    risk,
+    perf: 6,
+    devTime: 5,
+    depsReady: 7,
+    explain: ['demo'],
+  },
+});
+
+const scaffold: ScaffoldPlan = {
+  version: '0.1.0',
+  template: 'dual-stack',
+  generatedAt: '1970-01-01T00:00:00.000Z',
+  meta: { seed: 42, specHash: 'hash', version: '0.1.0' },
+  branches: [
+    {
+      nodeId: 'a'.repeat(64),
+      branchName: 't4/dual-stack/a',
+      workingDir: 'branches/a',
+      template: 'dual-stack',
+      planChoice: 'choice-a',
+      summary: 'summary',
+      repoActions: [],
+      ciActions: [],
+    },
+    {
+      nodeId: 'b'.repeat(64),
+      branchName: 't4/dual-stack/b',
+      workingDir: 'branches/b',
+      template: 'dual-stack',
+      planChoice: 'choice-b',
+      summary: 'summary',
+      repoActions: [],
+      ciActions: [],
+    },
+  ],
+  lookup: {},
+};
+
+describe('buildCompareReport', () => {
+  it('sorts branches by score and assigns ranks', () => {
+    const report = buildCompareReport([
+      node('a'.repeat(64), 9, 2),
+      node('b'.repeat(64), 8, 1),
+    ], scaffold);
+    expect(report.branches[0].branchName).toBe('t4/dual-stack/a');
+    expect(report.branches[0].rank).toBe(1);
+    expect(report.version).toBeDefined();
+  });
+});

--- a/packages/tf-plan-compare-core/tsconfig.json
+++ b/packages/tf-plan-compare-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-compare-render/package.json
+++ b/packages/tf-plan-compare-render/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tf-lang/tf-plan-compare-render",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-compare-core": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-compare-render/src/index.ts
+++ b/packages/tf-plan-compare-render/src/index.ts
@@ -1,0 +1,53 @@
+import { CompareReport } from '@tf-lang/tf-plan-compare-core';
+
+export function renderMarkdown(report: CompareReport): string {
+  const header = `# tf-plan comparison (version ${report.version})\n\n`;
+  const meta = `*Seed:* ${report.meta.seed}\\n\n`;
+  const tableHeader = '| Rank | Branch | Total | Risk | Notes |\n| --- | --- | --- | --- | --- |\n';
+  const tableRows = report.branches
+    .map((branch) => `| ${branch.rank} | ${branch.branchName} | ${branch.score.total.toFixed(2)} | ${branch.score.risk.toFixed(2)} | ${branch.summary} |`)
+    .join('\n');
+  const oracleSection = report.branches
+    .map((branch) => {
+      if (branch.oracles.length === 0) {
+        return `### ${branch.branchName}\n- No oracle results available\n`;
+      }
+      const oracleLines = branch.oracles
+        .map((oracle) => `- ${oracle.name}: ${oracle.status}${oracle.artifact ? ` ([artifact](${oracle.artifact}))` : ''}`)
+        .join('\n');
+      return `### ${branch.branchName}\n${oracleLines}\n`;
+    })
+    .join('\n');
+  return `${header}${meta}${tableHeader}${tableRows}\n\n${oracleSection}`;
+}
+
+export function renderHtml(report: CompareReport): string {
+  const rows = report.branches
+    .map(
+      (branch) =>
+        `<tr><td>${branch.rank}</td><td>${branch.branchName}</td><td>${branch.score.total.toFixed(2)}</td><td>${branch.score.risk.toFixed(2)}</td><td>${branch.summary}</td></tr>`,
+    )
+    .join('');
+  const oracleBlocks = report.branches
+    .map((branch) => {
+      const items = branch.oracles
+        .map((oracle) => {
+          const artifact = oracle.artifact ? `<a href="${oracle.artifact}">artifact</a>` : '';
+          return `<li><strong>${oracle.name}</strong>: ${oracle.status}${artifact ? ` (${artifact})` : ''}</li>`;
+        })
+        .join('');
+      const fallback = items.length > 0 ? items : '<li>No oracle results available</li>';
+      return `<section><h3>${branch.branchName}</h3><ul>${fallback}</ul></section>`;
+    })
+    .join('');
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>tf-plan comparison</title><style>
+      body { font-family: system-ui, sans-serif; padding: 1rem; }
+      table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }
+      th, td { border: 1px solid #ddd; padding: 0.5rem; text-align: left; }
+      th { background-color: #f2f2f2; }
+    </style></head><body><h1>tf-plan comparison (version ${report.version})</h1>
+    <p><strong>Seed:</strong> ${report.meta.seed}</p>
+    <table><thead><tr><th>Rank</th><th>Branch</th><th>Total</th><th>Risk</th><th>Summary</th></tr></thead><tbody>${rows}</tbody></table>
+    ${oracleBlocks}
+    </body></html>`;
+}

--- a/packages/tf-plan-compare-render/tests/index.test.ts
+++ b/packages/tf-plan-compare-render/tests/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { CompareReport } from '@tf-lang/tf-plan-compare-core';
+import { renderHtml, renderMarkdown } from '../src/index.js';
+
+const report: CompareReport = {
+  version: '0.1.0',
+  meta: { seed: 42, planVersion: '0.1.0', generatedAt: '1970-01-01T00:00:00.000Z', notes: [] },
+  branches: [
+    {
+      nodeId: 'node',
+      branchName: 't4/demo',
+      planChoice: 'choice',
+      rank: 1,
+      score: { total: 9, risk: 2, complexity: 4, perf: 6, devTime: 5, depsReady: 7 },
+      summary: 'top branch',
+      oracles: [],
+    },
+  ],
+};
+
+describe('renderers', () => {
+  it('renders markdown deterministically', () => {
+    const md = renderMarkdown(report);
+    expect(md).toContain('# tf-plan comparison');
+  });
+
+  it('renders html deterministically', () => {
+    const html = renderHtml(report);
+    expect(html).toContain('<table');
+  });
+});

--- a/packages/tf-plan-compare-render/tsconfig.json
+++ b/packages/tf-plan-compare-render/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-compare/package.json
+++ b/packages/tf-plan-compare/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@tf-lang/tf-plan-compare",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "tf-plan-compare": "dist/cli.js"
+  },
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-compare-core": "0.1.0",
+    "@tf-lang/tf-plan-compare-render": "0.1.0",
+    "@tf-lang/tf-plan-core": "0.1.0",
+    "@tf-lang/tf-plan-scaffold-core": "0.1.0",
+    "ajv": "^8.12.0",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-compare/src/cli.ts
+++ b/packages/tf-plan-compare/src/cli.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { resolve } from 'node:path';
+import { generateComparison } from './index.js';
+
+const program = new Command();
+program
+  .name('tf-plan-compare')
+  .description('tf-plan comparison CLI');
+
+program
+  .command('compare')
+  .option('--plan <path>', 'Path to plan.ndjson', 'out/t4/plan/plan.ndjson')
+  .option('--inputs <path>', 'Path to scaffold index JSON', 'out/t4/scaffold/index.json')
+  .option('--out <dir>', 'Output directory', 'out/t4/compare')
+  .action(async (options) => {
+    try {
+      await generateComparison({
+        planNdjsonPath: resolve(options.plan),
+        scaffoldPath: resolve(options.inputs),
+        outDir: resolve(options.out),
+      });
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error((error as Error).message);
+  process.exitCode = 1;
+});

--- a/packages/tf-plan-compare/src/index.ts
+++ b/packages/tf-plan-compare/src/index.ts
@@ -1,0 +1,88 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
+import { PlanNode } from '@tf-lang/tf-plan-core';
+import { ScaffoldPlan } from '@tf-lang/tf-plan-scaffold-core';
+import { buildCompareReport } from '@tf-lang/tf-plan-compare-core';
+import type { CompareReport } from '@tf-lang/tf-plan-compare-core';
+import { renderHtml, renderMarkdown } from '@tf-lang/tf-plan-compare-render';
+
+const require = createRequire(import.meta.url);
+const branchSchema = loadSchema('tf-branch.schema.json');
+const compareSchema = loadSchema('tf-compare.schema.json');
+const ajv = new Ajv({ allErrors: true, strict: false });
+ajv.addSchema(branchSchema, 'tf-branch.schema.json');
+const validateNode = ajv.compile<PlanNode>(branchSchema);
+const validateCompare = ajv.compile<CompareReport>(compareSchema);
+
+function loadSchema(name: string): Record<string, unknown> {
+  const candidates = [
+    `../../../schema/${name}`,
+    `../../../../schema/${name}`,
+  ];
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`Unable to load schema ${name}`);
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(filePath, { recursive: true });
+}
+
+async function readNdjson(planPath: string): Promise<PlanNode[]> {
+  const raw = await readFile(resolve(planPath), 'utf8');
+  const lines = raw.trim().length === 0 ? [] : raw.trim().split('\n');
+  const nodes = lines.map((line) => JSON.parse(line) as PlanNode);
+  nodes.forEach((node) => {
+    if (!validateNode(node)) {
+      const message =
+        validateNode.errors?.map((error: ErrorObject) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+      throw new Error(`Invalid plan node in ${planPath}: ${message}`);
+    }
+  });
+  return nodes;
+}
+
+async function readScaffold(indexPath: string): Promise<ScaffoldPlan> {
+  const raw = await readFile(resolve(indexPath), 'utf8');
+  return JSON.parse(raw) as ScaffoldPlan;
+}
+
+export interface CompareArgs {
+  readonly planNdjsonPath: string;
+  readonly scaffoldPath: string;
+  readonly outDir: string;
+}
+
+export interface CompareOutputs {
+  readonly report: ReturnType<typeof buildCompareReport>;
+  readonly jsonPath: string;
+  readonly markdownPath: string;
+  readonly htmlPath: string;
+}
+
+export async function generateComparison(args: CompareArgs): Promise<CompareOutputs> {
+  const nodes = await readNdjson(args.planNdjsonPath);
+  const scaffold = await readScaffold(args.scaffoldPath);
+  const report = buildCompareReport(nodes, scaffold);
+  if (!validateCompare(report)) {
+    const message = validateCompare.errors?.map((error) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+    throw new Error(`Generated report failed validation: ${message}`);
+  }
+  const jsonPath = join(args.outDir, 'report.json');
+  const markdownPath = join(args.outDir, 'report.md');
+  const htmlPath = join(args.outDir, 'index.html');
+  await ensureDir(args.outDir);
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await writeFile(markdownPath, `${renderMarkdown(report)}\n`, 'utf8');
+  await writeFile(htmlPath, `${renderHtml(report)}\n`, 'utf8');
+  console.log(`Comparison report written to ${args.outDir}`);
+  return { report, jsonPath, markdownPath, htmlPath };
+}

--- a/packages/tf-plan-compare/tests/index.test.ts
+++ b/packages/tf-plan-compare/tests/index.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };
+import { enumeratePlan } from '@tf-lang/tf-plan-enum';
+import { createScaffoldPlan } from '@tf-lang/tf-plan-scaffold-core';
+import { generateComparison } from '../src/index.js';
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'tf-compare-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('generateComparison', () => {
+  it('produces report artifacts', async () => {
+    const plan = enumeratePlan(demoSpec, { seed: 42, beamWidth: 2, maxBranches: 2 });
+    const scaffold = createScaffoldPlan(plan.nodes, plan.meta, { template: 'dual-stack', top: 2 });
+    const dir = await createTempDir();
+    const planNdjsonPath = join(dir, 'plan.ndjson');
+    const scaffoldPath = join(dir, 'index.json');
+    const ndjson = plan.nodes.map((node) => JSON.stringify(node)).join('\n');
+    await writeFile(planNdjsonPath, `${ndjson}\n`);
+    await writeFile(scaffoldPath, `${JSON.stringify(scaffold, null, 2)}\n`);
+
+    const outputs = await generateComparison({ planNdjsonPath, scaffoldPath, outDir: join(dir, 'out') });
+    expect(outputs.report.branches.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/tf-plan-compare/tsconfig.json
+++ b/packages/tf-plan-compare/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "paths": {
+      "@tf-lang/tf-plan-core": ["../tf-plan-core/dist/index.d.ts"],
+      "@tf-lang/tf-plan-scaffold-core": ["../tf-plan-scaffold-core/dist/index.d.ts"],
+      "@tf-lang/tf-plan-compare-core": ["../tf-plan-compare-core/dist/index.d.ts"],
+      "@tf-lang/tf-plan-compare-render": ["../tf-plan-compare-render/dist/index.d.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-compare/vitest.config.ts
+++ b/packages/tf-plan-compare/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    alias: {
+      '@tf-lang/tf-plan-core': resolve(__dirname, '../tf-plan-core/src/index.ts'),
+      '@tf-lang/tf-plan-scaffold-core': resolve(__dirname, '../tf-plan-scaffold-core/src/index.ts'),
+      '@tf-lang/tf-plan-compare-core': resolve(__dirname, '../tf-plan-compare-core/src/index.ts'),
+      '@tf-lang/tf-plan-compare-render': resolve(__dirname, '../tf-plan-compare-render/src/index.ts'),
+      '@tf-lang/tf-plan-enum': resolve(__dirname, '../tf-plan-enum/src/index.ts'),
+    },
+  },
+});

--- a/packages/tf-plan-core/package.json
+++ b/packages/tf-plan-core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tf-lang/tf-plan-core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-core/src/index.d.ts
+++ b/packages/tf-plan-core/src/index.d.ts
@@ -1,0 +1,64 @@
+export declare const PLAN_GRAPH_VERSION = "0.1.0";
+export interface Score {
+    readonly total: number;
+    readonly complexity: number;
+    readonly risk: number;
+    readonly perf: number;
+    readonly devTime: number;
+    readonly depsReady: number;
+    readonly explain: readonly string[];
+}
+export interface PlanNode {
+    readonly nodeId: string;
+    readonly specId: string;
+    readonly component: string;
+    readonly choice: string;
+    readonly deps: readonly string[];
+    readonly rationale: string;
+    readonly score: Score;
+}
+export interface PlanEdge {
+    readonly from: string;
+    readonly to: string;
+    readonly kind: 'depends' | 'sequence';
+}
+export interface PlanGraphMeta {
+    readonly seed: number;
+    readonly specHash: string;
+    readonly version: string;
+}
+export interface PlanGraph {
+    readonly version: string;
+    readonly nodes: readonly PlanNode[];
+    readonly edges: readonly PlanEdge[];
+    readonly meta: PlanGraphMeta;
+}
+export interface StableIdInput {
+    readonly scope: string;
+    readonly specId: string;
+    readonly component: string;
+    readonly choice: string;
+    readonly seed: number;
+    readonly version: string;
+}
+export interface StableIdResult {
+    readonly full: string;
+    readonly short: string;
+}
+export declare function stableId(input: StableIdInput): StableIdResult;
+export declare function deepFreeze<T>(value: T): Readonly<T>;
+export type Comparator<T> = (a: T, b: T) => number;
+export declare function stableSort<T>(items: readonly T[], compare: Comparator<T>): T[];
+export interface SeededRng {
+    next(): number;
+    nextInt(maxExclusive: number): number;
+}
+export declare function seedRng(seed: number | string): SeededRng;
+export declare function canonicalStringify(value: unknown): string;
+export declare function hashObject(value: unknown): string;
+export type RepoSignals = Readonly<Record<string, unknown>>;
+export interface PlanGraphValidationResult {
+    readonly valid: boolean;
+    readonly errors: readonly string[];
+}
+export type SchemaValidator = (value: unknown) => PlanGraphValidationResult;

--- a/packages/tf-plan-core/src/index.js
+++ b/packages/tf-plan-core/src/index.js
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+export const PLAN_GRAPH_VERSION = '0.1.0';
+export function stableId(input) {
+    const canonical = `${input.scope}:${input.specId}|${input.component}|${input.choice}|${input.seed}|${input.version}`;
+    const full = createHash('sha256').update(canonical).digest('hex');
+    return {
+        full,
+        short: full.slice(0, 12),
+    };
+}
+export function deepFreeze(value) {
+    if (value === null) {
+        return value;
+    }
+    if (typeof value !== 'object') {
+        return value;
+    }
+    const seen = new Set();
+    const freeze = (target) => {
+        if (target === null || typeof target !== 'object') {
+            return target;
+        }
+        if (seen.has(target)) {
+            return target;
+        }
+        seen.add(target);
+        if (Array.isArray(target)) {
+            for (const item of target) {
+                freeze(item);
+            }
+        }
+        else {
+            const entries = Object.entries(target);
+            for (const [, entryValue] of entries) {
+                freeze(entryValue);
+            }
+        }
+        return Object.freeze(target);
+    };
+    return freeze(value);
+}
+export function stableSort(items, compare) {
+    return items
+        .map((value, index) => ({ value, index }))
+        .sort((left, right) => {
+        const result = compare(left.value, right.value);
+        if (result !== 0) {
+            return result;
+        }
+        return left.index - right.index;
+    })
+        .map((entry) => entry.value);
+}
+function normalizeSeed(seed) {
+    if (typeof seed === 'number' && Number.isFinite(seed)) {
+        return seed >>> 0;
+    }
+    const text = typeof seed === 'string' ? seed : JSON.stringify(seed);
+    const hash = createHash('sha256').update(text).digest();
+    return hash.readUInt32BE(0);
+}
+export function seedRng(seed) {
+    let state = normalizeSeed(seed) || 1;
+    const next = () => {
+        // Mulberry32 PRNG
+        state |= 0;
+        state = (state + 0x6D2B79F5) | 0;
+        let t = Math.imul(state ^ (state >>> 15), 1 | state);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+    };
+    return {
+        next,
+        nextInt(maxExclusive) {
+            if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+                throw new Error(`maxExclusive must be a positive finite number, received ${maxExclusive}`);
+            }
+            return Math.floor(next() * maxExclusive);
+        },
+    };
+}
+export function canonicalStringify(value) {
+    const serialize = (input) => {
+        if (input === null || typeof input !== 'object') {
+            return JSON.stringify(input);
+        }
+        if (Array.isArray(input)) {
+            const items = input.map((element) => serialize(element));
+            return `[${items.join(',')}]`;
+        }
+        const entries = Object.entries(input);
+        entries.sort((left, right) => {
+            if (left[0] < right[0]) {
+                return -1;
+            }
+            if (left[0] > right[0]) {
+                return 1;
+            }
+            return 0;
+        });
+        const parts = entries.map(([key, val]) => `${JSON.stringify(key)}:${serialize(val)}`);
+        return `{${parts.join(',')}}`;
+    };
+    return serialize(value);
+}
+export function hashObject(value) {
+    const canonical = canonicalStringify(value);
+    return createHash('sha256').update(canonical).digest('hex');
+}

--- a/packages/tf-plan-core/src/index.ts
+++ b/packages/tf-plan-core/src/index.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto';
+
+export const PLAN_GRAPH_VERSION = '0.1.0';
+
+export interface Score {
+  readonly total: number;
+  readonly complexity: number;
+  readonly risk: number;
+  readonly perf: number;
+  readonly devTime: number;
+  readonly depsReady: number;
+  readonly explain: readonly string[];
+}
+
+export interface PlanNode {
+  readonly nodeId: string;
+  readonly specId: string;
+  readonly component: string;
+  readonly choice: string;
+  readonly deps: readonly string[];
+  readonly rationale: string;
+  readonly score: Score;
+}
+
+export interface PlanEdge {
+  readonly from: string;
+  readonly to: string;
+  readonly kind: 'depends' | 'sequence';
+}
+
+export interface PlanGraphMeta {
+  readonly seed: number;
+  readonly specHash: string;
+  readonly version: string;
+}
+
+export interface PlanGraph {
+  readonly version: string;
+  readonly nodes: readonly PlanNode[];
+  readonly edges: readonly PlanEdge[];
+  readonly meta: PlanGraphMeta;
+}
+
+export interface StableIdInput {
+  readonly scope: string;
+  readonly specId: string;
+  readonly component: string;
+  readonly choice: string;
+  readonly seed: number;
+  readonly version: string;
+}
+
+export interface StableIdResult {
+  readonly full: string;
+  readonly short: string;
+}
+
+export function stableId(input: StableIdInput): StableIdResult {
+  const canonical = `${input.scope}:${input.specId}|${input.component}|${input.choice}|${input.seed}|${input.version}`;
+  const full = createHash('sha256').update(canonical).digest('hex');
+  return {
+    full,
+    short: full.slice(0, 12),
+  };
+}
+
+export function deepFreeze<T>(value: T): Readonly<T> {
+  if (value === null) {
+    return value as Readonly<T>;
+  }
+
+  if (typeof value !== 'object') {
+    return value as Readonly<T>;
+  }
+
+  const seen = new Set<unknown>();
+
+  const freeze = (target: unknown): unknown => {
+    if (target === null || typeof target !== 'object') {
+      return target;
+    }
+
+    if (seen.has(target)) {
+      return target;
+    }
+
+    seen.add(target);
+
+    if (Array.isArray(target)) {
+      for (const item of target) {
+        freeze(item);
+      }
+    } else {
+      const entries = Object.entries(target as Record<string, unknown>);
+      for (const [, entryValue] of entries) {
+        freeze(entryValue);
+      }
+    }
+
+    return Object.freeze(target);
+  };
+
+  return freeze(value) as Readonly<T>;
+}
+
+export type Comparator<T> = (a: T, b: T) => number;
+
+export function stableSort<T>(items: readonly T[], compare: Comparator<T>): T[] {
+  return items
+    .map((value, index) => ({ value, index }))
+    .sort((left, right) => {
+      const result = compare(left.value, right.value);
+      if (result !== 0) {
+        return result;
+      }
+      return left.index - right.index;
+    })
+    .map((entry) => entry.value);
+}
+
+function normalizeSeed(seed: number | string): number {
+  if (typeof seed === 'number' && Number.isFinite(seed)) {
+    return seed >>> 0;
+  }
+
+  const text = typeof seed === 'string' ? seed : JSON.stringify(seed);
+  const hash = createHash('sha256').update(text).digest();
+  return hash.readUInt32BE(0);
+}
+
+export interface SeededRng {
+  next(): number;
+  nextInt(maxExclusive: number): number;
+}
+
+export function seedRng(seed: number | string): SeededRng {
+  let state = normalizeSeed(seed) || 1;
+
+  const next = (): number => {
+    // Mulberry32 PRNG
+    state |= 0;
+    state = (state + 0x6D2B79F5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+
+  return {
+    next,
+    nextInt(maxExclusive: number) {
+      if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+        throw new Error(`maxExclusive must be a positive finite number, received ${maxExclusive}`);
+      }
+      return Math.floor(next() * maxExclusive);
+    },
+  };
+}
+
+export function canonicalStringify(value: unknown): string {
+  const serialize = (input: unknown): string => {
+    if (input === null || typeof input !== 'object') {
+      return JSON.stringify(input);
+    }
+
+    if (Array.isArray(input)) {
+      const items = input.map((element) => serialize(element));
+      return `[${items.join(',')}]`;
+    }
+
+    const entries = Object.entries(input as Record<string, unknown>);
+    entries.sort((left, right) => {
+      if (left[0] < right[0]) {
+        return -1;
+      }
+      if (left[0] > right[0]) {
+        return 1;
+      }
+      return 0;
+    });
+
+    const parts = entries.map(([key, val]) => `${JSON.stringify(key)}:${serialize(val)}`);
+    return `{${parts.join(',')}}`;
+  };
+
+  return serialize(value);
+}
+
+export function hashObject(value: unknown): string {
+  const canonical = canonicalStringify(value);
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+export type RepoSignals = Readonly<Record<string, unknown>>;
+
+export interface PlanGraphValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+}
+
+export type SchemaValidator = (value: unknown) => PlanGraphValidationResult;

--- a/packages/tf-plan-core/tests/index.test.ts
+++ b/packages/tf-plan-core/tests/index.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PLAN_GRAPH_VERSION,
+  canonicalStringify,
+  deepFreeze,
+  hashObject,
+  seedRng,
+  stableId,
+  stableSort,
+} from '../src/index.js';
+
+describe('PLAN_GRAPH_VERSION', () => {
+  it('is pinned for deterministic outputs', () => {
+    expect(PLAN_GRAPH_VERSION).toBe('0.1.0');
+  });
+});
+
+describe('stableId', () => {
+  it('produces deterministic hashes and short ids', () => {
+    const first = stableId({
+      scope: 'branch',
+      specId: 'demo',
+      component: 'transfer',
+      choice: 'rsync',
+      seed: 42,
+      version: PLAN_GRAPH_VERSION,
+    });
+
+    const second = stableId({
+      scope: 'branch',
+      specId: 'demo',
+      component: 'transfer',
+      choice: 'rsync',
+      seed: 42,
+      version: PLAN_GRAPH_VERSION,
+    });
+
+    expect(first.full).toEqual(second.full);
+    expect(first.short).toEqual(second.short);
+    expect(first.short).toHaveLength(12);
+  });
+});
+
+describe('deepFreeze', () => {
+  it('freezes nested structures without mutating the original reference', () => {
+    const input = { foo: { bar: [1, 2, 3] } };
+    const frozen = deepFreeze(input);
+
+    expect(() => {
+      (frozen as { foo: { bar: number[] } }).foo.bar.push(4);
+    }).toThrow();
+
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen((frozen as { foo: unknown }).foo)).toBe(true);
+  });
+});
+
+describe('stableSort', () => {
+  it('keeps the original order for equal elements', () => {
+    const input = [
+      { value: 2, id: 'a' },
+      { value: 1, id: 'b' },
+      { value: 1, id: 'c' },
+      { value: 3, id: 'd' },
+    ];
+    const sorted = stableSort(input, (left, right) => left.value - right.value);
+    expect(sorted.map((entry) => entry.id)).toEqual(['b', 'c', 'a', 'd']);
+  });
+});
+
+describe('seedRng', () => {
+  it('produces deterministic sequences for the same seed', () => {
+    const rngA = seedRng(42);
+    const rngB = seedRng(42);
+    const seqA = [rngA.next(), rngA.next(), rngA.next()];
+    const seqB = [rngB.next(), rngB.next(), rngB.next()];
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('produces values in the expected range for nextInt', () => {
+    const rng = seedRng(123);
+    for (let i = 0; i < 20; i += 1) {
+      const value = rng.nextInt(5);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(5);
+    }
+  });
+});
+
+describe('canonicalStringify', () => {
+  it('orders object keys recursively for determinism', () => {
+    const first = canonicalStringify({
+      b: 2,
+      a: { z: 3, y: [2, 1] },
+    });
+    const second = canonicalStringify({
+      a: { y: [2, 1], z: 3 },
+      b: 2,
+    });
+    expect(first).toEqual(second);
+    expect(first).toEqual('{"a":{"y":[2,1],"z":3},"b":2}');
+  });
+});
+
+describe('hashObject', () => {
+  it('derives the hash from the canonical stringification', () => {
+    const hash = hashObject({ foo: 1, bar: 2 });
+    expect(hash).toHaveLength(64);
+    const same = hashObject({ bar: 2, foo: 1 });
+    expect(hash).toEqual(same);
+  });
+});

--- a/packages/tf-plan-core/tsconfig.json
+++ b/packages/tf-plan-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-enum/package.json
+++ b/packages/tf-plan-enum/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@tf-lang/tf-plan-enum",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "0.1.0",
+    "@tf-lang/tf-plan-scoring": "0.1.0",
+    "ajv": "^8.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-enum/src/index.d.ts
+++ b/packages/tf-plan-enum/src/index.d.ts
@@ -1,0 +1,24 @@
+import { PlanGraph, RepoSignals } from '@tf-lang/tf-plan-core';
+export interface TfSpecStep {
+    readonly op: 'copy' | 'create_vm' | 'create_network';
+    readonly params: Record<string, unknown>;
+}
+export interface TfSpec {
+    readonly version: string;
+    readonly name: string;
+    readonly steps: readonly TfSpecStep[];
+}
+export interface EnumerateOptions {
+    readonly seed?: number;
+    readonly beamWidth?: number;
+    readonly maxBranches?: number;
+    readonly includeChoices?: Readonly<Record<string, readonly string[]>>;
+    readonly excludeChoices?: Readonly<Record<string, readonly string[]>>;
+    readonly repoSignals?: RepoSignals;
+}
+export interface EnumeratePlanResult {
+    readonly plan: PlanGraph;
+    readonly branchCount: number;
+}
+export declare function readSpec(specPath: string): Promise<TfSpec>;
+export declare function enumeratePlan(spec: TfSpec, options?: EnumerateOptions): PlanGraph;

--- a/packages/tf-plan-enum/src/index.js
+++ b/packages/tf-plan-enum/src/index.js
@@ -1,0 +1,292 @@
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import Ajv from 'ajv';
+import tfSpecSchema from '../../../schema/tf-spec.schema.json' with { type: 'json' };
+import { PLAN_GRAPH_VERSION, deepFreeze, hashObject, seedRng, stableId, stableSort, } from '@tf-lang/tf-plan-core';
+import { scorePlanNode } from '@tf-lang/tf-plan-scoring';
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validateSpec = ajv.compile(tfSpecSchema);
+const choiceLibrary = {
+    copy: [
+        {
+            choice: 'managed rsync pipeline',
+            rationale: 'Leverages existing rsync workers with checksum validation and resumable syncs.',
+        },
+        {
+            choice: 'object storage replication',
+            rationale: 'Pushes payloads to durable object storage with lifecycle policies and versioning.',
+        },
+        {
+            choice: 'delta snapshot streaming',
+            rationale: 'Streams block-level snapshots incrementally to reduce data transfer volume.',
+        },
+    ],
+    create_vm: [
+        {
+            choice: 'standard compute pool',
+            rationale: 'Uses balanced compute instances with reserved capacity for predictable throughput.',
+        },
+        {
+            choice: 'spot auto-healing cluster',
+            rationale: 'Optimises cost with spot nodes while health checks replace evicted instances quickly.',
+        },
+        {
+            choice: 'gpu accelerated workers',
+            rationale: 'Accelerates compute-heavy workloads with managed GPU nodes and tuned drivers.',
+        },
+    ],
+    create_network: [
+        {
+            choice: 'segmented service mesh',
+            rationale: 'Creates layered subnets with strict firewall policies and service discovery.',
+        },
+        {
+            choice: 'flat network with security groups',
+            rationale: 'Keeps topology simple with security groups guarding ingress and egress.',
+        },
+        {
+            choice: 'zero trust overlay',
+            rationale: 'Applies identity-aware proxies and policy enforcement at the edge.',
+        },
+    ],
+};
+function assertValidSpec(spec) {
+    const result = validateSpec(spec);
+    if (!result) {
+        const message = validateSpec.errors?.map((error) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+        throw new Error(`Invalid tf-spec: ${message}`);
+    }
+}
+function isChoiceAllowed(componentId, choice, options) {
+    const { includeChoices, excludeChoices } = options;
+    if (includeChoices && includeChoices[componentId] && !includeChoices[componentId]?.includes(choice.choice)) {
+        return false;
+    }
+    if (excludeChoices && excludeChoices[componentId] && excludeChoices[componentId]?.includes(choice.choice)) {
+        return false;
+    }
+    return true;
+}
+function buildComponentPlan(componentId, label, choice, specId, seed, version, repoSignals) {
+    const nodeIdentity = stableId({
+        scope: 'component',
+        specId,
+        component: componentId,
+        choice: choice.choice,
+        seed,
+        version,
+    });
+    const score = scorePlanNode({ component: componentId, choice: choice.choice, seed, repoSignals });
+    return {
+        nodeId: nodeIdentity.full,
+        specId,
+        component: componentId,
+        choice: choice.choice,
+        deps: [],
+        rationale: `${label}: ${choice.rationale}`,
+        score,
+    };
+}
+function round(value, precision = 3) {
+    const factor = 10 ** precision;
+    return Math.round(value * factor) / factor;
+}
+function aggregateScore(nodes) {
+    if (nodes.length === 0) {
+        return {
+            total: 0,
+            complexity: 0,
+            risk: 0,
+            perf: 0,
+            devTime: 0,
+            depsReady: 0,
+            explain: ['No component nodes were provided.'],
+        };
+    }
+    const totals = nodes.reduce((acc, node) => {
+        acc.total += node.score.total;
+        acc.complexity += node.score.complexity;
+        acc.risk += node.score.risk;
+        acc.perf += node.score.perf;
+        acc.devTime += node.score.devTime;
+        acc.depsReady += node.score.depsReady;
+        acc.explain.push(`${node.component} via ${node.choice} → total ${node.score.total.toFixed(2)}`);
+        return acc;
+    }, {
+        total: 0,
+        complexity: 0,
+        risk: 0,
+        perf: 0,
+        devTime: 0,
+        depsReady: 0,
+        explain: [],
+    });
+    const count = nodes.length;
+    const summary = `Aggregated from ${count} components.`;
+    totals.explain.push(summary);
+    return {
+        total: round(totals.total / count),
+        complexity: round(totals.complexity / count),
+        risk: round(totals.risk / count),
+        perf: round(totals.perf / count),
+        devTime: round(totals.devTime / count),
+        depsReady: round(totals.depsReady / count),
+        explain: totals.explain,
+    };
+}
+function buildBranchNode(specId, branchLabel, components, seed, version) {
+    const choiceSummary = components.map((component) => `${component.label}=${component.choice.choice}`).join('; ');
+    const nodeIdentity = stableId({
+        scope: 'branch',
+        specId,
+        component: branchLabel,
+        choice: choiceSummary,
+        seed,
+        version,
+    });
+    const componentNodes = components.map((component) => component.node);
+    const score = aggregateScore(componentNodes);
+    const rationale = `Combines ${components.map((component) => `${component.label} via ${component.choice.choice}`).join(', ')}.`;
+    return {
+        nodeId: nodeIdentity.full,
+        specId,
+        component: branchLabel,
+        choice: choiceSummary,
+        deps: componentNodes.map((node) => node.nodeId),
+        rationale,
+        score,
+    };
+}
+function enumerateComponentPlans(spec, options, specId, seed, version) {
+    const plans = [];
+    const repoSignals = options.repoSignals ?? {};
+    spec.steps.forEach((step, index) => {
+        const componentId = `${step.op}:${index}`;
+        const label = `${step.op}#${index + 1}`;
+        const library = choiceLibrary[step.op];
+        library.forEach((choice) => {
+            if (!isChoiceAllowed(componentId, choice, options)) {
+                return;
+            }
+            const node = buildComponentPlan(componentId, label, choice, specId, seed, version, repoSignals);
+            plans.push({ componentId, label, choice, node });
+        });
+    });
+    return plans;
+}
+function groupByComponent(plans) {
+    const map = new Map();
+    plans.forEach((plan) => {
+        const existing = map.get(plan.componentId);
+        if (existing) {
+            existing.push(plan);
+        }
+        else {
+            map.set(plan.componentId, [plan]);
+        }
+    });
+    return map;
+}
+function enumerateBranches(componentsById, specId, seed, version, options) {
+    const componentIds = [...componentsById.keys()].sort();
+    const branchLabel = `branch:${specId}`;
+    const branches = [];
+    const rng = seedRng(seed);
+    const explore = (index, selected) => {
+        if (index === componentIds.length) {
+            branches.push(buildBranchNode(specId, branchLabel, selected, seed, version));
+            return;
+        }
+        const componentId = componentIds[index];
+        const optionsForComponent = componentsById.get(componentId) ?? [];
+        const sortedOptions = stableSort(optionsForComponent, (left, right) => {
+            const totalDiff = right.node.score.total - left.node.score.total;
+            if (totalDiff !== 0) {
+                return totalDiff;
+            }
+            const riskDiff = left.node.score.risk - right.node.score.risk;
+            if (riskDiff !== 0) {
+                return riskDiff;
+            }
+            return left.node.nodeId.localeCompare(right.node.nodeId);
+        });
+        const beamWidth = options.beamWidth ?? sortedOptions.length;
+        const limited = sortedOptions.slice(0, beamWidth);
+        limited.forEach((choice) => {
+            explore(index + 1, [...selected, choice]);
+        });
+    };
+    explore(0, []);
+    const sortedBranches = stableSort(branches, (left, right) => {
+        const totalDiff = right.score.total - left.score.total;
+        if (totalDiff !== 0) {
+            return totalDiff;
+        }
+        const riskDiff = left.score.risk - right.score.risk;
+        if (riskDiff !== 0) {
+            return riskDiff;
+        }
+        return left.nodeId.localeCompare(right.nodeId);
+    });
+    const maxBranches = options.maxBranches ?? sortedBranches.length;
+    const chosen = sortedBranches.slice(0, maxBranches);
+    // Shuffle deterministically to avoid bias when totals tie.
+    const decorated = chosen.map((branch) => ({ branch, key: rng.next() }));
+    decorated.sort((a, b) => {
+        if (a.branch.score.total !== b.branch.score.total) {
+            return b.branch.score.total - a.branch.score.total;
+        }
+        if (a.branch.score.risk !== b.branch.score.risk) {
+            return a.branch.score.risk - b.branch.score.risk;
+        }
+        return a.key - b.key;
+    });
+    return decorated.map((entry) => entry.branch);
+}
+export async function readSpec(specPath) {
+    const absolute = resolvePath(specPath);
+    const raw = await readFile(absolute, 'utf8');
+    const parsed = JSON.parse(raw);
+    assertValidSpec(parsed);
+    return parsed;
+}
+export function enumeratePlan(spec, options = {}) {
+    assertValidSpec(spec);
+    const seed = options.seed ?? 42;
+    const specHash = hashObject(spec);
+    const specId = `${spec.name}:${specHash.slice(0, 8)}`;
+    const componentPlans = enumerateComponentPlans(spec, options, specId, seed, PLAN_GRAPH_VERSION);
+    if (componentPlans.length === 0) {
+        throw new Error('No component plans generated. Adjust constraints to allow at least one choice per component.');
+    }
+    const componentsById = groupByComponent(componentPlans);
+    const branchNodes = enumerateBranches(componentsById, specId, seed, PLAN_GRAPH_VERSION, options);
+    if (branchNodes.length === 0) {
+        throw new Error('Enumeration finished without branch nodes. Relax beam or maxBranches constraints.');
+    }
+    const branchIds = new Set(branchNodes.map((branch) => branch.nodeId));
+    const nodes = [...componentPlans.map((plan) => plan.node), ...branchNodes];
+    const sortedNodes = stableSort(nodes, (left, right) => {
+        const totalDiff = right.score.total - left.score.total;
+        if (totalDiff !== 0) {
+            return totalDiff;
+        }
+        const riskDiff = left.score.risk - right.score.risk;
+        if (riskDiff !== 0) {
+            return riskDiff;
+        }
+        return left.nodeId.localeCompare(right.nodeId);
+    });
+    const edges = branchNodes.flatMap((branch) => branch.deps.map((dependency) => ({ from: branch.nodeId, to: dependency, kind: 'depends' })));
+    const planGraph = {
+        version: PLAN_GRAPH_VERSION,
+        nodes: sortedNodes,
+        edges,
+        meta: {
+            seed,
+            specHash,
+            version: PLAN_GRAPH_VERSION,
+        },
+    };
+    return deepFreeze(planGraph);
+}

--- a/packages/tf-plan-enum/src/index.ts
+++ b/packages/tf-plan-enum/src/index.ts
@@ -1,0 +1,409 @@
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
+import tfSpecSchema from '../../../schema/tf-spec.schema.json' with { type: 'json' };
+import {
+  PLAN_GRAPH_VERSION,
+  PlanEdge,
+  PlanGraph,
+  PlanNode,
+  RepoSignals,
+  Score,
+  deepFreeze,
+  hashObject,
+  seedRng,
+  stableId,
+  stableSort,
+} from '@tf-lang/tf-plan-core';
+import { scorePlanNode } from '@tf-lang/tf-plan-scoring';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validateSpec = ajv.compile(tfSpecSchema);
+
+export interface TfSpecStep {
+  readonly op: 'copy' | 'create_vm' | 'create_network';
+  readonly params: Record<string, unknown>;
+}
+
+export interface TfSpec {
+  readonly version: string;
+  readonly name: string;
+  readonly steps: readonly TfSpecStep[];
+}
+
+export interface EnumerateOptions {
+  readonly seed?: number;
+  readonly beamWidth?: number;
+  readonly maxBranches?: number;
+  readonly includeChoices?: Readonly<Record<string, readonly string[]>>;
+  readonly excludeChoices?: Readonly<Record<string, readonly string[]>>;
+  readonly repoSignals?: RepoSignals;
+}
+
+interface ComponentChoice {
+  readonly choice: string;
+  readonly rationale: string;
+}
+
+interface ComponentPlan {
+  readonly componentId: string;
+  readonly label: string;
+  readonly choice: ComponentChoice;
+  readonly node: PlanNode;
+}
+
+const choiceLibrary: Record<TfSpecStep['op'], readonly ComponentChoice[]> = {
+  copy: [
+    {
+      choice: 'managed rsync pipeline',
+      rationale: 'Leverages existing rsync workers with checksum validation and resumable syncs.',
+    },
+    {
+      choice: 'object storage replication',
+      rationale: 'Pushes payloads to durable object storage with lifecycle policies and versioning.',
+    },
+    {
+      choice: 'delta snapshot streaming',
+      rationale: 'Streams block-level snapshots incrementally to reduce data transfer volume.',
+    },
+  ],
+  create_vm: [
+    {
+      choice: 'standard compute pool',
+      rationale: 'Uses balanced compute instances with reserved capacity for predictable throughput.',
+    },
+    {
+      choice: 'spot auto-healing cluster',
+      rationale: 'Optimises cost with spot nodes while health checks replace evicted instances quickly.',
+    },
+    {
+      choice: 'gpu accelerated workers',
+      rationale: 'Accelerates compute-heavy workloads with managed GPU nodes and tuned drivers.',
+    },
+  ],
+  create_network: [
+    {
+      choice: 'segmented service mesh',
+      rationale: 'Creates layered subnets with strict firewall policies and service discovery.',
+    },
+    {
+      choice: 'flat network with security groups',
+      rationale: 'Keeps topology simple with security groups guarding ingress and egress.',
+    },
+    {
+      choice: 'zero trust overlay',
+      rationale: 'Applies identity-aware proxies and policy enforcement at the edge.',
+    },
+  ],
+};
+
+function assertValidSpec(spec: TfSpec): void {
+  const result = validateSpec(spec);
+  if (!result) {
+    const message =
+      validateSpec.errors?.map((error: ErrorObject) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+    throw new Error(`Invalid tf-spec: ${message}`);
+  }
+}
+
+function isChoiceAllowed(componentId: string, choice: ComponentChoice, options: EnumerateOptions): boolean {
+  const { includeChoices, excludeChoices } = options;
+  if (includeChoices && includeChoices[componentId] && !includeChoices[componentId]?.includes(choice.choice)) {
+    return false;
+  }
+  if (excludeChoices && excludeChoices[componentId] && excludeChoices[componentId]?.includes(choice.choice)) {
+    return false;
+  }
+  return true;
+}
+
+function buildComponentPlan(
+  componentId: string,
+  label: string,
+  choice: ComponentChoice,
+  specId: string,
+  seed: number,
+  version: string,
+  repoSignals: RepoSignals,
+): PlanNode {
+  const nodeIdentity = stableId({
+    scope: 'component',
+    specId,
+    component: componentId,
+    choice: choice.choice,
+    seed,
+    version,
+  });
+
+  const score = scorePlanNode({ component: componentId, choice: choice.choice, seed, repoSignals });
+
+  return {
+    nodeId: nodeIdentity.full,
+    specId,
+    component: componentId,
+    choice: choice.choice,
+    deps: [],
+    rationale: `${label}: ${choice.rationale}`,
+    score,
+  };
+}
+
+function round(value: number, precision = 3): number {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function aggregateScore(nodes: readonly PlanNode[]): Score {
+  if (nodes.length === 0) {
+    return {
+      total: 0,
+      complexity: 0,
+      risk: 0,
+      perf: 0,
+      devTime: 0,
+      depsReady: 0,
+      explain: ['No component nodes were provided.'],
+    };
+  }
+
+  const totals = nodes.reduce(
+    (acc, node) => {
+      acc.total += node.score.total;
+      acc.complexity += node.score.complexity;
+      acc.risk += node.score.risk;
+      acc.perf += node.score.perf;
+      acc.devTime += node.score.devTime;
+      acc.depsReady += node.score.depsReady;
+      acc.explain.push(`${node.component} via ${node.choice} → total ${node.score.total.toFixed(2)}`);
+      return acc;
+    },
+    {
+      total: 0,
+      complexity: 0,
+      risk: 0,
+      perf: 0,
+      devTime: 0,
+      depsReady: 0,
+      explain: [] as string[],
+    },
+  );
+
+  const count = nodes.length;
+  const summary = `Aggregated from ${count} components.`;
+  totals.explain.push(summary);
+
+  return {
+    total: round(totals.total / count),
+    complexity: round(totals.complexity / count),
+    risk: round(totals.risk / count),
+    perf: round(totals.perf / count),
+    devTime: round(totals.devTime / count),
+    depsReady: round(totals.depsReady / count),
+    explain: totals.explain,
+  };
+}
+
+function buildBranchNode(
+  specId: string,
+  branchLabel: string,
+  components: readonly ComponentPlan[],
+  seed: number,
+  version: string,
+): PlanNode {
+  const choiceSummary = components.map((component) => `${component.label}=${component.choice.choice}`).join('; ');
+  const nodeIdentity = stableId({
+    scope: 'branch',
+    specId,
+    component: branchLabel,
+    choice: choiceSummary,
+    seed,
+    version,
+  });
+
+  const componentNodes = components.map((component) => component.node);
+  const score = aggregateScore(componentNodes);
+  const rationale = `Combines ${components.map((component) => `${component.label} via ${component.choice.choice}`).join(', ')}.`;
+
+  return {
+    nodeId: nodeIdentity.full,
+    specId,
+    component: branchLabel,
+    choice: choiceSummary,
+    deps: componentNodes.map((node) => node.nodeId),
+    rationale,
+    score,
+  };
+}
+
+function enumerateComponentPlans(
+  spec: TfSpec,
+  options: EnumerateOptions,
+  specId: string,
+  seed: number,
+  version: string,
+): ComponentPlan[] {
+  const plans: ComponentPlan[] = [];
+  const repoSignals = options.repoSignals ?? {};
+
+  spec.steps.forEach((step, index) => {
+    const componentId = `${step.op}:${index}`;
+    const label = `${step.op}#${index + 1}`;
+    const library = choiceLibrary[step.op];
+
+    library.forEach((choice) => {
+      if (!isChoiceAllowed(componentId, choice, options)) {
+        return;
+      }
+      const node = buildComponentPlan(componentId, label, choice, specId, seed, version, repoSignals);
+      plans.push({ componentId, label, choice, node });
+    });
+  });
+
+  return plans;
+}
+
+function groupByComponent(plans: readonly ComponentPlan[]): Map<string, ComponentPlan[]> {
+  const map = new Map<string, ComponentPlan[]>();
+  plans.forEach((plan) => {
+    const existing = map.get(plan.componentId);
+    if (existing) {
+      existing.push(plan);
+    } else {
+      map.set(plan.componentId, [plan]);
+    }
+  });
+  return map;
+}
+
+function enumerateBranches(
+  componentsById: Map<string, ComponentPlan[]>,
+  specId: string,
+  seed: number,
+  version: string,
+  options: EnumerateOptions,
+): PlanNode[] {
+  const componentIds = [...componentsById.keys()].sort();
+  const branchLabel = `branch:${specId}`;
+  const branches: PlanNode[] = [];
+  const rng = seedRng(seed);
+
+  const explore = (index: number, selected: ComponentPlan[]) => {
+    if (index === componentIds.length) {
+      branches.push(buildBranchNode(specId, branchLabel, selected, seed, version));
+      return;
+    }
+    const componentId = componentIds[index];
+    const optionsForComponent = componentsById.get(componentId) ?? [];
+    const sortedOptions = stableSort(optionsForComponent, (left, right) => {
+      const totalDiff = right.node.score.total - left.node.score.total;
+      if (totalDiff !== 0) {
+        return totalDiff;
+      }
+      const riskDiff = left.node.score.risk - right.node.score.risk;
+      if (riskDiff !== 0) {
+        return riskDiff;
+      }
+      return left.node.nodeId.localeCompare(right.node.nodeId);
+    });
+
+    const beamWidth = options.beamWidth ?? sortedOptions.length;
+    const limited = sortedOptions.slice(0, beamWidth);
+
+    limited.forEach((choice) => {
+      explore(index + 1, [...selected, choice]);
+    });
+  };
+
+  explore(0, []);
+
+  const sortedBranches = stableSort(branches, (left, right) => {
+    const totalDiff = right.score.total - left.score.total;
+    if (totalDiff !== 0) {
+      return totalDiff;
+    }
+    const riskDiff = left.score.risk - right.score.risk;
+    if (riskDiff !== 0) {
+      return riskDiff;
+    }
+    return left.nodeId.localeCompare(right.nodeId);
+  });
+
+  const maxBranches = options.maxBranches ?? sortedBranches.length;
+  const chosen = sortedBranches.slice(0, maxBranches);
+
+  // Shuffle deterministically to avoid bias when totals tie.
+  const decorated = chosen.map((branch) => ({ branch, key: rng.next() }));
+  decorated.sort((a, b) => {
+    if (a.branch.score.total !== b.branch.score.total) {
+      return b.branch.score.total - a.branch.score.total;
+    }
+    if (a.branch.score.risk !== b.branch.score.risk) {
+      return a.branch.score.risk - b.branch.score.risk;
+    }
+    return a.key - b.key;
+  });
+
+  return decorated.map((entry) => entry.branch);
+}
+
+export interface EnumeratePlanResult {
+  readonly plan: PlanGraph;
+  readonly branchCount: number;
+}
+
+export async function readSpec(specPath: string): Promise<TfSpec> {
+  const absolute = resolvePath(specPath);
+  const raw = await readFile(absolute, 'utf8');
+  const parsed = JSON.parse(raw) as TfSpec;
+  assertValidSpec(parsed);
+  return parsed;
+}
+
+export function enumeratePlan(spec: TfSpec, options: EnumerateOptions = {}): PlanGraph {
+  assertValidSpec(spec);
+  const seed = options.seed ?? 42;
+  const specHash = hashObject(spec);
+  const specId = `${spec.name}:${specHash.slice(0, 8)}`;
+  const componentPlans = enumerateComponentPlans(spec, options, specId, seed, PLAN_GRAPH_VERSION);
+  if (componentPlans.length === 0) {
+    throw new Error('No component plans generated. Adjust constraints to allow at least one choice per component.');
+  }
+
+  const componentsById = groupByComponent(componentPlans);
+  const branchNodes = enumerateBranches(componentsById, specId, seed, PLAN_GRAPH_VERSION, options);
+  if (branchNodes.length === 0) {
+    throw new Error('Enumeration finished without branch nodes. Relax beam or maxBranches constraints.');
+  }
+
+  const branchIds = new Set(branchNodes.map((branch) => branch.nodeId));
+  const nodes: PlanNode[] = [...componentPlans.map((plan) => plan.node), ...branchNodes];
+  const sortedNodes = stableSort(nodes, (left, right) => {
+    const totalDiff = right.score.total - left.score.total;
+    if (totalDiff !== 0) {
+      return totalDiff;
+    }
+    const riskDiff = left.score.risk - right.score.risk;
+    if (riskDiff !== 0) {
+      return riskDiff;
+    }
+    return left.nodeId.localeCompare(right.nodeId);
+  });
+
+  const edges: PlanEdge[] = branchNodes.flatMap((branch) =>
+    branch.deps.map((dependency) => ({ from: branch.nodeId, to: dependency, kind: 'depends' as const })),
+  );
+
+  const planGraph: PlanGraph = {
+    version: PLAN_GRAPH_VERSION,
+    nodes: sortedNodes,
+    edges,
+    meta: {
+      seed,
+      specHash,
+      version: PLAN_GRAPH_VERSION,
+    },
+  };
+
+  return deepFreeze(planGraph);
+}

--- a/packages/tf-plan-enum/tests/index.test.ts
+++ b/packages/tf-plan-enum/tests/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { enumeratePlan } from '../src/index.js';
+import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };
+
+describe('enumeratePlan', () => {
+  it('produces deterministic branch nodes for the same seed', () => {
+    const first = enumeratePlan(demoSpec, { seed: 42, beamWidth: 3, maxBranches: 5 });
+    const second = enumeratePlan(demoSpec, { seed: 42, beamWidth: 3, maxBranches: 5 });
+    expect(first.meta.specHash).toEqual(second.meta.specHash);
+    expect(first.nodes.map((node) => node.nodeId)).toEqual(second.nodes.map((node) => node.nodeId));
+  });
+
+  it('creates at least three branch nodes with rationales', () => {
+    const plan = enumeratePlan(demoSpec, { seed: 42, beamWidth: 3 });
+    const branchNodes = plan.nodes.filter((node) => node.component.startsWith('branch:'));
+    expect(branchNodes.length).toBeGreaterThanOrEqual(3);
+    branchNodes.forEach((node) => {
+      expect(node.rationale.length).toBeGreaterThan(0);
+      expect(node.score.explain.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/tf-plan-enum/tsconfig.json
+++ b/packages/tf-plan-enum/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "./",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "paths": {
+      "@tf-lang/tf-plan-core": ["../tf-plan-core/dist/index.d.ts"],
+      "@tf-lang/tf-plan-scoring": ["../tf-plan-scoring/dist/index.d.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-scaffold-core/package.json
+++ b/packages/tf-plan-scaffold-core/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tf-lang/tf-plan-scaffold-core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-scaffold-core/src/index.ts
+++ b/packages/tf-plan-scaffold-core/src/index.ts
@@ -1,0 +1,162 @@
+import { PlanNode, stableSort } from '@tf-lang/tf-plan-core';
+
+export const SCAFFOLD_VERSION = '0.1.0';
+
+export type TemplateKind = 'ts' | 'rs' | 'dual-stack';
+
+export interface PlanSummaryMeta {
+  readonly seed: number;
+  readonly specHash: string;
+  readonly version: string;
+}
+
+export interface RepoAction {
+  readonly type: 'checkout' | 'createBranch' | 'applyTemplate' | 'updateScripts';
+  readonly params: Record<string, unknown>;
+}
+
+export interface CiAction {
+  readonly type: 'workflow';
+  readonly path: string;
+  readonly uses: string;
+  readonly with: Record<string, unknown>;
+}
+
+export interface ScaffoldBranch {
+  readonly nodeId: string;
+  readonly branchName: string;
+  readonly workingDir: string;
+  readonly template: TemplateKind;
+  readonly planChoice: string;
+  readonly summary: string;
+  readonly repoActions: readonly RepoAction[];
+  readonly ciActions: readonly CiAction[];
+}
+
+export interface ScaffoldPlan {
+  readonly version: string;
+  readonly template: TemplateKind;
+  readonly generatedAt: string;
+  readonly meta: PlanSummaryMeta;
+  readonly branches: readonly ScaffoldBranch[];
+  readonly lookup: Readonly<Record<string, { branchName: string; workingDir: string }>>;
+}
+
+export interface ScaffoldOptions {
+  readonly template: TemplateKind;
+  readonly top: number;
+  readonly baseBranch?: string;
+  readonly workingDirPrefix?: string;
+}
+
+function pickBranchNodes(nodes: readonly PlanNode[]): PlanNode[] {
+  return nodes.filter((node) => node.component.startsWith('branch:'));
+}
+
+function defaultWorkingDir(node: PlanNode, prefix = 'branches'): string {
+  return `${prefix}/${node.nodeId.slice(0, 12)}`;
+}
+
+function defaultBranchName(node: PlanNode, template: TemplateKind): string {
+  const suffix = node.nodeId.slice(0, 12);
+  return `t4/${template}/${suffix}`;
+}
+
+function createRepoActions(branchName: string, template: TemplateKind, baseBranch: string): RepoAction[] {
+  return [
+    {
+      type: 'checkout',
+      params: { base: baseBranch },
+    },
+    {
+      type: 'createBranch',
+      params: { name: branchName },
+    },
+    {
+      type: 'applyTemplate',
+      params: { template },
+    },
+    {
+      type: 'updateScripts',
+      params: {
+        scripts: {
+          't4:oracle': 'pnpm tf-check run --mode=ci',
+          't4:report': 'pnpm tf-plan compare --plan out/t4/plan/plan.ndjson --inputs out/t4/scaffold/index.json --out out/t4/compare',
+        },
+      },
+    },
+  ];
+}
+
+function createCiActions(branchName: string): CiAction[] {
+  const workflowName = `.github/workflows/${branchName.replace(/\//g, '-')}.yml`;
+  return [
+    {
+      type: 'workflow',
+      path: workflowName,
+      uses: '.github/workflows/reusable-tf-check.yml',
+      with: {
+        branch: branchName,
+        upload: true,
+      },
+    },
+  ];
+}
+
+export function createScaffoldPlan(
+  nodes: readonly PlanNode[],
+  meta: PlanSummaryMeta,
+  options: ScaffoldOptions,
+): ScaffoldPlan {
+  if (options.top <= 0) {
+    throw new Error('Scaffold requires at least one branch to select.');
+  }
+  const branchNodes = pickBranchNodes(nodes);
+  if (branchNodes.length === 0) {
+    throw new Error('No branch nodes available for scaffolding.');
+  }
+
+  const sorted = stableSort(branchNodes, (left, right) => {
+    const totalDiff = right.score.total - left.score.total;
+    if (totalDiff !== 0) {
+      return totalDiff;
+    }
+    const riskDiff = left.score.risk - right.score.risk;
+    if (riskDiff !== 0) {
+      return riskDiff;
+    }
+    return left.nodeId.localeCompare(right.nodeId);
+  });
+
+  const chosen = sorted.slice(0, options.top);
+  const baseBranch = options.baseBranch ?? 'main';
+  const generatedAt = '1970-01-01T00:00:00.000Z';
+  const branches: ScaffoldBranch[] = chosen.map((node) => {
+    const branchName = defaultBranchName(node, options.template);
+    const workingDir = defaultWorkingDir(node, options.workingDirPrefix ?? 'branches');
+    const repoActions = createRepoActions(branchName, options.template, baseBranch);
+    const ciActions = createCiActions(branchName);
+    const summary = `${branchName} tracks ${node.choice} (total ${node.score.total.toFixed(2)})`;
+    return {
+      nodeId: node.nodeId,
+      branchName,
+      workingDir,
+      template: options.template,
+      planChoice: node.choice,
+      summary,
+      repoActions,
+      ciActions,
+    };
+  });
+
+  const lookup = Object.fromEntries(branches.map((branch) => [branch.nodeId, { branchName: branch.branchName, workingDir: branch.workingDir }]));
+
+  return {
+    version: SCAFFOLD_VERSION,
+    template: options.template,
+    generatedAt,
+    meta,
+    branches,
+    lookup,
+  };
+}

--- a/packages/tf-plan-scaffold-core/tests/index.test.ts
+++ b/packages/tf-plan-scaffold-core/tests/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { PlanNode } from '@tf-lang/tf-plan-core';
+import { createScaffoldPlan } from '../src/index.js';
+
+const baseMeta = { seed: 42, specHash: 'hash', version: '0.1.0' } as const;
+
+function makeNode(total: number, risk: number, id: string): PlanNode {
+  return {
+    nodeId: id,
+    specId: 'spec',
+    component: 'branch:spec',
+    choice: `choice-${id}`,
+    deps: [],
+    rationale: 'demo',
+    score: {
+      total,
+      complexity: 5,
+      risk,
+      perf: 6,
+      devTime: 4,
+      depsReady: 7,
+      explain: ['demo'],
+    },
+  };
+}
+
+describe('createScaffoldPlan', () => {
+  it('selects top branches and produces deterministic mapping', () => {
+    const nodes: PlanNode[] = [makeNode(8, 3, 'a'.repeat(64)), makeNode(9, 2, 'b'.repeat(64)), makeNode(9, 4, 'c'.repeat(64))];
+    const plan = createScaffoldPlan(nodes, baseMeta, { template: 'dual-stack', top: 2 });
+    expect(plan.branches).toHaveLength(2);
+    expect(plan.branches[0].branchName).toContain('dual-stack');
+    expect(plan.lookup[plan.branches[0].nodeId].workingDir).toBe(plan.branches[0].workingDir);
+  });
+});

--- a/packages/tf-plan-scaffold-core/tsconfig.json
+++ b/packages/tf-plan-scaffold-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-scaffold/package.json
+++ b/packages/tf-plan-scaffold/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tf-lang/tf-plan-scaffold",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "tf-plan-scaffold": "dist/cli.js"
+  },
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "0.1.0",
+    "@tf-lang/tf-plan-scaffold-core": "0.1.0",
+    "ajv": "^8.12.0",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-scaffold/src/cli.ts
+++ b/packages/tf-plan-scaffold/src/cli.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { resolve } from 'node:path';
+import { applyScaffold, generateScaffold, parseNumber, parseTemplate } from './index.js';
+
+const program = new Command();
+program
+  .name('tf-plan-scaffold')
+  .description('tf-plan scaffolding utilities');
+
+program
+  .command('scaffold')
+  .option('--plan <path>', 'Path to plan.ndjson', 'out/t4/plan/plan.ndjson')
+  .option('--graph <path>', 'Optional plan.json metadata path')
+  .option('--top <number>', 'Number of branches to scaffold', '3')
+  .option('--template <kind>', 'Template kind (ts|rs|dual-stack)', 'dual-stack')
+  .option('--out <path>', 'Output index JSON path', 'out/t4/scaffold/index.json')
+  .option('--base <branch>', 'Base branch name', 'main')
+  .option('--apply <path>', 'Apply an existing scaffold index instead of generating')
+  .action(async (options) => {
+    try {
+      if (options.apply) {
+        await applyScaffold({ indexPath: resolve(options.apply) });
+        return;
+      }
+      await generateScaffold({
+        planNdjsonPath: resolve(options.plan),
+        planJsonPath: options.graph ? resolve(options.graph) : undefined,
+        top: parseNumber(options.top, 3),
+        template: parseTemplate(options.template, 'dual-stack'),
+        outPath: resolve(options.out),
+        baseBranch: options.base,
+      });
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('pr')
+  .option('--apply <path>', 'Path to scaffold index JSON')
+  .option('--open-draft', 'Open a draft PR via gh cli')
+  .action(() => {
+    console.log('Draft PR automation is not implemented. Use the scaffold index to prepare branches manually.');
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error((error as Error).message);
+  process.exitCode = 1;
+});

--- a/packages/tf-plan-scaffold/src/index.ts
+++ b/packages/tf-plan-scaffold/src/index.ts
@@ -1,0 +1,132 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
+import {
+  PlanGraph,
+  PlanNode,
+  PLAN_GRAPH_VERSION,
+} from '@tf-lang/tf-plan-core';
+import {
+  PlanSummaryMeta,
+  ScaffoldPlan,
+  TemplateKind,
+  createScaffoldPlan,
+} from '@tf-lang/tf-plan-scaffold-core';
+
+const require = createRequire(import.meta.url);
+const planSchema = loadSchema('tf-plan.schema.json');
+const branchSchema = loadSchema('tf-branch.schema.json');
+const ajv = new Ajv({ allErrors: true, strict: false });
+ajv.addSchema(branchSchema, 'tf-branch.schema.json');
+const validateNode = ajv.compile<PlanNode>(branchSchema);
+const validatePlanGraph = ajv.compile<PlanGraph>(planSchema);
+
+function loadSchema(name: string): Record<string, unknown> {
+  const candidates = [
+    `../../../schema/${name}`,
+    `../../../../schema/${name}`,
+  ];
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`Unable to load schema ${name}`);
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(filePath, { recursive: true });
+}
+
+function parseTemplate(input: string | undefined, fallback: TemplateKind): TemplateKind {
+  if (!input) {
+    return fallback;
+  }
+  if (input === 'ts' || input === 'rs' || input === 'dual-stack') {
+    return input;
+  }
+  throw new Error(`Unsupported template '${input}'.`);
+}
+
+function parseNumber(input: unknown, fallback: number): number {
+  const value = typeof input === 'string' ? Number.parseInt(input, 10) : typeof input === 'number' ? input : fallback;
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+async function readNodesFromNdjson(planPath: string): Promise<PlanNode[]> {
+  const raw = await readFile(resolve(planPath), 'utf8');
+  const lines = raw.trim().length === 0 ? [] : raw.trim().split('\n');
+  const nodes: PlanNode[] = lines.map((line) => JSON.parse(line) as PlanNode);
+  nodes.forEach((node) => {
+    if (!validateNode(node)) {
+      const message =
+        validateNode.errors?.map((error: ErrorObject) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+      throw new Error(`Invalid plan node in NDJSON: ${message}`);
+    }
+  });
+  return nodes;
+}
+
+async function readPlanMeta(planJsonPath: string | undefined, nodes: readonly PlanNode[]): Promise<PlanSummaryMeta> {
+  if (planJsonPath) {
+    const raw = await readFile(resolve(planJsonPath), 'utf8');
+    const parsed = JSON.parse(raw) as PlanGraph;
+    if (!validatePlanGraph(parsed)) {
+      const message =
+        validatePlanGraph.errors?.map((error: ErrorObject) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+      throw new Error(`Plan graph validation failed: ${message}`);
+    }
+    return parsed.meta;
+  }
+
+  const fallbackSeed = 42;
+  const specHash = nodes.length > 0 ? nodes[0].specId.split(':')[1] ?? 'unknown' : 'unknown';
+  return { seed: fallbackSeed, specHash, version: PLAN_GRAPH_VERSION };
+}
+
+async function writeJsonFile(outPath: string, value: unknown): Promise<void> {
+  await ensureDir(dirname(outPath));
+  await writeFile(outPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export interface GenerateScaffoldArgs {
+  readonly planNdjsonPath: string;
+  readonly planJsonPath?: string;
+  readonly top: number;
+  readonly template: TemplateKind;
+  readonly outPath: string;
+  readonly baseBranch?: string;
+}
+
+export interface ApplyScaffoldArgs {
+  readonly indexPath: string;
+}
+
+export async function generateScaffold(args: GenerateScaffoldArgs): Promise<ScaffoldPlan> {
+  const nodes = await readNodesFromNdjson(args.planNdjsonPath);
+  const meta = await readPlanMeta(args.planJsonPath, nodes);
+  const plan = createScaffoldPlan(nodes, meta, {
+    template: args.template,
+    top: args.top,
+    baseBranch: args.baseBranch,
+  });
+  await writeJsonFile(args.outPath, plan);
+  console.log(`Scaffold dry-run written to ${args.outPath} with ${plan.branches.length} branches.`);
+  return plan;
+}
+
+export async function applyScaffold(args: ApplyScaffoldArgs): Promise<ScaffoldPlan> {
+  const raw = await readFile(resolve(args.indexPath), 'utf8');
+  const parsed = JSON.parse(raw) as ScaffoldPlan;
+  console.log(`Apply mode is currently a no-op. Review ${args.indexPath} and execute actions manually.`);
+  return parsed;
+}
+
+export { parseTemplate, parseNumber };

--- a/packages/tf-plan-scaffold/tests/index.test.ts
+++ b/packages/tf-plan-scaffold/tests/index.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };
+import { enumeratePlan } from '@tf-lang/tf-plan-enum';
+import { generateScaffold } from '../src/index.js';
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'tf-scaffold-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('generateScaffold', () => {
+  it('produces a scaffold plan from ndjson nodes', async () => {
+    const plan = enumeratePlan(demoSpec, { seed: 42, beamWidth: 2, maxBranches: 3 });
+    const dir = await createTempDir();
+    const planJsonPath = join(dir, 'plan.json');
+    const planNdjsonPath = join(dir, 'plan.ndjson');
+    await writeFile(planJsonPath, `${JSON.stringify(plan, null, 2)}\n`);
+    const ndjsonLines = plan.nodes.map((node) => JSON.stringify(node)).join('\n');
+    await writeFile(planNdjsonPath, `${ndjsonLines}\n`);
+
+    const outPath = join(dir, 'index.json');
+    const scaffold = await generateScaffold({
+      planNdjsonPath,
+      planJsonPath,
+      top: 2,
+      template: 'dual-stack',
+      outPath,
+    });
+    expect(scaffold.branches.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/tf-plan-scaffold/tsconfig.json
+++ b/packages/tf-plan-scaffold/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "paths": {
+      "@tf-lang/tf-plan-core": ["../tf-plan-core/dist/index.d.ts"],
+      "@tf-lang/tf-plan-scaffold-core": ["../tf-plan-scaffold-core/dist/index.d.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan-scaffold/vitest.config.ts
+++ b/packages/tf-plan-scaffold/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    alias: {
+      '@tf-lang/tf-plan-core': resolve(__dirname, '../tf-plan-core/src/index.ts'),
+      '@tf-lang/tf-plan-scaffold-core': resolve(__dirname, '../tf-plan-scaffold-core/src/index.ts'),
+      '@tf-lang/tf-plan-enum': resolve(__dirname, '../tf-plan-enum/src/index.ts'),
+    },
+  },
+});

--- a/packages/tf-plan-scoring/package.json
+++ b/packages/tf-plan-scoring/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tf-lang/tf-plan-scoring",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan-scoring/src/index.d.ts
+++ b/packages/tf-plan-scoring/src/index.d.ts
@@ -1,0 +1,22 @@
+import { RepoSignals, Score } from '@tf-lang/tf-plan-core';
+type Dimension = 'complexity' | 'risk' | 'perf' | 'devTime' | 'depsReady';
+export interface DimensionScore {
+    readonly value: number;
+    readonly reason: string;
+}
+export interface ScoreContext {
+    readonly component: string;
+    readonly choice: string;
+    readonly seed: number;
+    readonly repoSignals?: RepoSignals;
+}
+export declare function complexity(component: string, choice: string): DimensionScore;
+export declare function risk(component: string, choice: string): DimensionScore;
+export declare function perf(component: string, choice: string): DimensionScore;
+export declare function devTime(component: string, choice: string): DimensionScore;
+export declare function depsReady(component: string, choice: string, repoSignals?: RepoSignals): DimensionScore;
+export interface ScorePlanNodeInput extends ScoreContext {
+    readonly overrides?: Partial<Record<Dimension, number>>;
+}
+export declare function scorePlanNode(input: ScorePlanNodeInput): Score;
+export {};

--- a/packages/tf-plan-scoring/src/index.js
+++ b/packages/tf-plan-scoring/src/index.js
@@ -1,0 +1,142 @@
+import { seedRng, } from '@tf-lang/tf-plan-core';
+function clampScore(value) {
+    if (Number.isNaN(value)) {
+        return 0;
+    }
+    return Math.min(10, Math.max(0, Number.parseFloat(value.toFixed(3))));
+}
+function keywordFactor(text, keywords, delta) {
+    const lower = text.toLowerCase();
+    for (const keyword of keywords) {
+        if (lower.includes(keyword)) {
+            return delta;
+        }
+    }
+    return 0;
+}
+function tokenize(text) {
+    return text
+        .split(/[^a-z0-9]+/i)
+        .map((part) => part.trim().toLowerCase())
+        .filter((part) => part.length > 0);
+}
+const dimensionWeights = {
+    perf: 0.35,
+    depsReady: 0.2,
+    complexity: 0.15,
+    devTime: 0.15,
+    risk: 0.15,
+};
+const defaultComplexityBase = 4.5;
+export function complexity(component, choice) {
+    const tokens = tokenize(`${component} ${choice}`);
+    const structural = Math.log2(tokens.length + 1);
+    const keywordAdjust = keywordFactor(choice, ['managed', 'serverless', 'hosted'], -1.2);
+    const value = clampScore(defaultComplexityBase + structural + keywordAdjust);
+    return {
+        value,
+        reason: `Complexity derives from ${tokens.length} concept tokens with managed adjustment ${keywordAdjust.toFixed(1)} → ${value.toFixed(2)}`,
+    };
+}
+export function risk(component, choice) {
+    const base = 3.5;
+    let result = base;
+    result += keywordFactor(choice, ['beta', 'experimental', 'preview'], 3.2);
+    result += keywordFactor(choice, ['legacy', 'replace', 'migration'], 2.1);
+    result += keywordFactor(choice, ['managed', 'hosted', 'proven'], -1.3);
+    result += keywordFactor(component, ['network'], 0.4);
+    const value = clampScore(result);
+    return {
+        value,
+        reason: `Risk adjusted by component '${component}' and keywords in '${choice}' → ${value.toFixed(2)}`,
+    };
+}
+export function perf(component, choice) {
+    const base = 6;
+    let result = base;
+    result += keywordFactor(choice, ['cache', 'accelerated', 'optimized'], 1.8);
+    result += keywordFactor(choice, ['spot', 'cost'], -1.5);
+    result += keywordFactor(component, ['compute'], 0.6);
+    result += keywordFactor(component, ['transfer'], -0.3);
+    const value = clampScore(result);
+    return {
+        value,
+        reason: `Performance baseline ${base} tuned by component '${component}' → ${value.toFixed(2)}`,
+    };
+}
+export function devTime(component, choice) {
+    const complexityScore = complexity(component, choice).value;
+    const automationBonus = keywordFactor(choice, ['automated', 'managed', 'template'], -1.0);
+    const value = clampScore(5 + complexityScore / 2 + automationBonus);
+    return {
+        value,
+        reason: `Dev time proportional to complexity ${complexityScore.toFixed(2)} with automation bonus ${automationBonus.toFixed(1)} → ${value.toFixed(2)}`,
+    };
+}
+export function depsReady(component, choice, repoSignals = {}) {
+    const readiness = (() => {
+        const key = `${component}:${choice}`.toLowerCase();
+        if (repoSignals[key] === 'ready') {
+            return 9.5;
+        }
+        if (repoSignals[key] === 'blocked') {
+            return 2.5;
+        }
+        const tokens = tokenize(choice);
+        if (tokens.includes('existing') || tokens.includes('reuse')) {
+            return 8.5;
+        }
+        if (tokens.includes('new') || tokens.includes('prototype')) {
+            return 4.5;
+        }
+        return 6.5;
+    })();
+    const value = clampScore(readiness);
+    return {
+        value,
+        reason: `Dependency readiness inferred from repo signals '${component}:${choice}' → ${value.toFixed(2)}`,
+    };
+}
+function combineScores(scores, overrides = {}) {
+    const explain = [];
+    let weightedTotal = 0;
+    Object.keys(scores).forEach((dimension) => {
+        const override = overrides[dimension];
+        const value = override !== undefined ? clampScore(override) : scores[dimension].value;
+        weightedTotal += value * dimensionWeights[dimension];
+        const detail = override !== undefined
+            ? `${dimension} overridden to ${value.toFixed(2)} (was ${scores[dimension].value.toFixed(2)})`
+            : scores[dimension].reason;
+        explain.push(detail);
+    });
+    const total = clampScore(weightedTotal);
+    explain.push(`Weighted total = ${total.toFixed(2)} using weights ${JSON.stringify(dimensionWeights)}`);
+    return {
+        total,
+        complexity: overrides.complexity ?? scores.complexity.value,
+        risk: overrides.risk ?? scores.risk.value,
+        perf: overrides.perf ?? scores.perf.value,
+        devTime: overrides.devTime ?? scores.devTime.value,
+        depsReady: overrides.depsReady ?? scores.depsReady.value,
+        explain,
+    };
+}
+export function scorePlanNode(input) {
+    const baseScores = {
+        complexity: complexity(input.component, input.choice),
+        risk: risk(input.component, input.choice),
+        perf: perf(input.component, input.choice),
+        devTime: devTime(input.component, input.choice),
+        depsReady: depsReady(input.component, input.choice, input.repoSignals),
+    };
+    const seeded = seedRng(`${input.component}|${input.choice}|${input.seed}`);
+    const jitter = (dimension, magnitude) => {
+        const offset = (seeded.next() - 0.5) * magnitude;
+        return clampScore(baseScores[dimension].value + offset);
+    };
+    const overrides = {
+        perf: jitter('perf', 0.6),
+        risk: jitter('risk', 0.4),
+    };
+    return combineScores(baseScores, overrides);
+}

--- a/packages/tf-plan-scoring/src/index.ts
+++ b/packages/tf-plan-scoring/src/index.ts
@@ -1,0 +1,182 @@
+import {
+  RepoSignals,
+  Score,
+  seedRng,
+} from '@tf-lang/tf-plan-core';
+
+type Dimension = 'complexity' | 'risk' | 'perf' | 'devTime' | 'depsReady';
+
+export interface DimensionScore {
+  readonly value: number;
+  readonly reason: string;
+}
+
+export interface ScoreContext {
+  readonly component: string;
+  readonly choice: string;
+  readonly seed: number;
+  readonly repoSignals?: RepoSignals;
+}
+
+function clampScore(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(10, Math.max(0, Number.parseFloat(value.toFixed(3))));
+}
+
+function keywordFactor(text: string, keywords: readonly string[], delta: number): number {
+  const lower = text.toLowerCase();
+  for (const keyword of keywords) {
+    if (lower.includes(keyword)) {
+      return delta;
+    }
+  }
+  return 0;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .split(/[^a-z0-9]+/i)
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+}
+
+const dimensionWeights: Record<Dimension, number> = {
+  perf: 0.35,
+  depsReady: 0.2,
+  complexity: 0.15,
+  devTime: 0.15,
+  risk: 0.15,
+};
+
+const defaultComplexityBase = 4.5;
+
+export function complexity(component: string, choice: string): DimensionScore {
+  const tokens = tokenize(`${component} ${choice}`);
+  const structural = Math.log2(tokens.length + 1);
+  const keywordAdjust = keywordFactor(choice, ['managed', 'serverless', 'hosted'], -1.2);
+  const value = clampScore(defaultComplexityBase + structural + keywordAdjust);
+  return {
+    value,
+    reason: `Complexity derives from ${tokens.length} concept tokens with managed adjustment ${keywordAdjust.toFixed(1)} → ${value.toFixed(2)}`,
+  };
+}
+
+export function risk(component: string, choice: string): DimensionScore {
+  const base = 3.5;
+  let result = base;
+  result += keywordFactor(choice, ['beta', 'experimental', 'preview'], 3.2);
+  result += keywordFactor(choice, ['legacy', 'replace', 'migration'], 2.1);
+  result += keywordFactor(choice, ['managed', 'hosted', 'proven'], -1.3);
+  result += keywordFactor(component, ['network'], 0.4);
+  const value = clampScore(result);
+  return {
+    value,
+    reason: `Risk adjusted by component '${component}' and keywords in '${choice}' → ${value.toFixed(2)}`,
+  };
+}
+
+export function perf(component: string, choice: string): DimensionScore {
+  const base = 6;
+  let result = base;
+  result += keywordFactor(choice, ['cache', 'accelerated', 'optimized'], 1.8);
+  result += keywordFactor(choice, ['spot', 'cost'], -1.5);
+  result += keywordFactor(component, ['compute'], 0.6);
+  result += keywordFactor(component, ['transfer'], -0.3);
+  const value = clampScore(result);
+  return {
+    value,
+    reason: `Performance baseline ${base} tuned by component '${component}' → ${value.toFixed(2)}`,
+  };
+}
+
+export function devTime(component: string, choice: string): DimensionScore {
+  const complexityScore = complexity(component, choice).value;
+  const automationBonus = keywordFactor(choice, ['automated', 'managed', 'template'], -1.0);
+  const value = clampScore(5 + complexityScore / 2 + automationBonus);
+  return {
+    value,
+    reason: `Dev time proportional to complexity ${complexityScore.toFixed(2)} with automation bonus ${automationBonus.toFixed(1)} → ${value.toFixed(2)}`,
+  };
+}
+
+export function depsReady(component: string, choice: string, repoSignals: RepoSignals = {}): DimensionScore {
+  const readiness = (() => {
+    const key = `${component}:${choice}`.toLowerCase();
+    if (repoSignals[key] === 'ready') {
+      return 9.5;
+    }
+    if (repoSignals[key] === 'blocked') {
+      return 2.5;
+    }
+    const tokens = tokenize(choice);
+    if (tokens.includes('existing') || tokens.includes('reuse')) {
+      return 8.5;
+    }
+    if (tokens.includes('new') || tokens.includes('prototype')) {
+      return 4.5;
+    }
+    return 6.5;
+  })();
+  const value = clampScore(readiness);
+  return {
+    value,
+    reason: `Dependency readiness inferred from repo signals '${component}:${choice}' → ${value.toFixed(2)}`,
+  };
+}
+
+export interface ScorePlanNodeInput extends ScoreContext {
+  readonly overrides?: Partial<Record<Dimension, number>>;
+}
+
+function combineScores(scores: Record<Dimension, DimensionScore>, overrides: Partial<Record<Dimension, number>> = {}): Score {
+  const explain: string[] = [];
+  let weightedTotal = 0;
+
+  (Object.keys(scores) as Dimension[]).forEach((dimension) => {
+    const override = overrides[dimension];
+    const value = override !== undefined ? clampScore(override) : scores[dimension].value;
+    weightedTotal += value * dimensionWeights[dimension];
+    const detail = override !== undefined
+      ? `${dimension} overridden to ${value.toFixed(2)} (was ${scores[dimension].value.toFixed(2)})`
+      : scores[dimension].reason;
+    explain.push(detail);
+  });
+
+  const total = clampScore(weightedTotal);
+  explain.push(`Weighted total = ${total.toFixed(2)} using weights ${JSON.stringify(dimensionWeights)}`);
+
+  return {
+    total,
+    complexity: overrides.complexity ?? scores.complexity.value,
+    risk: overrides.risk ?? scores.risk.value,
+    perf: overrides.perf ?? scores.perf.value,
+    devTime: overrides.devTime ?? scores.devTime.value,
+    depsReady: overrides.depsReady ?? scores.depsReady.value,
+    explain,
+  };
+}
+
+export function scorePlanNode(input: ScorePlanNodeInput): Score {
+  const baseScores: Record<Dimension, DimensionScore> = {
+    complexity: complexity(input.component, input.choice),
+    risk: risk(input.component, input.choice),
+    perf: perf(input.component, input.choice),
+    devTime: devTime(input.component, input.choice),
+    depsReady: depsReady(input.component, input.choice, input.repoSignals),
+  };
+
+  const seeded = seedRng(`${input.component}|${input.choice}|${input.seed}`);
+  const jitter = (dimension: Dimension, magnitude: number): number => {
+    const offset = (seeded.next() - 0.5) * magnitude;
+    return clampScore(baseScores[dimension].value + offset);
+  };
+
+  const overrides: Partial<Record<Dimension, number>> = {
+    perf: jitter('perf', 0.6),
+    risk: jitter('risk', 0.4),
+  };
+
+  return combineScores(baseScores, overrides);
+}

--- a/packages/tf-plan-scoring/tests/index.test.ts
+++ b/packages/tf-plan-scoring/tests/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { scorePlanNode } from '../src/index.js';
+
+describe('scorePlanNode', () => {
+  it('produces deterministic totals for the same input', () => {
+    const first = scorePlanNode({ component: 'transfer', choice: 'managed rsync pipeline', seed: 42 });
+    const second = scorePlanNode({ component: 'transfer', choice: 'managed rsync pipeline', seed: 42 });
+    expect(first.total).toEqual(second.total);
+    expect(first.explain.length).toBeGreaterThan(0);
+  });
+
+  it('yields different totals when the choice changes', () => {
+    const first = scorePlanNode({ component: 'transfer', choice: 'managed rsync pipeline', seed: 42 });
+    const second = scorePlanNode({ component: 'transfer', choice: 'prototype delta sync', seed: 42 });
+    expect(first.total).not.toEqual(second.total);
+  });
+});

--- a/packages/tf-plan-scoring/tsconfig.json
+++ b/packages/tf-plan-scoring/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan/package.json
+++ b/packages/tf-plan/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tf-lang/tf-plan",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "tf-plan": "dist/cli.js"
+  },
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tf-lang/tf-plan-core": "0.1.0",
+    "@tf-lang/tf-plan-enum": "0.1.0",
+    "ajv": "^8.12.0",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/tf-plan/src/cli.ts
+++ b/packages/tf-plan/src/cli.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { resolve } from 'node:path';
+import {
+  parseNumberOption,
+  runEnumerateCommand,
+  runExportCommand,
+  runScoreCommand,
+} from './index.js';
+
+const program = new Command();
+program
+  .name('tf-plan')
+  .description('tf-plan branch enumeration and scoring toolkit');
+
+program
+  .command('enumerate')
+  .requiredOption('--spec <path>', 'Path to the tf-spec JSON file')
+  .option('--seed <number>', 'Random seed for deterministic enumeration', '42')
+  .option('--beam <number>', 'Beam width per component')
+  .option('--max <number>', 'Maximum branch nodes to keep')
+  .option('--out <dir>', 'Output directory for plan artifacts', 'out/t4/plan')
+  .action(async (options) => {
+    try {
+      const plan = await runEnumerateCommand({
+        specPath: resolve(options.spec),
+        seed: parseNumberOption(options.seed, 42),
+        beamWidth: options.beam ? parseNumberOption(options.beam, 0) : undefined,
+        maxBranches: options.max ? parseNumberOption(options.max, 0) : undefined,
+        outDir: resolve(options.out),
+      });
+      if (!plan) {
+        process.exitCode = 1;
+      }
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('score')
+  .requiredOption('--plan <path>', 'Path to plan.json')
+  .option('--seed <number>', 'Override seed when re-scoring')
+  .option('--out <path>', 'Output path for scored plan', 'out/t4/plan/plan.scored.json')
+  .action(async (options) => {
+    try {
+      await runScoreCommand({
+        planPath: resolve(options.plan),
+        seed: options.seed ? parseNumberOption(options.seed, 42) : undefined,
+        outPath: resolve(options.out),
+      });
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('export')
+  .requiredOption('--plan <path>', 'Path to plan.json')
+  .option('--ndjson <path>', 'Output NDJSON path', 'out/t4/plan/plan.ndjson')
+  .action(async (options) => {
+    try {
+      await runExportCommand({
+        planPath: resolve(options.plan),
+        ndjsonPath: resolve(options.ndjson),
+      });
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error((error as Error).message);
+  process.exitCode = 1;
+});

--- a/packages/tf-plan/src/index.ts
+++ b/packages/tf-plan/src/index.ts
@@ -1,0 +1,238 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
+import {
+  PlanGraph,
+  PlanNode,
+  Score,
+  PLAN_GRAPH_VERSION,
+  deepFreeze,
+  stableSort,
+} from '@tf-lang/tf-plan-core';
+import { enumeratePlan, readSpec } from '@tf-lang/tf-plan-enum';
+import { scorePlanNode } from '@tf-lang/tf-plan-scoring';
+
+const require = createRequire(import.meta.url);
+const planSchema = loadSchema('tf-plan.schema.json');
+const branchSchema = loadSchema('tf-branch.schema.json');
+const ajv = new Ajv({ allErrors: true, strict: false });
+ajv.addSchema(branchSchema, 'tf-branch.schema.json');
+const validatePlanGraph = ajv.compile<PlanGraph>(planSchema);
+const validatePlanNode = ajv.compile<PlanNode>(branchSchema);
+
+function loadSchema(name: string): Record<string, unknown> {
+  const candidates = [
+    `../../../schema/${name}`,
+    `../../../../schema/${name}`,
+  ];
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`Unable to load schema ${name}`);
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  const parsed = typeof value === 'string' ? Number.parseFloat(value) : typeof value === 'number' ? value : fallback;
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return parsed;
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(filePath, { recursive: true });
+}
+
+export interface EnumerateCommandArgs {
+  readonly specPath: string;
+  readonly seed: number;
+  readonly beamWidth?: number;
+  readonly maxBranches?: number;
+  readonly outDir: string;
+}
+
+export interface ScoreCommandArgs {
+  readonly planPath: string;
+  readonly outPath: string;
+  readonly seed?: number;
+}
+
+export interface ExportCommandArgs {
+  readonly planPath: string;
+  readonly ndjsonPath: string;
+}
+
+export function validatePlan(plan: PlanGraph): void {
+  if (!validatePlanGraph(plan)) {
+    const message =
+      validatePlanGraph.errors?.map((error: ErrorObject) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+    throw new Error(`Plan graph failed validation: ${message}`);
+  }
+  plan.nodes.forEach((node) => {
+    if (!validatePlanNode(node)) {
+      const message =
+        validatePlanNode.errors?.map((error: ErrorObject) => `${error.instancePath} ${error.message}`).join(', ') ?? 'unknown error';
+      const nodeId = (node as { nodeId?: string }).nodeId ?? '<unknown>';
+      throw new Error(`Plan node ${nodeId} failed validation: ${message}`);
+    }
+  });
+}
+
+function round(value: number, precision = 3): number {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function aggregateScores(nodes: readonly PlanNode[]): Score {
+  if (nodes.length === 0) {
+    return {
+      total: 0,
+      complexity: 0,
+      risk: 0,
+      perf: 0,
+      devTime: 0,
+      depsReady: 0,
+      explain: ['No dependency scores provided.'],
+    };
+  }
+  const totals = nodes.reduce(
+    (acc, node) => {
+      acc.total += node.score.total;
+      acc.complexity += node.score.complexity;
+      acc.risk += node.score.risk;
+      acc.perf += node.score.perf;
+      acc.devTime += node.score.devTime;
+      acc.depsReady += node.score.depsReady;
+      acc.explain.push(`${node.component} via ${node.choice} scored ${node.score.total.toFixed(2)}`);
+      return acc;
+    },
+    {
+      total: 0,
+      complexity: 0,
+      risk: 0,
+      perf: 0,
+      devTime: 0,
+      depsReady: 0,
+      explain: [] as string[],
+    },
+  );
+  const count = nodes.length;
+  totals.explain.push(`Aggregate of ${count} nodes.`);
+  return {
+    total: round(totals.total / count),
+    complexity: round(totals.complexity / count),
+    risk: round(totals.risk / count),
+    perf: round(totals.perf / count),
+    devTime: round(totals.devTime / count),
+    depsReady: round(totals.depsReady / count),
+    explain: totals.explain,
+  };
+}
+
+function rescorePlan(plan: PlanGraph, seedOverride?: number): PlanGraph {
+  const seed = seedOverride ?? plan.meta.seed;
+  const nodeMap = new Map(plan.nodes.map((node) => [node.nodeId, node] as const));
+  const rescoredNodes = plan.nodes.map((node) => {
+    if (node.deps.length === 0) {
+      const score = scorePlanNode({ component: node.component, choice: node.choice, seed });
+      return { ...node, score } satisfies PlanNode;
+    }
+    const dependencies = node.deps.map((dep) => nodeMap.get(dep)).filter((dep): dep is PlanNode => dep !== undefined);
+    const score = aggregateScores(dependencies);
+    return { ...node, score } satisfies PlanNode;
+  });
+
+  const sorted = stableSort(rescoredNodes, (left, right) => {
+    const totalDiff = right.score.total - left.score.total;
+    if (totalDiff !== 0) {
+      return totalDiff;
+    }
+    const riskDiff = left.score.risk - right.score.risk;
+    if (riskDiff !== 0) {
+      return riskDiff;
+    }
+    return left.nodeId.localeCompare(right.nodeId);
+  });
+
+  const updated: PlanGraph = {
+    ...plan,
+    nodes: sorted,
+    meta: {
+      ...plan.meta,
+      seed,
+    },
+  };
+
+  return deepFreeze(updated);
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await ensureDir(dirname(filePath));
+  const content = `${JSON.stringify(value, null, 2)}\n`;
+  await writeFile(filePath, content, 'utf8');
+}
+
+async function writeNdjson(filePath: string, nodes: readonly PlanNode[]): Promise<void> {
+  await ensureDir(dirname(filePath));
+  const lines = nodes.map((node) => JSON.stringify(node));
+  const content = `${lines.join('\n')}\n`;
+  await writeFile(filePath, content, 'utf8');
+}
+
+async function readPlan(planPath: string): Promise<PlanGraph> {
+  const absolute = resolve(planPath);
+  const raw = await readFile(absolute, 'utf8');
+  const parsed = JSON.parse(raw) as PlanGraph;
+  validatePlan(parsed);
+  return parsed;
+}
+
+export async function runEnumerateCommand(args: EnumerateCommandArgs): Promise<PlanGraph> {
+  const spec = await readSpec(args.specPath);
+  const plan = enumeratePlan(spec, {
+    seed: args.seed,
+    beamWidth: args.beamWidth,
+    maxBranches: args.maxBranches,
+  });
+  validatePlan(plan);
+
+  const planPath = join(args.outDir, 'plan.json');
+  const ndjsonPath = join(args.outDir, 'plan.ndjson');
+  await writeJsonFile(planPath, plan);
+  await writeNdjson(ndjsonPath, plan.nodes);
+
+  const branchNodes = plan.nodes.filter((node) => node.component.startsWith('branch:'));
+  const summary = branchNodes
+    .slice(0, 5)
+    .map((node, index) => `${index + 1}. ${node.choice} → total ${node.score.total.toFixed(2)}`)
+    .join('\n');
+  console.log(`Enumerated ${branchNodes.length} branches (seed=${plan.meta.seed}). Top branches:\n${summary}`);
+
+  return plan;
+}
+
+export async function runScoreCommand(args: ScoreCommandArgs): Promise<PlanGraph> {
+  const plan = await readPlan(args.planPath);
+  const rescored = rescorePlan(plan, args.seed);
+  await writeJsonFile(args.outPath, rescored);
+  console.log(`Re-scored plan graph written to ${args.outPath}`);
+  return rescored;
+}
+
+export async function runExportCommand(args: ExportCommandArgs): Promise<void> {
+  const plan = await readPlan(args.planPath);
+  await writeNdjson(args.ndjsonPath, plan.nodes);
+  console.log(`Exported ${plan.nodes.length} nodes to ${args.ndjsonPath}`);
+}
+
+export function parseNumberOption(value: unknown, fallback: number): number {
+  return asNumber(value, fallback);
+}
+
+export { PLAN_GRAPH_VERSION } from '@tf-lang/tf-plan-core';

--- a/packages/tf-plan/tests/index.test.ts
+++ b/packages/tf-plan/tests/index.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+  runEnumerateCommand,
+  runExportCommand,
+  runScoreCommand,
+} from '../src/index.js';
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'tf-plan-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('tf-plan CLI helpers', () => {
+  it('enumerates, scores, and exports deterministically', async () => {
+    const outputDir = await createTempDir();
+    const specPath = resolve(process.cwd(), '../../tests/specs/demo.json');
+    const plan = await runEnumerateCommand({
+      specPath,
+      seed: 42,
+      outDir: outputDir,
+    });
+    const planPath = join(outputDir, 'plan.json');
+    const ndjsonPath = join(outputDir, 'plan.ndjson');
+    const planFile = JSON.parse(await readFile(planPath, 'utf8'));
+    expect(planFile.nodes.length).toEqual(plan.nodes.length);
+    expect(planFile.meta.seed).toBe(42);
+
+    const scoredPath = join(outputDir, 'plan.scored.json');
+    await runScoreCommand({ planPath, outPath: scoredPath });
+    const scoredFile = JSON.parse(await readFile(scoredPath, 'utf8'));
+    expect(scoredFile.nodes[0].score.total).toBeGreaterThan(0);
+
+    const exportPath = join(outputDir, 'export.ndjson');
+    await runExportCommand({ planPath, ndjsonPath: exportPath });
+    const ndjson = await readFile(exportPath, 'utf8');
+    expect(ndjson.trim().split('\n').length).toBe(plan.nodes.length);
+  });
+});

--- a/packages/tf-plan/tsconfig.json
+++ b/packages/tf-plan/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "paths": {
+      "@tf-lang/tf-plan-core": ["../tf-plan-core/dist/index.d.ts"],
+      "@tf-lang/tf-plan-enum": ["../tf-plan-enum/dist/index.d.ts"],
+      "@tf-lang/tf-plan-scoring": ["../tf-plan-scoring/dist/index.d.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/tf-plan/vitest.config.ts
+++ b/packages/tf-plan/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    alias: {
+      '@tf-lang/tf-plan-core': resolve(__dirname, '../tf-plan-core/src/index.ts'),
+      '@tf-lang/tf-plan-enum': resolve(__dirname, '../tf-plan-enum/src/index.ts'),
+      '@tf-lang/tf-plan-scoring': resolve(__dirname, '../tf-plan-scoring/src/index.ts'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,188 @@ importers:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
 
+  packages/tf-plan:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+      '@tf-lang/tf-plan-enum':
+        specifier: 0.1.0
+        version: link:../tf-plan-enum
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-compare:
+    dependencies:
+      '@tf-lang/tf-plan-compare-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-compare-core
+      '@tf-lang/tf-plan-compare-render':
+        specifier: 0.1.0
+        version: link:../tf-plan-compare-render
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+      '@tf-lang/tf-plan-scaffold-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-scaffold-core
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-compare-core:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+      '@tf-lang/tf-plan-scaffold-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-scaffold-core
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-compare-render:
+    dependencies:
+      '@tf-lang/tf-plan-compare-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-compare-core
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-core:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-enum:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+      '@tf-lang/tf-plan-scoring':
+        specifier: 0.1.0
+        version: link:../tf-plan-scoring
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-scaffold:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+      '@tf-lang/tf-plan-scaffold-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-scaffold-core
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-scaffold-core:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
+  packages/tf-plan-scoring:
+    dependencies:
+      '@tf-lang/tf-plan-core':
+        specifier: 0.1.0
+        version: link:../tf-plan-core
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)
+
   packages/utils:
     devDependencies:
       '@types/node':
@@ -751,6 +933,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -1668,6 +1854,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@20.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 5.4.20(@types/node@20.19.17)
+
   '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@24.3.1))':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -1798,6 +1992,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   confbox@0.1.8: {}
 
@@ -2395,6 +2591,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@20.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.20(@types/node@20.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.9(@types/node@24.3.1):
     dependencies:
       cac: 6.7.14
@@ -2412,6 +2626,15 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite@5.4.20(@types/node@20.19.17):
+    dependencies:
+      esbuild: 0.25.0
+      postcss: 8.5.6
+      rollup: 4.50.1
+    optionalDependencies:
+      '@types/node': 20.19.17
+      fsevents: 2.3.3
 
   vite@5.4.20(@types/node@24.3.1):
     dependencies:
@@ -2450,6 +2673,42 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@20.19.17)(jsdom@24.1.3):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@20.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.20(@types/node@20.19.17)
+      vite-node: 2.1.9(@types/node@20.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.17
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus

--- a/schema/tf-branch.schema.json
+++ b/schema/tf-branch.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tf-plan-branch",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "nodeId",
+    "specId",
+    "component",
+    "choice",
+    "deps",
+    "rationale",
+    "score"
+  ],
+  "properties": {
+    "nodeId": { "type": "string", "minLength": 1 },
+    "specId": { "type": "string", "minLength": 1 },
+    "component": { "type": "string", "minLength": 1 },
+    "choice": { "type": "string", "minLength": 1 },
+    "deps": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "rationale": { "type": "string", "minLength": 1 },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "complexity",
+        "risk",
+        "perf",
+        "devTime",
+        "depsReady",
+        "explain"
+      ],
+      "properties": {
+        "total": { "type": "number" },
+        "complexity": { "type": "number" },
+        "risk": { "type": "number" },
+        "perf": { "type": "number" },
+        "devTime": { "type": "number" },
+        "depsReady": { "type": "number" },
+        "explain": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schema/tf-compare.schema.json
+++ b/schema/tf-compare.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tf-plan-compare",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "meta", "branches"],
+  "properties": {
+    "version": { "type": "string" },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["seed", "planVersion", "generatedAt"],
+      "properties": {
+        "seed": { "type": "number" },
+        "planVersion": { "type": "string" },
+        "generatedAt": { "type": "string" },
+        "notes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "branches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["nodeId", "rank", "score", "summary"],
+        "properties": {
+          "nodeId": { "type": "string" },
+          "branchName": { "type": "string" },
+          "planChoice": { "type": "string" },
+          "rank": { "type": "integer", "minimum": 1 },
+          "score": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["total", "risk", "complexity", "perf", "devTime", "depsReady"],
+            "properties": {
+              "total": { "type": "number" },
+              "risk": { "type": "number" },
+              "complexity": { "type": "number" },
+              "perf": { "type": "number" },
+              "devTime": { "type": "number" },
+              "depsReady": { "type": "number" }
+            }
+          },
+          "summary": { "type": "string" },
+          "oracles": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name", "status"],
+              "properties": {
+                "name": { "type": "string" },
+                "status": { "type": "string", "enum": ["pass", "fail", "unknown"] },
+                "details": { "type": "string" },
+                "artifact": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/tf-plan.schema.json
+++ b/schema/tf-plan.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tf-plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "nodes", "edges", "meta"],
+  "properties": {
+    "version": { "type": "string" },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "tf-branch.schema.json" }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to", "kind"],
+        "properties": {
+          "from": { "type": "string" },
+          "to": { "type": "string" },
+          "kind": { "type": "string", "enum": ["depends", "sequence"] }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["seed", "specHash", "version"],
+      "properties": {
+        "seed": { "type": "number" },
+        "specHash": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    }
+  }
+}

--- a/templates/t4/dual-stack/Makefile
+++ b/templates/t4/dual-stack/Makefile
@@ -1,0 +1,7 @@
+.PHONY: oracle demo
+
+oracle:
+pnpm tf-check run --mode=ci
+
+demo:
+pnpm tf-plan compare --plan out/t4/plan/plan.ndjson --inputs out/t4/scaffold/index.json --out out/t4/compare

--- a/templates/t4/dual-stack/README.md
+++ b/templates/t4/dual-stack/README.md
@@ -1,0 +1,11 @@
+# Dual-stack Template
+
+This template provides paired TypeScript and Rust entrypoints that integrate with `tf-check` for oracle execution.
+
+## Layout
+
+- `ts/src/index.ts` — TypeScript harness invoking tf-check oracles.
+- `rust/src/lib.rs` — Rust harness mirroring TypeScript coverage.
+- `Makefile` — Convenience targets for running oracles locally.
+
+Copy the template into a fresh branch and wire branch-specific implementations before running CI.

--- a/templates/t4/dual-stack/rust/src/lib.rs
+++ b/templates/t4/dual-stack/rust/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn run_oracle() {
+    println!("TODO: implement dual-stack oracle harness.");
+}

--- a/templates/t4/dual-stack/ts/src/index.ts
+++ b/templates/t4/dual-stack/ts/src/index.ts
@@ -1,0 +1,3 @@
+export function runOracle(): void {
+  console.log('TODO: implement dual-stack oracle harness.');
+}

--- a/templates/t4/rs/README.md
+++ b/templates/t4/rs/README.md
@@ -1,0 +1,3 @@
+# Rust Template
+
+Minimal Rust harness for tf-check.

--- a/templates/t4/rs/src/lib.rs
+++ b/templates/t4/rs/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn run_oracle() {
+    println!("TODO: implement Rust oracle harness.");
+}

--- a/templates/t4/ts/README.md
+++ b/templates/t4/ts/README.md
@@ -1,0 +1,3 @@
+# TypeScript Template
+
+Minimal TypeScript harness for tf-check.

--- a/templates/t4/ts/src/index.ts
+++ b/templates/t4/ts/src/index.ts
@@ -1,0 +1,3 @@
+export function runOracle(): void {
+  console.log('TODO: implement TypeScript oracle harness.');
+}

--- a/tests/specs/demo.json
+++ b/tests/specs/demo.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1",
+  "name": "demo-plan",
+  "steps": [
+    { "op": "copy", "params": { "src": "app", "dest": "backup" } },
+    { "op": "create_vm", "params": { "image": "ubuntu-22", "cpus": 4 } },
+    { "op": "create_network", "params": { "cidr": "10.0.0.0/24" } }
+  ]
+}

--- a/tests/specs/fast-track.json
+++ b/tests/specs/fast-track.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1",
+  "name": "fast-track",
+  "steps": [
+    { "op": "copy", "params": { "src": "datasets", "dest": "analytics" } },
+    { "op": "create_vm", "params": { "image": "debian-12", "cpus": 2 } }
+  ]
+}

--- a/tests/specs/resilience.json
+++ b/tests/specs/resilience.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1",
+  "name": "resilience",
+  "steps": [
+    { "op": "create_network", "params": { "cidr": "10.10.0.0/16" } },
+    { "op": "copy", "params": { "src": "primary", "dest": "secondary" } },
+    { "op": "create_vm", "params": { "image": "centos-9", "cpus": 8 } }
+  ]
+}


### PR DESCRIPTION
## Summary
- load CLI schemas via `createRequire` helpers so builds work from dist output without JSON import assertions
- point T4 CLI TypeScript configs at `src` to emit `dist/{index,cli}.js` directly and rebuild the packages
- regenerate the T4 plan, scaffold, and compare artifacts using the new binaries

## Testing
- pnpm --filter @tf-lang/tf-plan-core build
- pnpm --filter @tf-lang/tf-plan-scoring build
- pnpm --filter @tf-lang/tf-plan-enum build
- pnpm --filter @tf-lang/tf-plan build
- pnpm --filter @tf-lang/tf-plan-scaffold-core build
- pnpm --filter @tf-lang/tf-plan-scaffold build
- pnpm --filter @tf-lang/tf-plan-compare-core build
- pnpm --filter @tf-lang/tf-plan-compare-render build
- pnpm --filter @tf-lang/tf-plan-compare build
- pnpm --filter @tf-lang/tf-plan test
- pnpm --filter @tf-lang/tf-plan-scaffold test
- pnpm --filter @tf-lang/tf-plan-compare test

------
https://chatgpt.com/codex/tasks/task_e_68cd3bbd69d48320b9b40df727d50c63