### PR TITLE
Add deterministic effect derivation and reporting

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -9,3 +9,8 @@ Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
 `spec/seed/*.json` overlay into the generated catalog. The seed entries carry
 minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
 conflict detection stay runnable while curation continues.
+
+### Effect derivation rules
+Deterministic name matches fill gaps for primitives (e.g. read-object → Storage.Read, publish → Network.Out, sign-data → Crypto).
+The deriver only applies when a primitive lacks effects or QoS, so curated seed overlays remain authoritative.
+Network operations default to at-least-once/per-key QoS when missing to ensure consistent coverage.

--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -11,6 +11,6 @@ minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
 conflict detection stay runnable while curation continues.
 
 ### Effect derivation rules
-Deterministic name matches fill gaps for primitives (e.g. read-object → Storage.Read, publish → Network.Out, sign-data → Crypto).
-The deriver only applies when a primitive lacks effects or QoS, so curated seed overlays remain authoritative.
-Network operations default to at-least-once/per-key QoS when missing to ensure consistent coverage.
+Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
+Seed overlays remain authoritative for existing effects or qos values.
+Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test": "pnpm run test:workspace && pnpm run test:l0",
     "a0": "node packages/tf-l0-spec/scripts/build-ids.mjs && node packages/tf-l0-spec/scripts/finalize-a0.mjs",
     "a1": "node packages/tf-l0-spec/scripts/build-catalog.mjs && node packages/tf-l0-spec/scripts/derive-effects.mjs && node packages/tf-l0-spec/scripts/build-laws.mjs && node packages/tf-l0-spec/scripts/finalize-a1.mjs",
+    "a1:summary": "node scripts/effects-summary.mjs",
+    "a1:all": "pnpm run a1 && pnpm run a1:summary",
     "tf": "node packages/tf-compose/bin/tf.mjs",
     "validate:ids": "node scripts/validate-ids.mjs",
     "validate:catalog": "node scripts/validate-catalog.mjs",

--- a/scripts/effects-summary.mjs
+++ b/scripts/effects-summary.mjs
@@ -1,0 +1,78 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { canonicalize } from '../packages/tf-l0-spec/scripts/canonical-json.mjs';
+
+const catalogPath = 'packages/tf-l0-spec/spec/catalog.json';
+const outputDir = 'out/0.4/spec';
+const summaryJsonPath = `${outputDir}/effects-summary.json`;
+const summaryTextPath = `${outputDir}/effects-summary.txt`;
+
+const NETWORK_EFFECTS = new Set(['Network.In', 'Network.Out']);
+
+const rawCatalog = await readFile(catalogPath, 'utf8');
+const catalog = JSON.parse(rawCatalog);
+
+const effectCounts = new Map();
+const unknownEffects = [];
+let networkTotal = 0;
+let networkWithDelivery = 0;
+let networkWithOrdering = 0;
+const networkMissing = [];
+
+for (const primitive of catalog.primitives) {
+  const effects = Array.isArray(primitive.effects) ? primitive.effects : [];
+
+  if (effects.length === 0) {
+    unknownEffects.push(primitive.id);
+  }
+
+  for (const effect of effects) {
+    effectCounts.set(effect, (effectCounts.get(effect) ?? 0) + 1);
+  }
+
+  if (effects.some(effect => NETWORK_EFFECTS.has(effect))) {
+    networkTotal += 1;
+    const hasDelivery =
+      typeof primitive.qos?.delivery_guarantee === 'string' &&
+      primitive.qos.delivery_guarantee.length > 0;
+    const hasOrdering =
+      typeof primitive.qos?.ordering === 'string' && primitive.qos.ordering.length > 0;
+
+    if (hasDelivery) networkWithDelivery += 1;
+    if (hasOrdering) networkWithOrdering += 1;
+
+    if (!hasDelivery || !hasOrdering) {
+      const missing = [];
+      if (!hasDelivery) missing.push('delivery_guarantee');
+      if (!hasOrdering) missing.push('ordering');
+      networkMissing.push({ id: primitive.id, missing });
+    }
+  }
+}
+
+const summary = {
+  catalog_semver: catalog.catalog_semver,
+  effect_counts: Object.fromEntries(Array.from(effectCounts.entries()).sort(([a], [b]) => a.localeCompare(b))),
+  unknown_effects: unknownEffects,
+  network_qos: {
+    total: networkTotal,
+    with_delivery_guarantee: networkWithDelivery,
+    with_ordering: networkWithOrdering,
+    missing: networkMissing
+  }
+};
+
+await mkdir(outputDir, { recursive: true });
+await writeFile(summaryJsonPath, canonicalize(summary) + '\n', 'utf8');
+
+const effectParts = Array.from(effectCounts.entries())
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([effect, count]) => `${effect}=${count}`);
+const textSummary = [
+  `Effects: ${effectParts.join(', ')}`,
+  `Unknown=${unknownEffects.length}`,
+  `Network QoS: delivery=${networkWithDelivery}/${networkTotal}, ordering=${networkWithOrdering}/${networkTotal}`
+].join(' | ');
+
+await writeFile(summaryTextPath, `${textSummary}\n`, 'utf8');
+
+console.log(`effects summary written to ${summaryJsonPath} and ${summaryTextPath}`);

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,17 +1,32 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { applyEffectsAndQos, run as deriveEffects } from '../packages/tf-l0-spec/scripts/derive-effects.mjs';
+
+const catalogPath = 'packages/tf-l0-spec/spec/catalog.json';
 
 async function loadCatalog() {
-  const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+  const raw = await readFile(catalogPath, 'utf8');
   return JSON.parse(raw);
 }
 
-test('derive-effects: curated seed entries retain their effects', async () => {
+await deriveEffects();
+
+test('derive-effects: curated seed entries retain their effects and qos', async () => {
   const catalog = await loadCatalog();
-  const primitive = catalog.primitives.find(p => p.id === 'tf:resource/write-object@1');
-  assert.ok(primitive, 'write-object primitive present');
-  assert.deepEqual(primitive.effects, ['Storage.Write']);
+
+  const writeObject = catalog.primitives.find(p => p.id === 'tf:resource/write-object@1');
+  assert.ok(writeObject, 'write-object primitive present');
+  assert.deepEqual(writeObject.effects, ['Storage.Write']);
+  assert.deepEqual(writeObject.qos, {});
+
+  const publish = catalog.primitives.find(p => p.id === 'tf:network/publish@1');
+  assert.ok(publish, 'publish primitive present');
+  assert.deepEqual(publish.effects, ['Network.Out']);
+  assert.deepEqual(publish.qos, {
+    delivery_guarantee: 'at-least-once',
+    ordering: 'per-key'
+  });
 });
 
 test('derive-effects: all primitives have non-empty effects', async () => {
@@ -22,14 +37,39 @@ test('derive-effects: all primitives have non-empty effects', async () => {
   assert.equal(missing.length, 0, `primitives without effects: ${missing.join(', ')}`);
 });
 
-test('derive-effects: network primitives expose qos delivery guarantees', async () => {
-  const catalog = await loadCatalog();
-  const networkPrimitives = catalog.primitives.filter(p =>
-    Array.isArray(p.effects) && p.effects.some(effect => effect.startsWith('Network.'))
-  );
-  assert.ok(networkPrimitives.length > 0, 'expected network primitives in catalog');
-  const missing = networkPrimitives
-    .filter(p => typeof p.qos?.delivery_guarantee !== 'string' || p.qos.delivery_guarantee.length === 0)
-    .map(p => p.id);
-  assert.equal(missing.length, 0, `network primitives missing qos.delivery_guarantee: ${missing.join(', ')}`);
+test('derive-effects: network qos defaults fill gaps without overriding', () => {
+  const seeded = applyEffectsAndQos({
+    id: 'test:network/publish@1',
+    name: 'publish',
+    effects: ['Network.Out']
+  });
+  assert.deepEqual(seeded.qos, {
+    delivery_guarantee: 'at-least-once',
+    ordering: 'per-key'
+  });
+
+  const partial = applyEffectsAndQos({
+    id: 'test:network/subscribe@1',
+    name: 'subscribe',
+    effects: ['Network.In'],
+    qos: { delivery_guarantee: 'exactly-once' }
+  });
+  assert.deepEqual(partial.qos, {
+    delivery_guarantee: 'exactly-once',
+    ordering: 'per-key'
+  });
+
+  const curated = applyEffectsAndQos({
+    id: 'test:network/request@1',
+    name: 'request',
+    effects: ['Network.Out'],
+    qos: {
+      delivery_guarantee: 'exactly-once',
+      ordering: 'global'
+    }
+  });
+  assert.deepEqual(curated.qos, {
+    delivery_guarantee: 'exactly-once',
+    ordering: 'global'
+  });
 });

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+async function loadCatalog() {
+  const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+  return JSON.parse(raw);
+}
+
+test('derive-effects: curated seed entries retain their effects', async () => {
+  const catalog = await loadCatalog();
+  const primitive = catalog.primitives.find(p => p.id === 'tf:resource/write-object@1');
+  assert.ok(primitive, 'write-object primitive present');
+  assert.deepEqual(primitive.effects, ['Storage.Write']);
+});
+
+test('derive-effects: all primitives have non-empty effects', async () => {
+  const catalog = await loadCatalog();
+  const missing = catalog.primitives
+    .filter(p => !Array.isArray(p.effects) || p.effects.length === 0)
+    .map(p => p.id);
+  assert.equal(missing.length, 0, `primitives without effects: ${missing.join(', ')}`);
+});
+
+test('derive-effects: network primitives expose qos delivery guarantees', async () => {
+  const catalog = await loadCatalog();
+  const networkPrimitives = catalog.primitives.filter(p =>
+    Array.isArray(p.effects) && p.effects.some(effect => effect.startsWith('Network.'))
+  );
+  assert.ok(networkPrimitives.length > 0, 'expected network primitives in catalog');
+  const missing = networkPrimitives
+    .filter(p => typeof p.qos?.delivery_guarantee !== 'string' || p.qos.delivery_guarantee.length === 0)
+    .map(p => p.id);
+  assert.equal(missing.length, 0, `network primitives missing qos.delivery_guarantee: ${missing.join(', ')}`);
+});


### PR DESCRIPTION
## Summary
- derive missing primitive effects via deterministic name-based rules and apply default QoS only when network entries lack one
- add an effects summary script that reports effect coverage and network QoS presence
- document the derivation behaviour and add regression tests guarding curated effects and QoS coverage

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run validate:catalog
- pnpm run lint:catalog
- pnpm test *(fails: @tf-lang/coverage-generator test via vitest)*
- pnpm run test:l0
- node scripts/effects-summary.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf1ab52088832082b7a0725b0a5c3f