### PR TITLE
Add SMT emitter for parallel write conflicts

### DIFF
--- a/examples/flows/storage_ok.tf
+++ b/examples/flows/storage_ok.tf
@@ -1,6 +1,6 @@
 authorize{
-  seq{
-    write-object(uri="res://kv/bucket", key="x", value="1");
-    write-object(uri="res://kv/bucket", key="y", value="2")
+  par{
+    write-object(uri="res://kv/bucket/x", key="x", value="1");
+    write-object(uri="res://kv/bucket/y", key="y", value="2")
   }
 }

--- a/packages/tf-l0-proofs/src/smt.mjs
+++ b/packages/tf-l0-proofs/src/smt.mjs
@@ -1,0 +1,126 @@
+const UNKNOWN_URI = 'res://unknown';
+
+function isObject(value) {
+  return value !== null && typeof value === 'object';
+}
+
+function stringLiteral(value) {
+  return JSON.stringify(String(value ?? UNKNOWN_URI));
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && !/[<>]/.test(uri);
+}
+
+function argUri(node) {
+  if (!isObject(node?.args)) {
+    return null;
+  }
+  const candidate = node.args.uri || node.args.resource_uri;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+}
+
+function gatherUris(node) {
+  if (!isObject(node)) {
+    return [];
+  }
+
+  let sawWrites = false;
+  const concrete = new Set();
+  const placeholders = new Set();
+
+  if (Array.isArray(node.writes) && node.writes.length > 0) {
+    sawWrites = true;
+    for (const write of node.writes) {
+      const uri = write && typeof write.uri === 'string' ? write.uri : null;
+      if (!uri) {
+        continue;
+      }
+      if (isConcreteUri(uri)) {
+        concrete.add(uri);
+      } else {
+        placeholders.add(uri);
+      }
+    }
+  }
+
+  if (concrete.size > 0) {
+    return Array.from(concrete);
+  }
+
+  const fromArgs = argUri(node);
+  if (fromArgs) {
+    return [fromArgs];
+  }
+
+  if (Array.isArray(node.children)) {
+    const viaChildren = new Set();
+    for (const child of node.children) {
+      for (const uri of gatherUris(child)) {
+        viaChildren.add(uri);
+      }
+    }
+    if (viaChildren.size > 0) {
+      return Array.from(viaChildren);
+    }
+  }
+
+  if (sawWrites && placeholders.size > 0) {
+    return Array.from(placeholders);
+  }
+
+  return [];
+}
+
+function uriSymbol(node) {
+  const uris = gatherUris(node);
+  if (uris.length === 1) {
+    return stringLiteral(uris[0]);
+  }
+  return stringLiteral(UNKNOWN_URI);
+}
+
+export function emitSMT(ir) {
+  const declarations = [];
+  const pairAssertions = [];
+  const conflictNames = [];
+  let parIndex = 0;
+
+  function visit(node) {
+    if (!isObject(node)) {
+      return;
+    }
+
+    if (node.node === 'Par' && Array.isArray(node.children)) {
+      const localIndex = parIndex++;
+      const childUris = node.children.map(uriSymbol);
+      for (let i = 0; i < childUris.length; i++) {
+        for (let j = i + 1; j < childUris.length; j++) {
+          const name = `conflict_${localIndex}_${i}_${j}`;
+          declarations.push(`(declare-const ${name} Bool)`);
+          pairAssertions.push(`(assert (= ${name} (= ${childUris[i]} ${childUris[j]})))`);
+          conflictNames.push(name);
+        }
+      }
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(ir);
+
+  const lines = [];
+  lines.push(...declarations);
+  lines.push(...pairAssertions);
+  if (conflictNames.length > 0) {
+    lines.push(`(assert (not (or ${conflictNames.join(' ')})))`);
+  } else {
+    lines.push('(assert true)');
+  }
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}

--- a/scripts/emit-smt.mjs
+++ b/scripts/emit-smt.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, extname } from 'node:path';
+import process from 'node:process';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { checkIR } from '../packages/tf-l0-check/src/check.mjs';
+import { emitSMT } from '../packages/tf-l0-proofs/src/smt.mjs';
+
+async function loadCatalog() {
+  try {
+    const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+    const raw = await readFile(catalogUrl, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+function annotateWrites(node, catalog) {
+  if (!node || typeof node !== 'object' || node === null) {
+    return;
+  }
+  try {
+    const verdict = checkIR(node, catalog) || {};
+    node.writes = Array.isArray(verdict.writes) ? verdict.writes : [];
+  } catch {
+    node.writes = Array.isArray(node.writes) ? node.writes : [];
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      annotateWrites(child, catalog);
+    }
+  }
+}
+
+function usage() {
+  console.error('Usage: node scripts/emit-smt.mjs <flow.tf> [-o <out.smt2>]');
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  usage();
+  process.exit(1);
+}
+
+const flowPath = args[0];
+let outPath = null;
+for (let i = 1; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === '-o' || arg === '--out') {
+    outPath = args[i + 1] || null;
+    i++;
+  }
+}
+
+const defaultOut = () => {
+  const base = basename(flowPath, extname(flowPath) || undefined) || 'flow';
+  return `out/0.4/proofs/${base}.smt2`;
+};
+
+try {
+  const source = await readFile(flowPath, 'utf8');
+  const ir = parseDSL(source);
+  const catalog = await loadCatalog();
+  annotateWrites(ir, catalog);
+  const smt = emitSMT(ir);
+  const target = outPath || defaultOut();
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, smt, 'utf8');
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/tests/smt-emit.test.mjs
+++ b/tests/smt-emit.test.mjs
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { emitSMT } = await import('../packages/tf-l0-proofs/src/smt.mjs');
+const { checkIR } = await import('../packages/tf-l0-check/src/check.mjs');
+
+async function loadCatalog() {
+  try {
+    const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+    return JSON.parse(await readFile(catalogUrl, 'utf8'));
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+function annotateWrites(node, catalog) {
+  if (!node || typeof node !== 'object' || node === null) {
+    return;
+  }
+  const verdict = checkIR(node, catalog) || {};
+  node.writes = Array.isArray(verdict.writes) ? verdict.writes : [];
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      annotateWrites(child, catalog);
+    }
+  }
+}
+
+function countPairs(node) {
+  if (!node || typeof node !== 'object' || node === null) {
+    return 0;
+  }
+  let total = 0;
+  if (node.node === 'Par' && Array.isArray(node.children)) {
+    const n = node.children.length;
+    total += (n * (n - 1)) / 2;
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      total += countPairs(child);
+    }
+  }
+  return total;
+}
+
+test('storage conflict flow encodes at least one conflict pair', async () => {
+  const catalog = await loadCatalog();
+  const src = await readFile(new URL('../examples/flows/storage_conflict.tf', import.meta.url), 'utf8');
+  const ir = parseDSL(src);
+  annotateWrites(ir, catalog);
+  const smt = emitSMT(ir);
+  assert.match(smt, /\(declare-const conflict_\d+_\d+_\d+ Bool\)/);
+  assert.match(smt, /\(assert \(not \(or conflict_\d+_\d+_\d+/);
+  const equality = smt.match(/\(assert \(= (conflict_\d+_\d+_\d+) \(= "([^"]+)" "([^"]+)"\)\)\)/);
+  assert.ok(equality, 'expected an equality assertion for a conflict variable');
+  assert.equal(equality[2], equality[3]);
+  assert.match(smt, /\(check-sat\)/);
+});
+
+test('storage ok flow is deterministic and pair counts match', async () => {
+  const catalog = await loadCatalog();
+  const src = await readFile(new URL('../examples/flows/storage_ok.tf', import.meta.url), 'utf8');
+  const ir = parseDSL(src);
+  annotateWrites(ir, catalog);
+  const smtOne = emitSMT(ir);
+  const smtTwo = emitSMT(ir);
+  assert.equal(smtOne, smtTwo);
+  const expectedPairs = countPairs(ir);
+  const declared = (smtOne.match(/\(declare-const conflict_/g) || []).length;
+  assert.equal(declared, expectedPairs);
+  assert.match(smtOne, /\(assert \(not \(or conflict_\d+_\d+_\d+/);
+  assert.match(smtOne, /\(check-sat\)/);
+});


### PR DESCRIPTION
## Summary
- add an SMT emitter that encodes pairwise Par write conflicts with deterministic declarations and assertions
- wire up a `scripts/emit-smt.mjs` helper to parse flows, annotate writes, and write `.smt2` artifacts
- adjust the storage_ok example to exercise Par without conflicts and add regression tests covering both conflict and non-conflict flows

## Testing
- pnpm run a0
- pnpm run a1
- node scripts/emit-smt.mjs examples/flows/storage_conflict.tf -o out/0.4/proofs/storage_conflict.smt2
- node scripts/emit-smt.mjs examples/flows/storage_ok.tf -o out/0.4/proofs/storage_ok.smt2
- pnpm test *(fails: @tf-lang/adapter-execution-ts@0.1.0 test: `vitest run`)*
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf1acd0f0c83208c44ae31428229ee