### PR TITLE
Add deterministic effect derivation and summary

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -9,3 +9,8 @@ Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
 `spec/seed/*.json` overlay into the generated catalog. The seed entries carry
 minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
 conflict detection stay runnable while curation continues.
+
+### Effect derivation rules
+The A1 build only fills in missing `effects` and basic network `qos` fields
+using deterministic name-based rules. Curated entries from the seed overlay are
+treated as authoritative and are never overwritten by the deriver.

--- a/out/0.4/spec/effects-summary.json
+++ b/out/0.4/spec/effects-summary.json
@@ -1,0 +1,1 @@
+{"effect_counts":{"Crypto":2,"Network.In":1,"Network.Out":3,"Observability":1,"Pure":3,"Storage.Read":1,"Storage.Write":3},"network_qos":{"missing_delivery_guarantee":[],"missing_ordering":[],"total":4,"with_delivery_guarantee":4,"with_ordering":4},"unknown_effects":[]}

--- a/out/0.4/spec/effects-summary.txt
+++ b/out/0.4/spec/effects-summary.txt
@@ -1,0 +1,1 @@
+Total primitives: 14; Effects: Crypto=2, Network.In=1, Network.Out=3, Observability=1, Pure=3, Storage.Read=1, Storage.Write=3; Network QoS: delivery_guarantee 4/4, ordering 4/4; Unknown effects: 0

--- a/packages/tf-l0-spec/scripts/derive-effects.mjs
+++ b/packages/tf-l0-spec/scripts/derive-effects.mjs
@@ -3,25 +3,67 @@ import { join } from 'node:path';
 import { canonicalize } from './canonical-json.mjs';
 
 const spec = 'packages/tf-l0-spec/spec';
-const rules = JSON.parse(await readFile('packages/tf-l0-spec/rules/effect-rules.json', 'utf8')).rules;
 
-function derive(name) {
-  const n = name.toLowerCase();
-  const out = new Set();
-  for (const r of rules) if (new RegExp(r.match).test(n)) for (const e of r.effects) out.add(e);
-  return Array.from(out);
+const effectMap = new Map([
+  ['acknowledge', ['Network.Out']],
+  ['compare-and-swap', ['Storage.Write']],
+  ['decrypt', ['Crypto']],
+  ['delete-object', ['Storage.Write']],
+  ['deserialize', ['Pure']],
+  ['emit-log', ['Observability']],
+  ['emit-metric', ['Observability']],
+  ['encrypt', ['Crypto']],
+  ['hash', ['Pure']],
+  ['list-objects', ['Storage.Read']],
+  ['publish', ['Network.Out']],
+  ['read-object', ['Storage.Read']],
+  ['request', ['Network.Out']],
+  ['serialize', ['Pure']],
+  ['sign-data', ['Crypto']],
+  ['subscribe', ['Network.In']],
+  ['verify-signature', ['Crypto']],
+  ['write-object', ['Storage.Write']]
+]);
+
+function deriveEffects(name) {
+  const n = (name || '').toLowerCase();
+  return effectMap.get(n) || [];
 }
 
 const catalog = JSON.parse(await readFile(join(spec, 'catalog.json'), 'utf8'));
-for (const p of catalog.primitives) {
-  if (!Array.isArray(p.effects) || p.effects.length === 0) {
-    p.effects = derive(p.name);
+for (const primitive of catalog.primitives) {
+  if (!Array.isArray(primitive.effects) || primitive.effects.length === 0) {
+    const derived = deriveEffects(primitive.name);
+    if (derived.length === 0) {
+      console.warn(`No derived effects for primitive ${primitive.id}`);
+    }
+    primitive.effects = derived;
+  }
+
+  if (
+    Array.isArray(primitive.effects) &&
+    primitive.effects.some(effect => effect.startsWith('Network.'))
+  ) {
+    if (!primitive.qos || Object.keys(primitive.qos).length === 0) {
+      primitive.qos = {
+        delivery_guarantee: 'at-least-once',
+        ordering: 'per-key'
+      };
+    }
   }
 }
-await writeFile(join(spec, 'effects.json'), canonicalize({
-  catalog_semver: catalog.catalog_semver,
-  effects: catalog.primitives.map(p => ({ id: p.id, effects: p.effects }))
-}) + '\n', 'utf8');
+
+await writeFile(
+  join(spec, 'effects.json'),
+  canonicalize({
+    catalog_semver: catalog.catalog_semver,
+    effects: catalog.primitives.map(primitive => ({
+      id: primitive.id,
+      effects: primitive.effects
+    }))
+  }) + '\n',
+  'utf8'
+);
 
 await writeFile(join(spec, 'catalog.json'), canonicalize(catalog) + '\n', 'utf8');
-console.log("effects derived and catalog.json updated.");
+console.log('effects derived and catalog.json updated.');

--- a/scripts/effects-summary.mjs
+++ b/scripts/effects-summary.mjs
@@ -1,0 +1,74 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { canonicalize } from '../packages/tf-l0-spec/scripts/canonical-json.mjs';
+
+const catalogPath = 'packages/tf-l0-spec/spec/catalog.json';
+const outputJsonPath = 'out/0.4/spec/effects-summary.json';
+const outputTextPath = 'out/0.4/spec/effects-summary.txt';
+
+const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+const effectCounts = new Map();
+const unknownEffects = [];
+const networkPrimitives = [];
+
+for (const primitive of catalog.primitives) {
+  if (!Array.isArray(primitive.effects) || primitive.effects.length === 0) {
+    unknownEffects.push(primitive.id);
+    continue;
+  }
+
+  for (const effect of primitive.effects) {
+    effectCounts.set(effect, (effectCounts.get(effect) || 0) + 1);
+  }
+
+  if (primitive.effects.some(effect => effect.startsWith('Network.')))
+    networkPrimitives.push(primitive);
+}
+
+const networkMissingDelivery = networkPrimitives
+  .filter(primitive => !primitive.qos || !primitive.qos.delivery_guarantee)
+  .map(primitive => primitive.id)
+  .sort();
+
+const networkMissingOrdering = networkPrimitives
+  .filter(primitive => !primitive.qos || !primitive.qos.ordering)
+  .map(primitive => primitive.id)
+  .sort();
+
+const sortedEffectCounts = Object.fromEntries(
+  Array.from(effectCounts.entries()).sort(([a], [b]) => a.localeCompare(b))
+);
+
+const summary = {
+  effect_counts: sortedEffectCounts,
+  network_qos: {
+    missing_delivery_guarantee: networkMissingDelivery,
+    missing_ordering: networkMissingOrdering,
+    total: networkPrimitives.length,
+    with_delivery_guarantee:
+      networkPrimitives.length - networkMissingDelivery.length,
+    with_ordering: networkPrimitives.length - networkMissingOrdering.length
+  },
+  unknown_effects: unknownEffects.sort()
+};
+
+await mkdir(dirname(outputJsonPath), { recursive: true });
+await writeFile(outputJsonPath, canonicalize(summary) + '\n', 'utf8');
+
+const totalPrimitives = catalog.primitives.length;
+const effectParts = Object.entries(sortedEffectCounts)
+  .map(([effect, count]) => `${effect}=${count}`)
+  .join(', ');
+
+const textLine = [
+  `Total primitives: ${totalPrimitives}`,
+  `Effects: ${effectParts || 'none'}`,
+  `Network QoS: delivery_guarantee ${
+    summary.network_qos.with_delivery_guarantee
+  }/${summary.network_qos.total}, ordering ${
+    summary.network_qos.with_ordering
+  }/${summary.network_qos.total}`,
+  `Unknown effects: ${summary.unknown_effects.length}`
+].join('; ');
+
+await writeFile(outputTextPath, `${textLine}\n`, 'utf8');

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+async function loadCatalog() {
+  const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+  return JSON.parse(raw);
+}
+
+test('seed effects are preserved for write-object', async () => {
+  const catalog = await loadCatalog();
+  const primitive = catalog.primitives.find(
+    entry => entry.id === 'tf:resource/write-object@1'
+  );
+  assert.ok(primitive, 'write-object primitive exists');
+  assert.deepEqual(primitive.effects, ['Storage.Write']);
+});
+
+test('no primitives have empty effects after derivation', async () => {
+  const catalog = await loadCatalog();
+  for (const primitive of catalog.primitives) {
+    assert.ok(
+      Array.isArray(primitive.effects) && primitive.effects.length > 0,
+      `${primitive.id} should have derived effects`
+    );
+  }
+});
+
+test('network primitives include delivery_guarantee in qos', async () => {
+  const catalog = await loadCatalog();
+  for (const primitive of catalog.primitives) {
+    if (
+      Array.isArray(primitive.effects) &&
+      primitive.effects.some(effect => effect.startsWith('Network.'))
+    ) {
+      assert.ok(primitive.qos, `${primitive.id} qos missing`);
+      assert.ok(
+        primitive.qos.delivery_guarantee,
+        `${primitive.id} missing delivery_guarantee`
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- derive missing effects with deterministic name-based rules and default QoS for network primitives
- add a catalog effects summary script and persist the generated report
- cover the behavior with a dedicated test and document the derivation rules

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run validate:catalog
- pnpm run lint:catalog
- pnpm run test:l0
- pnpm test *(fails: vitest cannot resolve @tf-lang/utils inside @tf-lang/adapter-execution-ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1ab52088832082b7a0725b0a5c3f