### PR TITLE
Add manifest generator CLI and tests

### DIFF
--- a/examples/flows/manifest_publish.tf
+++ b/examples/flows/manifest_publish.tf
@@ -1,0 +1,1 @@
+publish(topic="orders", key="abc", payload="{}")

--- a/examples/flows/manifest_storage.tf
+++ b/examples/flows/manifest_storage.tf
@@ -1,0 +1,4 @@
+seq{
+  write-object(uri="res://kv/bucket", key="z", value="1");
+  read-object(uri="res://kv/bucket", key="z")
+}

--- a/packages/tf-compose/bin/tf-manifest.mjs
+++ b/packages/tf-compose/bin/tf-manifest.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parseDSL } from '../src/parser.mjs';
+import { checkIR } from '../../tf-l0-check/src/check.mjs';
+import { manifestFromVerdict } from '../../tf-l0-check/src/manifest.mjs';
+
+async function loadCatalog() {
+  try {
+    const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+function printUsage() {
+  console.error('Usage: node packages/tf-compose/bin/tf-manifest.mjs <flow.tf> [-o out.json]');
+}
+
+const args = process.argv.slice(2);
+let inputPath = null;
+let outputPath = null;
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === '-o' || arg === '--out') {
+    if (i + 1 >= args.length) {
+      printUsage();
+      process.exit(2);
+    }
+    outputPath = args[i + 1];
+    i += 1;
+  } else if (!inputPath) {
+    inputPath = arg;
+  } else {
+    printUsage();
+    process.exit(2);
+  }
+}
+
+if (!inputPath) {
+  printUsage();
+  process.exit(2);
+}
+
+const source = await readFile(inputPath, 'utf8');
+const ir = parseDSL(source);
+const catalog = await loadCatalog();
+const verdict = checkIR(ir, catalog);
+const manifest = manifestFromVerdict(verdict);
+const payload = JSON.stringify(manifest, null, 2) + '\n';
+
+if (outputPath) {
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, payload, 'utf8');
+} else {
+  process.stdout.write(payload);
+}
+
+process.exit(verdict.ok === false ? 1 : 0);

--- a/packages/tf-l0-check/src/manifest.mjs
+++ b/packages/tf-l0-check/src/manifest.mjs
@@ -1,8 +1,20 @@
-import { unionEffects } from './lattice.mjs';
-export function manifestFromVerdict(verdict) {
+export function manifestFromVerdict(v) {
+  const uniq = (xs = []) => Array.from(new Set(xs)).sort();
+  const dedupeObjArray = (arr = []) => {
+    const unique = Array.from(new Map(arr.map((o) => [JSON.stringify(o), o])).values());
+    return unique.sort((a, b) => {
+      const sa = JSON.stringify(a);
+      const sb = JSON.stringify(b);
+      return sa.localeCompare(sb);
+    });
+  };
+
   return {
-    effects: verdict.effects || [],
-    scopes: [],
-    footprints: [...(verdict.reads||[]), ...(verdict.writes||[])]
+    required_effects: uniq(v.effects || []),
+    footprints: {
+      reads: dedupeObjArray(v.reads || []),
+      writes: dedupeObjArray(v.writes || []),
+    },
+    qos: v.qos || {},
   };
 }

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkIR } = await import('../packages/tf-l0-check/src/check.mjs');
+const { manifestFromVerdict } = await import('../packages/tf-l0-check/src/manifest.mjs');
+import { readFile } from 'node:fs/promises';
+
+async function loadCatalog() {
+  try { return JSON.parse(await readFile('packages/tf-l0-spec/spec/catalog.json','utf8')); }
+  catch { return { primitives: [] }; }
+}
+
+test('publish manifest includes Network.Out and qos', async () => {
+  const cat = await loadCatalog();
+  const ir = parseDSL('publish(topic="orders", key="abc", payload="{}")');
+  const v = checkIR(ir, cat);
+  const m = manifestFromVerdict(v);
+  assert.ok(m.required_effects.includes('Network.Out'));
+  if (m.qos && m.qos.delivery_guarantee) {
+    assert.ok(['at-least-once', 'exactly-once', 'at-most-once'].includes(m.qos.delivery_guarantee));
+  }
+});
+
+test('storage manifest collects write+read footprints', async () => {
+  const cat = await loadCatalog();
+  const ir = parseDSL('seq{ write-object(uri="res://kv/b", key="z", value="1"); read-object(uri="res://kv/b", key="z") }');
+  const v = checkIR(ir, cat);
+  const m = manifestFromVerdict(v);
+  assert.ok(m.required_effects.includes('Storage.Write'));
+  assert.ok(m.required_effects.includes('Storage.Read'));
+  assert.ok((m.footprints.writes||[]).length > 0);
+  assert.ok((m.footprints.reads||[]).length > 0);
+});


### PR DESCRIPTION
## Summary
- update manifest extraction to produce canonical required effects, footprints, and qos
- add a standalone tf-manifest CLI and seed flows that exercise publish and storage manifests
- cover manifest behavior with new tests for network and storage flows

## Testing
- pnpm run a0
- pnpm run a1
- pnpm test *(fails: vitest cannot resolve @tf-lang/utils for @tf-lang/adapter-execution-ts)*
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf
- pnpm run determinism:full


------
https://chatgpt.com/codex/tasks/task_e_68cf0d4affd483209d5bb52fdc21b503