### PR TITLE
Add manifest CLI and coverage tests

### DIFF
--- a/examples/flows/manifest_publish.tf
+++ b/examples/flows/manifest_publish.tf
@@ -1,0 +1,1 @@
+publish(topic="orders", key="abc", payload="{}")

--- a/examples/flows/manifest_storage.tf
+++ b/examples/flows/manifest_storage.tf
@@ -1,0 +1,4 @@
+seq{
+  write-object(uri="res://kv/bucket", key="z", value="1");
+  read-object(uri="res://kv/bucket", key="z")
+}

--- a/packages/tf-compose/bin/tf-manifest.mjs
+++ b/packages/tf-compose/bin/tf-manifest.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+import path from 'node:path';
+
+const usage = 'Usage: node packages/tf-compose/bin/tf-manifest.mjs <flow.tf> [-o out.json]';
+
+async function main(argv) {
+  const args = argv.slice(2);
+  let flowPath;
+  let outPath;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-o') {
+      if (i + 1 >= args.length) {
+        throw new Error('-o requires a file path');
+      }
+      outPath = args[i + 1];
+      i += 1;
+    } else if (!flowPath) {
+      flowPath = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+
+  if (!flowPath) {
+    throw new Error('Missing flow path');
+  }
+
+  const [{ parseDSL }, { checkIR }, { manifestFromVerdict }] = await Promise.all([
+    import('../src/parser.mjs'),
+    import('../../tf-l0-check/src/check.mjs'),
+    import('../../tf-l0-check/src/manifest.mjs')
+  ]);
+
+  const flowSource = await readFile(flowPath, 'utf8');
+  const ir = parseDSL(flowSource);
+
+  const catalogPath = path.resolve('packages/tf-l0-spec/spec/catalog.json');
+  let catalog;
+  try {
+    catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  } catch (err) {
+    throw new Error(`Failed to load catalog at ${catalogPath}: ${err.message}`);
+  }
+
+  const verdict = checkIR(ir, catalog);
+  const manifest = manifestFromVerdict(verdict);
+  const json = JSON.stringify(manifest, null, 2);
+
+  if (outPath) {
+    await writeFile(outPath, `${json}\n`, 'utf8');
+  } else {
+    console.log(json);
+  }
+
+  if (verdict && verdict.ok === false) {
+    process.exitCode = 1;
+  }
+}
+
+main(process.argv).catch((err) => {
+  console.error(err.message || err);
+  console.error(usage);
+  process.exit(1);
+});

--- a/packages/tf-l0-check/src/manifest.mjs
+++ b/packages/tf-l0-check/src/manifest.mjs
@@ -1,8 +1,14 @@
-import { unionEffects } from './lattice.mjs';
-export function manifestFromVerdict(verdict) {
+export function manifestFromVerdict(verdict = {}) {
+  const uniq = (xs = []) => Array.from(new Set(xs)).sort();
+  const dedupeObjArray = (arr = []) =>
+    Array.from(new Map(arr.map((o) => [JSON.stringify(o), o])).values());
+
   return {
-    effects: verdict.effects || [],
-    scopes: [],
-    footprints: [...(verdict.reads||[]), ...(verdict.writes||[])]
+    required_effects: uniq(verdict.effects || []),
+    footprints: {
+      reads: dedupeObjArray(verdict.reads || []),
+      writes: dedupeObjArray(verdict.writes || [])
+    },
+    qos: verdict.qos || {}
   };
 }

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkIR } = await import('../packages/tf-l0-check/src/check.mjs');
+const { manifestFromVerdict } = await import('../packages/tf-l0-check/src/manifest.mjs');
+
+async function loadCatalog() {
+  try {
+    const contents = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+    return JSON.parse(contents);
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+test('publish manifest includes Network.Out and qos', async () => {
+  const cat = await loadCatalog();
+  const ir = parseDSL('publish(topic="orders", key="abc", payload="{}")');
+  const verdict = checkIR(ir, cat);
+  const manifest = manifestFromVerdict(verdict);
+
+  assert.ok(manifest.required_effects.includes('Network.Out'));
+  if (manifest.qos && manifest.qos.delivery_guarantee) {
+    assert.ok(['at-least-once', 'exactly-once', 'at-most-once'].includes(manifest.qos.delivery_guarantee));
+  }
+});
+
+test('storage manifest collects write+read footprints', async () => {
+  const cat = await loadCatalog();
+  const ir = parseDSL('seq{ write-object(uri="res://kv/b", key="z", value="1"); read-object(uri="res://kv/b", key="z") }');
+  const verdict = checkIR(ir, cat);
+  const manifest = manifestFromVerdict(verdict);
+
+  assert.ok(manifest.required_effects.includes('Storage.Write'));
+  assert.ok(manifest.required_effects.includes('Storage.Read'));
+  assert.ok((manifest.footprints.writes || []).length > 0);
+  assert.ok((manifest.footprints.reads || []).length > 0);
+});


### PR DESCRIPTION
## Summary
- implement canonical manifest generation from checker verdicts
- add a tf-manifest CLI to parse flows, run the checker, and emit JSON
- cover network and storage flows with manifest-focused tests and examples

## Testing
- pnpm run a0
- pnpm run a1
- pnpm test *(fails: vitest cannot resolve internal workspace packages such as @tf-lang/tf-plan-scoring without additional setup)*
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf
- pnpm run determinism:full

------
https://chatgpt.com/codex/tasks/task_e_68cf0d4affd483209d5bb52fdc21b503