### PR TITLE
Add trace filtering CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json
 # Manifests print to stdout or land under out/0.4/manifests/
+
+# Filter and pretty-print T3 traces
+cat out/t3/trace/ts.jsonl | node packages/tf-l0-tools/trace-filter.mjs --effect=Network.Out --grep=orders --pretty
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-filter.mjs --prim=tf:resource/write-object@1
 ```
 
 ### Tree

--- a/packages/tf-l0-tools/trace-filter.mjs
+++ b/packages/tf-l0-tools/trace-filter.mjs
@@ -1,0 +1,74 @@
+import { createInterface } from 'node:readline';
+import { parseArgs } from 'node:util';
+
+const {
+  values: { prim, effect, grep, pretty }
+} = parseArgs({
+  options: {
+    prim: { type: 'string' },
+    effect: { type: 'string' },
+    grep: { type: 'string' },
+    pretty: { type: 'boolean' }
+  },
+  allowPositionals: false
+});
+
+const grepNeedle = typeof grep === 'string' ? grep.toLowerCase() : null;
+
+const rl = createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity
+});
+
+rl.on('line', line => {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  let entry;
+  try {
+    entry = JSON.parse(trimmed);
+  } catch (error) {
+    return;
+  }
+
+  if (prim && entry.prim_id !== prim) {
+    return;
+  }
+
+  if (effect) {
+    const effectValue = entry.effect;
+    const effectFamily =
+      typeof effectValue === 'string'
+        ? effectValue
+        : effectValue && typeof effectValue === 'object'
+        ? effectValue.family
+        : undefined;
+
+    if (effectFamily !== effect) {
+      return;
+    }
+  }
+
+  if (grepNeedle) {
+    const tagValue = entry.tag;
+    const tagString =
+      typeof tagValue === 'string'
+        ? tagValue
+        : tagValue == null
+        ? ''
+        : JSON.stringify(tagValue);
+
+    if (!tagString.toLowerCase().includes(grepNeedle)) {
+      return;
+    }
+  }
+
+  const output = pretty ? JSON.stringify(entry, null, 2) : JSON.stringify(entry);
+  process.stdout.write(output + '\n');
+});
+
+rl.on('close', () => {
+  // no-op, allow process to exit naturally
+});

--- a/tests/fixtures/trace-sample.jsonl
+++ b/tests/fixtures/trace-sample.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2024-05-01T10:00:00.000Z","prim_id":"tf:resource/write-object@1","effect":{"family":"Storage.Write","name":"put"},"tag":{"object":"orders","keys":["order-123"],"actor":"checkout"}}
+{"timestamp":"2024-05-01T10:02:15.000Z","prim_id":"tf:resource/write-object@1","effect":{"family":"Storage.Write","name":"put"},"tag":{"object":"inventory","keys":["sku-42"]}}
+{"timestamp":"2024-05-01T10:05:30.000Z","prim_id":"tf:resource/publish-event@2","effect":{"family":"Network.Out","name":"publish"},"tag":{"topic":"Orders.created","payload":{"id":"ORDER-456"}}}
+{"timestamp":"2024-05-01T10:07:00.000Z","prim_id":"tf:resource/publish-event@2","effect":{"family":"Network.Out","name":"publish"},"tag":{"topic":"payments.received","payload":{"id":"pay-789"}}}
+{"timestamp":"2024-05-01T10:11:42.000Z","prim_id":"tf:resource/read-object@1","effect":{"family":"Pure"},"tag":"read inventory snapshot"}
+{"timestamp":"2024-05-01T10:13:00.000Z","prim_id":"tf:resource/emit-metric@1","effect":{"family":"Observability"},"tag":{"metric":"orders-latency","value":125}}

--- a/tests/trace-filter.test.mjs
+++ b/tests/trace-filter.test.mjs
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+
+const SCRIPT_PATH = 'packages/tf-l0-tools/trace-filter.mjs';
+const FIXTURE_PATH = 'tests/fixtures/trace-sample.jsonl';
+
+function runCli(args, { inputFile, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [SCRIPT_PATH, ...args], {
+      stdio: ['pipe', 'pipe', 'inherit']
+    });
+
+    let stdout = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code !== 0) {
+        reject(new Error(`trace-filter exited with code ${code}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+
+    if (inputFile) {
+      const stream = createReadStream(inputFile);
+      stream.setEncoding('utf8');
+      stream.on('error', reject);
+      stream.pipe(child.stdin);
+    } else if (typeof input === 'string') {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+test('filters by prim id', async () => {
+  const output = await runCli(['--prim=tf:resource/write-object@1'], {
+    inputFile: FIXTURE_PATH
+  });
+
+  const lines = output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  assert.equal(lines.length, 2);
+  for (const line of lines) {
+    const entry = JSON.parse(line);
+    assert.equal(entry.prim_id, 'tf:resource/write-object@1');
+  }
+});
+
+test('filters by effect and tag substring (case-insensitive)', async () => {
+  const output = await runCli(['--effect=Network.Out', '--grep=orders'], {
+    inputFile: FIXTURE_PATH
+  });
+
+  const lines = output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  assert.equal(lines.length, 1);
+  const entry = JSON.parse(lines[0]);
+  assert.equal(entry.effect.family, 'Network.Out');
+  assert.ok(JSON.stringify(entry.tag).toLowerCase().includes('orders'));
+});
+
+test('pretty printing expands entries across multiple lines', async () => {
+  const output = await runCli(
+    ['--pretty', '--effect=Network.Out', '--grep=ORDERS'],
+    { inputFile: FIXTURE_PATH }
+  );
+
+  assert.ok(output.includes('\n  "'));
+  const compactOutput = output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .join('');
+  const parsed = JSON.parse(compactOutput);
+  assert.equal(parsed.effect.family, 'Network.Out');
+});
+
+test('ignores invalid json lines without crashing', async () => {
+  const payload = [
+    '{"prim_id":"tf:resource/write-object@1","effect":{"family":"Pure"}}',
+    'this is not valid json',
+    '{"prim_id":"tf:resource/write-object@1","effect":{"family":"Pure"}}'
+  ].join('\n');
+
+  const output = await runCli(['--prim=tf:resource/write-object@1'], {
+    input: payload
+  });
+
+  const lines = output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  assert.equal(lines.length, 2);
+  for (const line of lines) {
+    const entry = JSON.parse(line);
+    assert.equal(entry.prim_id, 'tf:resource/write-object@1');
+  }
+});


### PR DESCRIPTION
## Summary
- add an ESM trace-filter CLI that streams JSONL input, filters by prim/effect/tag, and supports pretty output
- provide a representative JSONL fixture and node:test coverage for filtering, pretty-printing, and bad lines
- document the new CLI usage in the 0.4 quickstart section of the README

## Testing
- pnpm run a0
- pnpm run a1
- pnpm test *(fails: existing workspace packages such as @tf-lang/coverage-generator report vitest failures)*
- node --test tests/trace-filter.test.mjs


------
https://chatgpt.com/codex/tasks/task_e_68cf2742e3c483209d39de06552cecae