### PR TITLE
feat: add manifest cli

### DIFF
--- a/examples/flows/manifest_publish.tf
+++ b/examples/flows/manifest_publish.tf
@@ -1,0 +1,1 @@
+publish(topic="orders", key="abc", payload="{}")

--- a/examples/flows/manifest_storage.tf
+++ b/examples/flows/manifest_storage.tf
@@ -1,0 +1,4 @@
+seq{
+  write-object(uri="res://kv/bucket", key="z", value="1");
+  read-object(uri="res://kv/bucket", key="z")
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "5.9.2",
     "ajv": "^8.17.1",
     "yaml": "^2.4.5",
+    "@tf-lang/utils": "workspace:*",
     "@tf-lang/tf-plan": "workspace:*",
     "@tf-lang/tf-plan-scaffold": "workspace:*",
     "@tf-lang/tf-plan-compare": "workspace:*"

--- a/packages/tf-compose/bin/tf-manifest.mjs
+++ b/packages/tf-compose/bin/tf-manifest.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parseDSL } from '../src/parser.mjs';
+import { checkIR } from '../../tf-l0-check/src/check.mjs';
+import { manifestFromVerdict } from '../../tf-l0-check/src/manifest.mjs';
+
+async function loadCatalog() {
+  try {
+    return JSON.parse(
+      await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8')
+    );
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error('Usage: node packages/tf-compose/bin/tf-manifest.mjs <flow.tf> [-o out.json]');
+}
+
+let file = null;
+let out = null;
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === '-o' || arg === '--out') {
+    out = args[i + 1] || null;
+    i++;
+    continue;
+  }
+  if (!file) {
+    file = arg;
+    continue;
+  }
+  // unexpected extra positional args
+  usage();
+  process.exit(2);
+}
+
+if (!file) {
+  usage();
+  process.exit(2);
+}
+
+const src = await readFile(file, 'utf8');
+const ir = parseDSL(src);
+const catalog = await loadCatalog();
+const verdict = checkIR(ir, catalog);
+const manifest = manifestFromVerdict(verdict);
+const payload = JSON.stringify(manifest, null, 2) + '\n';
+
+if (out) {
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, payload, 'utf8');
+} else {
+  process.stdout.write(payload);
+}
+
+process.exit(verdict.ok === false ? 1 : 0);

--- a/packages/tf-l0-check/src/manifest.mjs
+++ b/packages/tf-l0-check/src/manifest.mjs
@@ -1,8 +1,16 @@
-import { unionEffects } from './lattice.mjs';
-export function manifestFromVerdict(verdict) {
+export function manifestFromVerdict(verdict = {}) {
+  const uniq = (xs = []) => Array.from(new Set(xs)).sort();
+  const dedupeObjArray = (arr = []) =>
+    Array.from(
+      new Map((arr || []).map((o) => [JSON.stringify(o ?? {}), o ?? {}])).values()
+    );
+
   return {
-    effects: verdict.effects || [],
-    scopes: [],
-    footprints: [...(verdict.reads||[]), ...(verdict.writes||[])]
+    required_effects: uniq(verdict.effects || []),
+    footprints: {
+      reads: dedupeObjArray(verdict.reads || []),
+      writes: dedupeObjArray(verdict.writes || [])
+    },
+    qos: verdict.qos || {}
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tf-lang/tf-plan-scaffold':
         specifier: workspace:*
         version: link:packages/tf-plan-scaffold
+      '@tf-lang/utils':
+        specifier: workspace:*
+        version: link:packages/utils
       ajv:
         specifier: ^8.17.1
         version: 8.17.1

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkIR } = await import('../packages/tf-l0-check/src/check.mjs');
+const { manifestFromVerdict } = await import('../packages/tf-l0-check/src/manifest.mjs');
+import { readFile } from 'node:fs/promises';
+
+async function loadCatalog() {
+  try { return JSON.parse(await readFile('packages/tf-l0-spec/spec/catalog.json','utf8')); }
+  catch { return { primitives: [] }; }
+}
+
+test('publish manifest includes Network.Out and qos', async () => {
+  const cat = await loadCatalog();
+  const ir = parseDSL('publish(topic="orders", key="abc", payload="{}")');
+  const v = checkIR(ir, cat);
+  const m = manifestFromVerdict(v);
+  assert.ok(m.required_effects.includes('Network.Out'));
+  // qos might be attached per-primitive; seed provides at-least-once
+  // Don’t assert exact shape beyond delivery_guarantee when present
+  if (m.qos.delivery_guarantee) {
+    assert.equal(typeof m.qos.delivery_guarantee, 'string');
+  }
+});
+
+test('storage manifest collects write+read footprints', async () => {
+  const cat = await loadCatalog();
+  const ir = parseDSL('seq{ write-object(uri="res://kv/b", key="z", value="1"); read-object(uri="res://kv/b", key="z") }');
+  const v = checkIR(ir, cat);
+  const m = manifestFromVerdict(v);
+  assert.ok(m.required_effects.includes('Storage.Write'));
+  assert.ok(m.required_effects.includes('Storage.Read'));
+  assert.ok((m.footprints.writes||[]).length > 0);
+  assert.ok((m.footprints.reads||[]).length > 0);
+});


### PR DESCRIPTION
## Summary
- normalize checker verdicts into capability manifests with deduped effects and footprints
- add a dedicated `tf-manifest` CLI for generating manifests from flow files
- cover manifest generation with new tests and example flows, and expose shared utils at the workspace root

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run --recursive build
- pnpm test
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf
- pnpm run determinism:full


------
https://chatgpt.com/codex/tasks/task_e_68cf0d4affd483209d5bb52fdc21b503