### PR TITLE
Add SMT emitter for parallel write conflicts

### DIFF
--- a/packages/tf-l0-proofs/src/smt.mjs
+++ b/packages/tf-l0-proofs/src/smt.mjs
@@ -10,32 +10,42 @@ export function emitSMT(ir) {
     }
     if (node.node === 'Par' && Array.isArray(node.children)) {
       const currentPar = parIndex++;
-      const childUris = node.children.map((child) => selectUri(child));
-      for (let i = 0; i < childUris.length; i++) {
-        for (let j = i + 1; j < childUris.length; j++) {
-          const conflictName = `conflict_p${currentPar}_${i}_${j}`;
-          declarations.push(`(declare-const ${conflictName} Bool)`);
-          const left = stringLiteral(childUris[i]);
-          const right = stringLiteral(childUris[j]);
-          conflictAssertions.push(
-            `(assert (= ${conflictName} (= ${left} ${right})))`
-          );
-          conflictNames.push(conflictName);
+      for (let i = 0; i < node.children.length; i++) {
+        const leftUris = collectWriteUris(node.children[i]);
+        if (leftUris.length === 0) {
+          continue;
+        }
+        for (let j = i + 1; j < node.children.length; j++) {
+          const rightUris = collectWriteUris(node.children[j]);
+          if (rightUris.length === 0) {
+            continue;
+          }
+          for (let a = 0; a < leftUris.length; a++) {
+            for (let b = 0; b < rightUris.length; b++) {
+              const conflictName = `conflict_p${currentPar}_${i}_${j}_${a}_${b}`;
+              declarations.push(`(declare-const ${conflictName} Bool)`);
+              const left = stringLiteral(leftUris[a]);
+              const right = stringLiteral(rightUris[b]);
+              conflictAssertions.push(
+                `(assert (= ${conflictName} (= ${left} ${right})))`
+              );
+              conflictNames.push(conflictName);
+            }
+          }
         }
       }
     }
   });
 
   const body = [];
-  if (declarations.length === 0 && conflictAssertions.length === 0) {
-    // still provide a deterministic empty model
-  } else {
-    body.push(...declarations);
-    body.push(...conflictAssertions);
-  }
+  body.push(...declarations);
+  body.push(...conflictAssertions);
 
-  const orArgs = conflictNames.join(' ');
-  body.push(`(assert (not (or${orArgs ? ' ' + orArgs : ''})))`);
+  if (conflictNames.length === 0) {
+    body.push('(assert true)');
+  } else {
+    body.push(`(assert (not (or ${conflictNames.join(' ')})))`);
+  }
   body.push('(check-sat)');
   return body.join('\n') + '\n';
 }
@@ -52,46 +62,57 @@ function walk(node, visit) {
   }
 }
 
-function selectUri(node) {
-  const uris = collectWriteUris(node);
-  if (uris.length > 0) {
-    return uris[0];
-  }
-  const fromArgs = extractUriFromArgs(node?.args || {});
-  if (fromArgs) {
-    return fromArgs;
-  }
-  return 'res://unknown';
-}
-
 function collectWriteUris(node) {
   if (!node || typeof node !== 'object') {
     return [];
   }
-  const uris = [];
-  if (Array.isArray(node.writes)) {
-    for (const w of node.writes) {
-      const uri = w?.uri;
-      if (typeof uri === 'string' && uri.length > 0) {
-        uris.push(uri);
-      }
-    }
+  if (Array.isArray(node.writes) && node.writes.length > 0) {
+    return dedupeAndSort(
+      node.writes
+        .map((entry) => concretizeUri(entry, node.args))
+        .filter((uri) => typeof uri === 'string' && uri.length > 0)
+    );
   }
-  if (uris.length === 0 && Array.isArray(node.children)) {
+  if (Array.isArray(node.children)) {
+    const collected = [];
     for (const child of node.children) {
-      uris.push(...collectWriteUris(child));
+      collected.push(...collectWriteUris(child));
     }
+    return dedupeAndSort(collected);
   }
-  if (uris.length === 0 && node.node === 'Prim') {
-    const inferred = extractUriFromArgs(node.args || {});
-    if (inferred) {
-      uris.push(inferred);
-    }
-  }
-  return uris;
+  return [];
 }
 
-function extractUriFromArgs(args = {}) {
+function stringLiteral(value) {
+  const s = typeof value === 'string' ? value : 'res://unknown';
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function concretizeUri(entry, args = {}) {
+  const uri = normalizeUri(entry);
+  if (uri && !isAbstractUri(uri)) {
+    return uri;
+  }
+  const fromArgs = selectUriFromArgs(args);
+  return fromArgs && fromArgs.length > 0 ? fromArgs : null;
+}
+
+function normalizeUri(entry) {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+  if (entry && typeof entry === 'object' && typeof entry.uri === 'string') {
+    return entry.uri;
+  }
+  return null;
+}
+
+function isAbstractUri(uri) {
+  return uri === 'res://unknown' || /[<>]/.test(uri);
+}
+
+function selectUriFromArgs(args = {}) {
   if (!args || typeof args !== 'object') {
     return null;
   }
@@ -105,8 +126,6 @@ function extractUriFromArgs(args = {}) {
   return null;
 }
 
-function stringLiteral(value) {
-  const s = typeof value === 'string' ? value : 'res://unknown';
-  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  return `"${escaped}"`;
+function dedupeAndSort(values = []) {
+  return Array.from(new Set(values)).sort();
 }

--- a/packages/tf-l0-proofs/src/smt.mjs
+++ b/packages/tf-l0-proofs/src/smt.mjs
@@ -1,0 +1,112 @@
+export function emitSMT(ir) {
+  const declarations = [];
+  const conflictAssertions = [];
+  const conflictNames = [];
+  let parIndex = 0;
+
+  walk(ir, (node) => {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node === 'Par' && Array.isArray(node.children)) {
+      const currentPar = parIndex++;
+      const childUris = node.children.map((child) => selectUri(child));
+      for (let i = 0; i < childUris.length; i++) {
+        for (let j = i + 1; j < childUris.length; j++) {
+          const conflictName = `conflict_p${currentPar}_${i}_${j}`;
+          declarations.push(`(declare-const ${conflictName} Bool)`);
+          const left = stringLiteral(childUris[i]);
+          const right = stringLiteral(childUris[j]);
+          conflictAssertions.push(
+            `(assert (= ${conflictName} (= ${left} ${right})))`
+          );
+          conflictNames.push(conflictName);
+        }
+      }
+    }
+  });
+
+  const body = [];
+  if (declarations.length === 0 && conflictAssertions.length === 0) {
+    // still provide a deterministic empty model
+  } else {
+    body.push(...declarations);
+    body.push(...conflictAssertions);
+  }
+
+  const orArgs = conflictNames.join(' ');
+  body.push(`(assert (not (or${orArgs ? ' ' + orArgs : ''})))`);
+  body.push('(check-sat)');
+  return body.join('\n') + '\n';
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}
+
+function selectUri(node) {
+  const uris = collectWriteUris(node);
+  if (uris.length > 0) {
+    return uris[0];
+  }
+  const fromArgs = extractUriFromArgs(node?.args || {});
+  if (fromArgs) {
+    return fromArgs;
+  }
+  return 'res://unknown';
+}
+
+function collectWriteUris(node) {
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+  const uris = [];
+  if (Array.isArray(node.writes)) {
+    for (const w of node.writes) {
+      const uri = w?.uri;
+      if (typeof uri === 'string' && uri.length > 0) {
+        uris.push(uri);
+      }
+    }
+  }
+  if (uris.length === 0 && Array.isArray(node.children)) {
+    for (const child of node.children) {
+      uris.push(...collectWriteUris(child));
+    }
+  }
+  if (uris.length === 0 && node.node === 'Prim') {
+    const inferred = extractUriFromArgs(node.args || {});
+    if (inferred) {
+      uris.push(inferred);
+    }
+  }
+  return uris;
+}
+
+function extractUriFromArgs(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const val = args[key];
+    if (typeof val === 'string' && val.length > 0) {
+      return val;
+    }
+  }
+  return null;
+}
+
+function stringLiteral(value) {
+  const s = typeof value === 'string' ? value : 'res://unknown';
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}

--- a/scripts/emit-smt.mjs
+++ b/scripts/emit-smt.mjs
@@ -1,38 +1,33 @@
 #!/usr/bin/env node
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, extname, resolve } from 'node:path';
 import process from 'node:process';
+import { parseArgs } from 'node:util';
 
 import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
 import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
 
 async function main(argv) {
-  const args = argv.slice(2);
-  if (args.length === 0) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: { out: { type: 'string', short: 'o' } },
+    allowPositionals: true
+  });
+
+  if (positionals.length !== 1) {
     usage();
     process.exit(1);
   }
 
-  const input = args[0];
-  let output = null;
+  const flowPath = positionals[0];
+  const outputArg = values.out ?? defaultOut(flowPath);
+  const srcPath = resolve(flowPath);
+  const outPath = resolve(outputArg);
 
-  for (let i = 1; i < args.length; i++) {
-    const part = args[i];
-    if (part === '-o' || part === '--output') {
-      output = args[i + 1] || null;
-      i++;
-    }
-  }
-
-  if (!output) {
-    usage();
-    process.exit(1);
-  }
-
-  const srcPath = resolve(input);
-  const outPath = resolve(output);
+  const catalog = await loadCatalog();
   const raw = await readFile(srcPath, 'utf8');
   const ir = parseDSL(raw);
+  annotateWrites(ir, catalog);
   const smt = emitSMT(ir);
 
   await mkdir(dirname(outPath), { recursive: true });
@@ -41,7 +36,108 @@ async function main(argv) {
 }
 
 function usage() {
-  process.stderr.write('Usage: node scripts/emit-smt.mjs <flow.tf> -o <output.smt2>\n');
+  process.stderr.write(
+    'Usage: node scripts/emit-smt.mjs <flow.tf> [-o out/0.4/proofs/<name>.smt2]\n'
+  );
+}
+
+function defaultOut(flowPath) {
+  const base = basename(flowPath);
+  const ext = extname(base);
+  const stem = ext ? base.slice(0, -ext.length) : base;
+  return `out/0.4/proofs/${stem}.smt2`;
+}
+
+async function loadCatalog() {
+  const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+  const raw = await readFile(catalogUrl, 'utf8');
+  return JSON.parse(raw);
+}
+
+function annotateWrites(ir, catalog) {
+  const index = buildCatalogIndex(catalog);
+  walk(ir, (node) => {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node === 'Prim') {
+      const primName = typeof node.prim === 'string' ? node.prim.toLowerCase() : '';
+      const prim = index.get(primName);
+      if (!prim) {
+        return;
+      }
+      const concretized = concretizeWrites(prim.writes, node.args);
+      if (concretized.length > 0) {
+        node.writes = concretized;
+      }
+    }
+  });
+}
+
+function buildCatalogIndex(catalog = {}) {
+  const index = new Map();
+  for (const prim of catalog.primitives || []) {
+    if (prim && typeof prim.name === 'string') {
+      index.set(prim.name.toLowerCase(), prim);
+    }
+  }
+  return index;
+}
+
+function concretizeWrites(writes = [], args = {}) {
+  if (!Array.isArray(writes) || writes.length === 0) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const entry of writes) {
+    const uri = concretizeUri(entry?.uri, args);
+    if (!uri || seen.has(uri)) {
+      continue;
+    }
+    seen.add(uri);
+    result.push({ ...entry, uri });
+  }
+  result.sort((a, b) => a.uri.localeCompare(b.uri));
+  return result;
+}
+
+function concretizeUri(uri, args = {}) {
+  if (isConcreteUri(uri)) {
+    return uri;
+  }
+  const fromArgs = selectUriFromArgs(args);
+  return isConcreteUri(fromArgs) ? fromArgs : null;
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && uri !== 'res://unknown' && !/[<>]/.test(uri);
+}
+
+function selectUriFromArgs(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
 }
 
 main(process.argv).catch((err) => {

--- a/scripts/emit-smt.mjs
+++ b/scripts/emit-smt.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
+
+async function main(argv) {
+  const args = argv.slice(2);
+  if (args.length === 0) {
+    usage();
+    process.exit(1);
+  }
+
+  const input = args[0];
+  let output = null;
+
+  for (let i = 1; i < args.length; i++) {
+    const part = args[i];
+    if (part === '-o' || part === '--output') {
+      output = args[i + 1] || null;
+      i++;
+    }
+  }
+
+  if (!output) {
+    usage();
+    process.exit(1);
+  }
+
+  const srcPath = resolve(input);
+  const outPath = resolve(output);
+  const raw = await readFile(srcPath, 'utf8');
+  const ir = parseDSL(raw);
+  const smt = emitSMT(ir);
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, smt, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage() {
+  process.stderr.write('Usage: node scripts/emit-smt.mjs <flow.tf> -o <output.smt2>\n');
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(String(err?.stack || err));
+  process.stderr.write('\n');
+  process.exit(1);
+});

--- a/tests/smt-emit.test.mjs
+++ b/tests/smt-emit.test.mjs
@@ -7,16 +7,22 @@ import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
 
 const conflictFlow = new URL('../examples/flows/storage_conflict.tf', import.meta.url);
 const okFlow = new URL('../examples/flows/storage_ok.tf', import.meta.url);
+const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+
+const catalogPromise = readFile(catalogUrl, 'utf8').then((raw) => JSON.parse(raw));
 
 async function loadIR(url) {
   const source = await readFile(url, 'utf8');
-  return parseDSL(source);
+  const ir = parseDSL(source);
+  const catalog = await catalogPromise;
+  annotateWrites(ir, catalog);
+  return ir;
 }
 
 test('storage_conflict emits conflict assertions', async () => {
   const ir = await loadIR(conflictFlow);
   const smt = emitSMT(ir);
-  assert.ok(/\(assert \(not \(or/.test(smt), 'should include global validity assert');
+  assert.ok(/\(assert \(not \(or /.test(smt), 'should include global validity assert');
   const declared = smt.match(/\(declare-const\s+conflict_/g) || [];
   assert.ok(declared.length >= 1, 'at least one conflict declared');
   assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
@@ -29,6 +35,126 @@ test('storage_ok emits deterministic model without conflicts', async () => {
   assert.equal(first, second, 'emission is deterministic');
   const declared = first.match(/\(declare-const\s+conflict_/g) || [];
   assert.equal(declared.length, 0, 'no conflicts declared for sequential flow');
-  assert.ok(first.includes('(assert (not (or)))'), 'validity assert handles empty ors');
+  assert.ok(first.includes('(assert true)'), 'validity assert handles no conflicts');
   assert.ok(/\(check-sat\)\s*$/.test(first), 'ends with check-sat');
 });
+
+test('multi-write branch conflicts on shared target', async () => {
+  const catalog = await catalogPromise;
+  const ir = parseDSL(`authorize{
+    par{
+      seq{
+        write-object(uri="res://a", key="x", value="1");
+        write-object(uri="res://b", key="x", value="2")
+      };
+      write-object(uri="res://b", key="y", value="3")
+    }
+  }`);
+  annotateWrites(ir, catalog);
+  const smt = emitSMT(ir);
+  const declared = smt.match(/\(declare-const\s+conflict_/g) || [];
+  assert.ok(declared.length >= 1, 'at least one conflict declared');
+  assert.ok(smt.includes('(= "res://b" "res://b")'), 'conflict pairs include res://b vs res://b');
+  assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
+});
+
+test('read-only par produces no conflicts', async () => {
+  const catalog = await catalogPromise;
+  const ir = parseDSL(`authorize{
+    par{
+      read-object(uri="res://a", key="1");
+      read-object(uri="res://b", key="2")
+    }
+  }`);
+  annotateWrites(ir, catalog);
+  const smt = emitSMT(ir);
+  assert.ok(!/\(declare-const\s+conflict_/.test(smt), 'no conflict vars declared');
+  assert.ok(smt.includes('(assert true)'), 'falls back to assert true');
+  assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
+});
+
+function annotateWrites(ir, catalog) {
+  const index = buildCatalogIndex(catalog);
+  walk(ir, (node) => {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node === 'Prim') {
+      const primName = typeof node.prim === 'string' ? node.prim.toLowerCase() : '';
+      const prim = index.get(primName);
+      if (!prim) {
+        return;
+      }
+      const writes = concretizeWrites(prim.writes, node.args);
+      if (writes.length > 0) {
+        node.writes = writes;
+      }
+    }
+  });
+}
+
+function buildCatalogIndex(catalog = {}) {
+  const index = new Map();
+  for (const prim of catalog.primitives || []) {
+    if (prim && typeof prim.name === 'string') {
+      index.set(prim.name.toLowerCase(), prim);
+    }
+  }
+  return index;
+}
+
+function concretizeWrites(writes = [], args = {}) {
+  if (!Array.isArray(writes) || writes.length === 0) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const entry of writes) {
+    const uri = concretizeUri(entry?.uri, args);
+    if (!uri || seen.has(uri)) {
+      continue;
+    }
+    seen.add(uri);
+    result.push({ ...entry, uri });
+  }
+  result.sort((a, b) => a.uri.localeCompare(b.uri));
+  return result;
+}
+
+function concretizeUri(uri, args = {}) {
+  if (isConcreteUri(uri)) {
+    return uri;
+  }
+  const fromArgs = selectUriFromArgs(args);
+  return isConcreteUri(fromArgs) ? fromArgs : null;
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && uri !== 'res://unknown' && !/[<>]/.test(uri);
+}
+
+function selectUriFromArgs(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}

--- a/tests/smt-emit.test.mjs
+++ b/tests/smt-emit.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
+
+const conflictFlow = new URL('../examples/flows/storage_conflict.tf', import.meta.url);
+const okFlow = new URL('../examples/flows/storage_ok.tf', import.meta.url);
+
+async function loadIR(url) {
+  const source = await readFile(url, 'utf8');
+  return parseDSL(source);
+}
+
+test('storage_conflict emits conflict assertions', async () => {
+  const ir = await loadIR(conflictFlow);
+  const smt = emitSMT(ir);
+  assert.ok(/\(assert \(not \(or/.test(smt), 'should include global validity assert');
+  const declared = smt.match(/\(declare-const\s+conflict_/g) || [];
+  assert.ok(declared.length >= 1, 'at least one conflict declared');
+  assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
+});
+
+test('storage_ok emits deterministic model without conflicts', async () => {
+  const ir = await loadIR(okFlow);
+  const first = emitSMT(ir);
+  const second = emitSMT(ir);
+  assert.equal(first, second, 'emission is deterministic');
+  const declared = first.match(/\(declare-const\s+conflict_/g) || [];
+  assert.equal(declared.length, 0, 'no conflicts declared for sequential flow');
+  assert.ok(first.includes('(assert (not (or)))'), 'validity assert handles empty ors');
+  assert.ok(/\(check-sat\)\s*$/.test(first), 'ends with check-sat');
+});


### PR DESCRIPTION
## Summary
- add an SMT emitter that encodes parallel write conflict booleans and a global validity assertion
- wire a CLI helper to parse a flow and emit the deterministic SMT-LIB model
- cover the new emitter with deterministic output tests for conflict and non-conflict flows

## Testing
- pnpm run a0
- pnpm run a1
- node scripts/emit-smt.mjs examples/flows/storage_conflict.tf -o out/0.4/proofs/storage_conflict.smt2
- node scripts/emit-smt.mjs examples/flows/storage_ok.tf -o out/0.4/proofs/storage_ok.smt2
- pnpm test *(fails: @tf-lang/adapter-execution-ts@0.1.0 test: `vitest run`)*
- node --test tests/smt-emit.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf1acd0f0c83208c44ae31428229ee