### PR TITLE
Add v0.4 manifest schema and validator

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -14,3 +14,8 @@ conflict detection stay runnable while curation continues.
 Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
 Seed overlays remain authoritative for existing effects or qos values.
 Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+
+### Manifest compatibility
+Capability manifests now include both the legacy `effects`/`footprints` fields and the new v0.4 `required_effects`/`footprints_rw`/`qos` fields.
+This dual shape keeps downstream consumers running while newer tooling migrates to the richer structure.
+Use `scripts/validate-manifest.mjs` to check either shape against the shared JSON Schema.

--- a/schemas/manifest.v0.4.schema.json
+++ b/schemas/manifest.v0.4.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://meta-ontology.local/schemas/manifest.v0.4.schema.json",
+  "title": "Capability Manifest v0.4",
+  "oneOf": [
+    {
+      "title": "Legacy manifest (v0.3)",
+      "type": "object",
+      "required": ["effects", "scopes", "footprints"],
+      "properties": {
+        "effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/footprintEntry" }
+        },
+        "seed": { "type": "integer" },
+        "clock_epoch": { "type": "integer" },
+        "catalog_hash": { "type": "string" },
+        "required_effects": false,
+        "footprints_rw": false,
+        "qos": false
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "Manifest v0.4",
+      "type": "object",
+      "required": ["required_effects", "footprints_rw", "qos"],
+      "properties": {
+        "required_effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints_rw": {
+          "type": "object",
+          "properties": {
+            "reads": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/readFootprint" }
+            },
+            "writes": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/writeFootprint" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "qos": {
+          "type": "object",
+          "properties": {
+            "delivery_guarantee": {
+              "type": "string",
+              "enum": ["at-least-once"]
+            },
+            "ordering": {
+              "type": "string",
+              "enum": ["per-key"]
+            }
+          },
+          "additionalProperties": false
+        },
+        "effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/footprintEntry" }
+        },
+        "seed": { "type": "integer" },
+        "clock_epoch": { "type": "integer" },
+        "catalog_hash": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  ],
+  "$defs": {
+    "footprintEntry": {
+      "type": "object",
+      "required": ["uri", "mode"],
+      "properties": {
+        "uri": { "type": "string" },
+        "mode": { "type": "string", "enum": ["read", "write"] },
+        "notes": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "readFootprint": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "type": "object",
+          "properties": {
+            "mode": { "const": "read" }
+          }
+        }
+      ]
+    },
+    "writeFootprint": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "type": "object",
+          "properties": {
+            "mode": { "const": "write" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/validate-manifest.mjs
+++ b/scripts/validate-manifest.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv/dist/2020.js';
+
+async function main() {
+  const [manifestPath] = process.argv.slice(2);
+  if (!manifestPath) {
+    console.error('Usage: node scripts/validate-manifest.mjs <manifest.json>');
+    process.exit(1);
+  }
+
+  const ajv = new Ajv({ strict: true, allErrors: true });
+
+  const schemaUrl = new URL('../schemas/manifest.v0.4.schema.json', import.meta.url);
+  const schemaPath = fileURLToPath(schemaUrl);
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const validate = ajv.compile(schema);
+
+  let manifest;
+  try {
+    const raw = await readFile(path.resolve(manifestPath), 'utf8');
+    manifest = JSON.parse(raw);
+  } catch (err) {
+    console.error(`Failed to read manifest from ${manifestPath}:`, err.message);
+    process.exit(1);
+  }
+
+  const ok = validate(manifest);
+  if (!ok) {
+    console.error('Manifest validation failed:');
+    for (const err of validate.errors || []) {
+      console.error('-', ajv.errorsText([err], { separator: '\n  ' }));
+    }
+    process.exit(1);
+  }
+
+  console.log('Manifest OK');
+}
+
+await main();

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import Ajv from 'ajv/dist/2020.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const schemaPath = fileURLToPath(new URL('../schemas/manifest.v0.4.schema.json', import.meta.url));
+const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+const ajv = new Ajv({ strict: true, allErrors: true });
+const validate = ajv.compile(schema);
+
+async function readManifestFromCli(flowPath) {
+  const cli = spawn('node', ['packages/tf-compose/bin/tf-manifest.mjs', flowPath], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'inherit']
+  });
+
+  const stdoutChunks = [];
+  cli.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+
+  const exitCode = await new Promise((resolve, reject) => {
+    cli.on('error', reject);
+    cli.on('close', resolve);
+  });
+
+  assert.strictEqual(exitCode, 0, 'manifest CLI exited with non-zero status');
+  const json = Buffer.concat(stdoutChunks).toString('utf8');
+  return JSON.parse(json);
+}
+
+test('publish flow manifest validates against v0.4 schema', async () => {
+  const manifest = await readManifestFromCli('examples/flows/manifest_publish.tf');
+  const ok = validate(manifest);
+  if (!ok) {
+    assert.fail(`publish manifest failed schema validation:\n${ajv.errorsText(validate.errors, { separator: '\n' })}`);
+  }
+
+  assert.ok(Array.isArray(manifest.required_effects));
+  assert.ok(manifest.footprints_rw);
+  assert.ok(manifest.qos);
+});
+
+test('storage flow manifest validates against v0.4 schema', async () => {
+  const manifest = await readManifestFromCli('examples/flows/manifest_storage.tf');
+  const ok = validate(manifest);
+  if (!ok) {
+    assert.fail(`storage manifest failed schema validation:\n${ajv.errorsText(validate.errors, { separator: '\n' })}`);
+  }
+
+  assert.ok(Array.isArray(manifest.required_effects));
+  assert.ok(manifest.footprints_rw);
+  assert.ok(manifest.qos);
+});
+
+test('legacy manifest shape still validates', () => {
+  const legacyManifest = {
+    effects: ['Network.Out'],
+    scopes: [],
+    footprints: [
+      {
+        uri: 'res://kv/orders',
+        mode: 'read'
+      }
+    ]
+  };
+
+  const ok = validate(legacyManifest);
+  if (!ok) {
+    assert.fail(`legacy manifest failed schema validation:\n${ajv.errorsText(validate.errors, { separator: '\n' })}`);
+  }
+});
+
+test('footprint without mode is rejected', () => {
+  const badManifest = {
+    required_effects: ['Network.Out'],
+    footprints_rw: {
+      reads: [
+        {
+          uri: 'res://kv/orders'
+        }
+      ],
+      writes: []
+    },
+    qos: {
+      delivery_guarantee: 'at-least-once',
+      ordering: 'per-key'
+    }
+  };
+
+  const ok = validate(badManifest);
+  assert.strictEqual(ok, false, 'manifest missing footprint mode should be invalid');
+});


### PR DESCRIPTION
## Summary
- add a v0.4 manifest JSON Schema that accepts both legacy and new manifest shapes
- provide an Ajv-based CLI to validate manifest JSON against the schema
- cover the schema with node:test cases and note the compatibility in the docs

## Testing
- pnpm run test:l0
- node scripts/validate-manifest.mjs /tmp/publish_manifest.json
- node scripts/validate-manifest.mjs /tmp/storage_manifest.json

------
https://chatgpt.com/codex/tasks/task_e_68cf2732251083208303c74ba4988af4