### PR TITLE
Derive missing effects and add summary tooling

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -9,3 +9,9 @@ Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
 `spec/seed/*.json` overlay into the generated catalog. The seed entries carry
 minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
 conflict detection stay runnable while curation continues.
+
+### Effect derivation rules
+Deterministic name-based rules fill in missing effect tags and default network QoS
+only when the catalog lacks curated data.
+Existing `effects` and `qos` values from the seed overlay remain authoritative
+and are never overwritten by the derivation script.

--- a/packages/tf-l0-spec/scripts/derive-effects.mjs
+++ b/packages/tf-l0-spec/scripts/derive-effects.mjs
@@ -3,25 +3,56 @@ import { join } from 'node:path';
 import { canonicalize } from './canonical-json.mjs';
 
 const spec = 'packages/tf-l0-spec/spec';
-const rules = JSON.parse(await readFile('packages/tf-l0-spec/rules/effect-rules.json', 'utf8')).rules;
 
-function derive(name) {
-  const n = name.toLowerCase();
-  const out = new Set();
-  for (const r of rules) if (new RegExp(r.match).test(n)) for (const e of r.effects) out.add(e);
-  return Array.from(out);
-}
+const EFFECT_RULES = new Map([
+  ['read-object', ['Storage.Read']],
+  ['list-objects', ['Storage.Read']],
+  ['write-object', ['Storage.Write']],
+  ['delete-object', ['Storage.Write']],
+  ['compare-and-swap', ['Storage.Write']],
+  ['publish', ['Network.Out']],
+  ['request', ['Network.Out']],
+  ['acknowledge', ['Network.Out']],
+  ['subscribe', ['Network.In']],
+  ['hash', ['Pure']],
+  ['serialize', ['Pure']],
+  ['deserialize', ['Pure']],
+  ['sign-data', ['Crypto']],
+  ['verify-signature', ['Crypto']],
+  ['encrypt', ['Crypto']],
+  ['decrypt', ['Crypto']],
+  ['emit-metric', ['Observability']],
+  ['emit-log', ['Observability']]
+]);
 
-const catalog = JSON.parse(await readFile(join(spec, 'catalog.json'), 'utf8'));
-for (const p of catalog.primitives) {
-  if (!Array.isArray(p.effects) || p.effects.length === 0) {
-    p.effects = derive(p.name);
+const NETWORK_QOS_DEFAULT = {
+  delivery_guarantee: 'at-least-once',
+  ordering: 'per-key'
+};
+
+const catalogPath = join(spec, 'catalog.json');
+const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+
+for (const primitive of catalog.primitives) {
+  if (!Array.isArray(primitive.effects) || primitive.effects.length === 0) {
+    const derived = EFFECT_RULES.get(primitive.name.toLowerCase()) ?? [];
+    primitive.effects = derived;
+  }
+
+  const hasNetworkEffect = Array.isArray(primitive.effects) && primitive.effects.some(effect => effect.startsWith('Network.'));
+  if (hasNetworkEffect && primitive.qos == null) {
+    primitive.qos = { ...NETWORK_QOS_DEFAULT };
   }
 }
+
 await writeFile(join(spec, 'effects.json'), canonicalize({
   catalog_semver: catalog.catalog_semver,
-  effects: catalog.primitives.map(p => ({ id: p.id, effects: p.effects }))
+  effects: catalog.primitives.map(primitive => ({
+    id: primitive.id,
+    effects: primitive.effects
+  }))
 }) + '\n', 'utf8');
 
-await writeFile(join(spec, 'catalog.json'), canonicalize(catalog) + '\n', 'utf8');
-console.log("effects derived and catalog.json updated.");
+await writeFile(catalogPath, canonicalize(catalog) + '\n', 'utf8');
+
+console.log('effects derived and catalog.json updated.');

--- a/scripts/effects-summary.mjs
+++ b/scripts/effects-summary.mjs
@@ -1,0 +1,72 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { canonicalize } from '../packages/tf-l0-spec/scripts/canonical-json.mjs';
+
+const catalogPath = 'packages/tf-l0-spec/spec/catalog.json';
+const outputJsonPath = 'out/0.4/spec/effects-summary.json';
+const outputTextPath = 'out/0.4/spec/effects-summary.txt';
+
+const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+
+const effectCounts = new Map();
+const unknownEffects = [];
+const networkStats = {
+  missing_qos: [],
+  total: 0,
+  with_delivery_guarantee: 0,
+  with_ordering: 0
+};
+
+for (const primitive of catalog.primitives) {
+  const effects = Array.isArray(primitive.effects) ? primitive.effects : [];
+  if (effects.length === 0) {
+    unknownEffects.push(primitive.id);
+  }
+
+  for (const effect of effects) {
+    const family = effect.includes('.') ? effect.split('.')[0] : effect;
+    effectCounts.set(family, (effectCounts.get(family) ?? 0) + 1);
+  }
+
+  const hasNetworkEffect = effects.some(effect => effect.startsWith('Network.'));
+  if (hasNetworkEffect) {
+    networkStats.total += 1;
+    if (primitive.qos == null) {
+      networkStats.missing_qos.push(primitive.id);
+    } else {
+      if (primitive.qos.delivery_guarantee != null) {
+        networkStats.with_delivery_guarantee += 1;
+      }
+      if (primitive.qos.ordering != null) {
+        networkStats.with_ordering += 1;
+      }
+      if (primitive.qos.delivery_guarantee == null || primitive.qos.ordering == null) {
+        networkStats.missing_qos.push(primitive.id);
+      }
+    }
+  }
+}
+
+const effectCountsObject = Object.fromEntries([...effectCounts.entries()].sort(([a], [b]) => a.localeCompare(b)));
+
+const summary = {
+  effect_counts: effectCountsObject,
+  network_qos: {
+    missing_qos: networkStats.missing_qos,
+    total: networkStats.total,
+    with_delivery_guarantee: networkStats.with_delivery_guarantee,
+    with_ordering: networkStats.with_ordering
+  },
+  unknown_effects: unknownEffects
+};
+
+await mkdir(dirname(outputJsonPath), { recursive: true });
+await writeFile(outputJsonPath, canonicalize(summary) + '\n', 'utf8');
+
+const familyTotals = Object.entries(effectCountsObject)
+  .map(([family, count]) => `${family}: ${count}`)
+  .join(', ');
+const textSummary = `Effect totals - ${familyTotals || 'none'} | Unknown: ${unknownEffects.length} | Network QoS missing: ${networkStats.missing_qos.length}/${networkStats.total}`;
+await writeFile(outputTextPath, `${textSummary}\n`, 'utf8');
+
+console.log('effects summary written.');

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+await import('../packages/tf-l0-spec/scripts/derive-effects.mjs');
+
+async function loadCatalog() {
+  const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+  return JSON.parse(raw);
+}
+
+test('seed primitive retains curated effects', async () => {
+  const catalog = await loadCatalog();
+  const primitive = catalog.primitives.find(p => p.id === 'tf:resource/write-object@1');
+  assert.ok(primitive, 'tf:resource/write-object@1 present');
+  assert.deepEqual(primitive.effects, ['Storage.Write']);
+});
+
+test('all primitives have at least one effect', async () => {
+  const catalog = await loadCatalog();
+  const missing = catalog.primitives.filter(
+    p => !Array.isArray(p.effects) || p.effects.length === 0
+  );
+  assert.deepEqual(missing, [], 'no primitives missing effects');
+});
+
+test('network primitives include qos delivery guarantee', async () => {
+  const catalog = await loadCatalog();
+  const offending = catalog.primitives.filter(primitive => {
+    if (!Array.isArray(primitive.effects)) {
+      return false;
+    }
+    const hasNetwork = primitive.effects.some(effect => effect.startsWith('Network.'));
+    if (!hasNetwork) {
+      return false;
+    }
+    return primitive.qos == null || primitive.qos.delivery_guarantee == null;
+  });
+  assert.deepEqual(offending, [], 'all network primitives have qos.delivery_guarantee');
+});


### PR DESCRIPTION
## Summary
- add deterministic name-based effect derivation plus default network QoS without touching curated entries
- provide an effects summary script that reports catalog coverage and network QoS status
- document the derivation guarantees and add targeted tests covering seed preservation, completeness, and QoS

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run validate:catalog
- pnpm run lint:catalog
- pnpm run test:l0
- node scripts/effects-summary.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf1ab52088832082b7a0725b0a5c3f