### PR TITLE
Add SMT emitter for parallel write conflicts

### DIFF
--- a/packages/tf-l0-proofs/src/smt.mjs
+++ b/packages/tf-l0-proofs/src/smt.mjs
@@ -1,0 +1,119 @@
+const UNKNOWN_URI = 'res://unknown';
+
+function escapeString(value = '') {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object';
+}
+
+function firstWriteUri(node) {
+  if (!isObject(node)) {
+    return null;
+  }
+
+  if (Array.isArray(node.writes)) {
+    for (const entry of node.writes) {
+      const uri = entry?.uri;
+      if (typeof uri === 'string' && uri.length > 0) {
+        return uri;
+      }
+    }
+  }
+
+  const direct = node?.args?.uri || node?.args?.resource_uri;
+  if (typeof direct === 'string' && direct.length > 0) {
+    return direct;
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const uri = firstWriteUri(child);
+      if (typeof uri === 'string' && uri.length > 0) {
+        return uri;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function emitSMT(ir) {
+  const uriCache = new WeakMap();
+  const uriDecls = [];
+  const uriAssertions = [];
+  const conflictDecls = [];
+  const conflictAssertions = [];
+  const conflictVars = [];
+
+  let uriCounter = 0;
+  let parCounter = 0;
+
+  function ensureUri(node) {
+    if (!isObject(node)) {
+      const name = `uri_${uriCounter++}`;
+      uriDecls.push(`(declare-const ${name} String)`);
+      uriAssertions.push(`(assert (= ${name} \"${escapeString(UNKNOWN_URI)}\"))`);
+      return { name, value: UNKNOWN_URI };
+    }
+
+    if (uriCache.has(node)) {
+      return uriCache.get(node);
+    }
+
+    const name = `uri_${uriCounter++}`;
+    const uri = firstWriteUri(node) || UNKNOWN_URI;
+    uriDecls.push(`(declare-const ${name} String)`);
+    uriAssertions.push(`(assert (= ${name} \"${escapeString(uri)}\"))`);
+    const record = { name, value: uri };
+    uriCache.set(node, record);
+    return record;
+  }
+
+  function visit(node) {
+    if (!isObject(node)) {
+      return;
+    }
+
+    if (node.node === 'Par' && Array.isArray(node.children) && node.children.length > 0) {
+      const currentPar = parCounter++;
+      const childInfos = node.children.map(child => ensureUri(child));
+      for (let i = 0; i < childInfos.length; i++) {
+        for (let j = i + 1; j < childInfos.length; j++) {
+          const infoA = childInfos[i];
+          const infoB = childInfos[j];
+          const varName = `conflict_${currentPar}_${i}_${j}`;
+          conflictDecls.push(`(declare-const ${varName} Bool)`);
+          conflictAssertions.push(
+            `(assert (= ${varName} (= ${infoA.name} ${infoB.name})))`
+          );
+          conflictVars.push(varName);
+        }
+      }
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(ir);
+
+  const lines = [];
+  lines.push('; SMT encoding for parallel write conflicts');
+  lines.push(...uriDecls);
+  lines.push(...uriAssertions);
+  lines.push(...conflictDecls);
+  lines.push(...conflictAssertions);
+
+  const finalAssert = conflictVars.length > 0
+    ? `(assert (not (or ${conflictVars.join(' ')})))`
+    : '(assert (not (or )))';
+  lines.push(finalAssert);
+  lines.push('(check-sat)');
+
+  return lines.join('\n') + '\n';
+}

--- a/scripts/emit-smt.mjs
+++ b/scripts/emit-smt.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error('Usage: node scripts/emit-smt.mjs <flow.tf> -o <out.smt2>');
+  process.exit(2);
+}
+
+const flowPath = args[0];
+if (!flowPath) {
+  console.error('Missing flow path.');
+  process.exit(2);
+}
+
+let outPath = null;
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === '-o' || args[i] === '--out') {
+    outPath = args[i + 1] || null;
+    break;
+  }
+}
+
+if (!outPath) {
+  console.error('Missing output path.');
+  process.exit(2);
+}
+
+const source = await readFile(flowPath, 'utf8');
+const ir = parseDSL(source);
+const payload = emitSMT(ir);
+
+await mkdir(dirname(outPath), { recursive: true });
+await writeFile(outPath, payload, 'utf8');

--- a/tests/smt-emit.test.mjs
+++ b/tests/smt-emit.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
+
+async function loadIR(path) {
+  const source = await readFile(path, 'utf8');
+  return parseDSL(source);
+}
+
+function countParPairs(node) {
+  if (!node || typeof node !== 'object') {
+    return 0;
+  }
+
+  let total = 0;
+  if (node.node === 'Par' && Array.isArray(node.children)) {
+    const n = node.children.length;
+    total += (n * (n - 1)) / 2;
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      total += countParPairs(child);
+    }
+  }
+
+  return total;
+}
+
+test('emitSMT encodes storage conflict flow', async () => {
+  const ir = await loadIR('examples/flows/storage_conflict.tf');
+  const smt = emitSMT(ir);
+  const again = emitSMT(ir);
+  assert.equal(smt, again, 'SMT emission must be deterministic');
+
+  assert.ok(smt.includes('(assert (not (or'), 'final assert missing');
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'missing check-sat');
+
+  const decls = smt.match(/\(declare-const conflict_[^\s]* Bool\)/g) || [];
+  const expectedPairs = countParPairs(ir);
+  assert.equal(decls.length, expectedPairs, 'pair count mismatch');
+  assert.ok(decls.length > 0, 'expected at least one conflict declaration');
+});
+
+test('emitSMT encodes storage ok flow', async () => {
+  const ir = await loadIR('examples/flows/storage_ok.tf');
+  const smt = emitSMT(ir);
+  const again = emitSMT(ir);
+  assert.equal(smt, again, 'SMT emission must be deterministic');
+
+  assert.ok(smt.includes('(assert (not (or'), 'final assert missing');
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'missing check-sat');
+
+  const decls = smt.match(/\(declare-const conflict_[^\s]* Bool\)/g) || [];
+  const expectedPairs = countParPairs(ir);
+  assert.equal(decls.length, expectedPairs, 'pair count mismatch');
+});


### PR DESCRIPTION
## Summary
- add an SMT emitter that detects parallel write conflicts and encodes them into SMT-LIB
- introduce a CLI helper to generate SMT payloads from flow files
- cover the new emitter with deterministic regression tests for conflict and non-conflict flows

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf1acd0f0c83208c44ae31428229ee