### PR TITLE
Fill L0 catalog effects and add summary tooling

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -9,3 +9,9 @@ Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
 `spec/seed/*.json` overlay into the generated catalog. The seed entries carry
 minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
 conflict detection stay runnable while curation continues.
+
+### Effect derivation rules
+During build we fill missing `effects` and network `qos` using deterministic name
+based rules for common primitives (e.g. storage, network, crypto).
+Seed overlay entries remain authoritative: existing effect tags or qos blocks are
+never overwritten by the derivation step.

--- a/packages/tf-l0-spec/scripts/derive-effects.mjs
+++ b/packages/tf-l0-spec/scripts/derive-effects.mjs
@@ -3,25 +3,74 @@ import { join } from 'node:path';
 import { canonicalize } from './canonical-json.mjs';
 
 const spec = 'packages/tf-l0-spec/spec';
-const rules = JSON.parse(await readFile('packages/tf-l0-spec/rules/effect-rules.json', 'utf8')).rules;
 
-function derive(name) {
-  const n = name.toLowerCase();
-  const out = new Set();
-  for (const r of rules) if (new RegExp(r.match).test(n)) for (const e of r.effects) out.add(e);
-  return Array.from(out);
+const effectRules = new Map([
+  ['read-object', ['Storage.Read']],
+  ['list-objects', ['Storage.Read']],
+  ['write-object', ['Storage.Write']],
+  ['delete-object', ['Storage.Write']],
+  ['compare-and-swap', ['Storage.Write']],
+  ['publish', ['Network.Out']],
+  ['request', ['Network.Out']],
+  ['acknowledge', ['Network.Out']],
+  ['subscribe', ['Network.In']],
+  ['hash', ['Pure']],
+  ['serialize', ['Pure']],
+  ['deserialize', ['Pure']],
+  ['sign-data', ['Crypto']],
+  ['verify-signature', ['Crypto']],
+  ['encrypt', ['Crypto']],
+  ['decrypt', ['Crypto']],
+  ['emit-metric', ['Observability']],
+  ['emit-log', ['Observability']]
+]);
+
+const defaultNetworkQos = {
+  delivery_guarantee: 'at-least-once',
+  ordering: 'per-key'
+};
+
+function deriveEffects(name = '') {
+  const key = String(name).toLowerCase();
+  return effectRules.get(key) ?? [];
 }
 
 const catalog = JSON.parse(await readFile(join(spec, 'catalog.json'), 'utf8'));
-for (const p of catalog.primitives) {
-  if (!Array.isArray(p.effects) || p.effects.length === 0) {
-    p.effects = derive(p.name);
+
+for (const primitive of catalog.primitives ?? []) {
+  if (!Array.isArray(primitive.effects) || primitive.effects.length === 0) {
+    primitive.effects = deriveEffects(primitive.name);
+  }
+
+  if (
+    Array.isArray(primitive.effects) &&
+    primitive.effects.some(effect => effect.startsWith('Network.'))
+  ) {
+    const qos = primitive.qos;
+    const hasQos =
+      qos && typeof qos === 'object' && Object.keys(qos).length > 0;
+    if (!hasQos) {
+      primitive.qos = { ...defaultNetworkQos };
+    }
   }
 }
-await writeFile(join(spec, 'effects.json'), canonicalize({
-  catalog_semver: catalog.catalog_semver,
-  effects: catalog.primitives.map(p => ({ id: p.id, effects: p.effects }))
-}) + '\n', 'utf8');
 
-await writeFile(join(spec, 'catalog.json'), canonicalize(catalog) + '\n', 'utf8');
-console.log("effects derived and catalog.json updated.");
+await writeFile(
+  join(spec, 'effects.json'),
+  canonicalize({
+    catalog_semver: catalog.catalog_semver,
+    effects: catalog.primitives.map(primitive => ({
+      effects: primitive.effects,
+      id: primitive.id
+    }))
+  }) + '\n',
+  'utf8'
+);
+
+await writeFile(
+  join(spec, 'catalog.json'),
+  canonicalize(catalog) + '\n',
+  'utf8'
+);
+
+console.log('effects derived and catalog.json updated.');

--- a/scripts/effects-summary.mjs
+++ b/scripts/effects-summary.mjs
@@ -1,0 +1,66 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { canonicalize } from '../packages/tf-l0-spec/scripts/canonical-json.mjs';
+
+const catalogPath = 'packages/tf-l0-spec/spec/catalog.json';
+const outputDir = 'out/0.4/spec';
+const jsonOutputPath = `${outputDir}/effects-summary.json`;
+const textOutputPath = `${outputDir}/effects-summary.txt`;
+
+const raw = await readFile(catalogPath, 'utf8');
+const catalog = JSON.parse(raw);
+
+const effectCounts = {};
+const unknownPrimitives = [];
+let networkTotal = 0;
+let networkWithDelivery = 0;
+let networkWithOrdering = 0;
+
+for (const primitive of catalog.primitives ?? []) {
+  const effects = Array.isArray(primitive.effects) ? primitive.effects : [];
+  if (effects.length === 0) {
+    unknownPrimitives.push({ id: primitive.id, name: primitive.name });
+  }
+
+  const families = new Set();
+  for (const effect of effects) {
+    const family = effect.includes('.') ? effect.split('.')[0] : effect;
+    families.add(family);
+  }
+
+  for (const family of families) {
+    effectCounts[family] = (effectCounts[family] ?? 0) + 1;
+  }
+
+  const hasNetworkEffect = effects.some(effect => effect.startsWith('Network.'));
+  if (hasNetworkEffect) {
+    networkTotal += 1;
+    const qos = primitive.qos;
+    if (qos && typeof qos === 'object') {
+      if (qos.delivery_guarantee) networkWithDelivery += 1;
+      if (qos.ordering) networkWithOrdering += 1;
+    }
+  }
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const summary = {
+  effect_counts: effectCounts,
+  network_qos: {
+    total: networkTotal,
+    with_delivery_guarantee: networkWithDelivery,
+    with_ordering: networkWithOrdering
+  },
+  unknown_primitives: unknownPrimitives
+};
+
+await writeFile(jsonOutputPath, canonicalize(summary) + '\n', 'utf8');
+
+const effectTotals = Object.entries(effectCounts)
+  .sort((a, b) => a[0].localeCompare(b[0]))
+  .map(([family, count]) => `${family}=${count}`)
+  .join(', ');
+const unknownTotal = unknownPrimitives.length;
+const textSummary = `Effects: ${effectTotals || 'none'}; Unknown: ${unknownTotal}; Network QoS: delivery ${networkWithDelivery}/${networkTotal}, ordering ${networkWithOrdering}/${networkTotal}`;
+
+await writeFile(textOutputPath, `${textSummary}\n`, 'utf8');

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+const catalog = JSON.parse(raw);
+
+function findPrimitive(id) {
+  return (catalog.primitives || []).find(primitive => primitive.id === id);
+}
+
+test('seed primitive effects remain curated', () => {
+  const writeObject = findPrimitive('tf:resource/write-object@1');
+  assert.ok(writeObject, 'write-object primitive present');
+  assert.deepEqual(writeObject.effects, ['Storage.Write']);
+});
+
+test('all primitives have at least one effect tag', () => {
+  const missing = (catalog.primitives || []).filter(
+    primitive => !Array.isArray(primitive.effects) || primitive.effects.length === 0
+  );
+  assert.deepEqual(missing, [], 'primitives without effects');
+});
+
+test('network primitives include qos delivery guarantee', () => {
+  const networkPrimitives = (catalog.primitives || []).filter(
+    primitive =>
+      Array.isArray(primitive.effects) &&
+      primitive.effects.some(effect => effect.startsWith('Network.'))
+  );
+
+  assert.ok(networkPrimitives.length > 0, 'network primitives present');
+
+  for (const primitive of networkPrimitives) {
+    assert.ok(
+      primitive.qos &&
+        typeof primitive.qos === 'object' &&
+        Object.hasOwn(primitive.qos, 'delivery_guarantee') &&
+        primitive.qos.delivery_guarantee,
+      `missing delivery_guarantee for ${primitive.id}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- derive missing primitive effects via deterministic name-to-effect rules and set default QoS only for network entries without curated data
- add an effects summary script plus Node test coverage to guard the derivation behaviour
- document the derivation guardrails in the L0 catalog guide

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run validate:catalog
- pnpm run lint:catalog
- pnpm test *(fails: upstream workspace test @tf-lang/coverage-generator@0.1.0)*
- pnpm run test:l0
- node scripts/effects-summary.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf1ab52088832082b7a0725b0a5c3f