### PR TITLE
feat: add trace filter CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json
 # Manifests print to stdout or land under out/0.4/manifests/
+
+# Filter trace output (T3)
+cat out/t3/trace/ts.jsonl | node packages/tf-l0-tools/trace-filter.mjs --effect=Network.Out --grep=orders --pretty
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-filter.mjs --prim=tf:resource/write-object@1
 ```
 
 ### Tree

--- a/packages/tf-l0-tools/trace-filter.mjs
+++ b/packages/tf-l0-tools/trace-filter.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import readline from 'node:readline';
+
+const {
+  values: { prim, effect, grep, pretty }
+} = parseArgs({
+  options: {
+    prim: { type: 'string' },
+    effect: { type: 'string' },
+    grep: { type: 'string' },
+    pretty: { type: 'boolean', default: false }
+  },
+  allowPositionals: false
+});
+
+const grepLower = typeof grep === 'string' ? grep.toLowerCase() : null;
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity
+});
+
+const writeRecord = (record) => {
+  const json = pretty ? JSON.stringify(record, null, 2) : JSON.stringify(record);
+  process.stdout.write(json);
+  process.stdout.write('\n');
+};
+
+rl.on('line', (line) => {
+  if (!line.trim()) {
+    return;
+  }
+
+  let record;
+  try {
+    record = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (prim && record.prim_id !== prim) {
+    return;
+  }
+
+  if (effect && record.effect !== effect) {
+    return;
+  }
+
+  if (grepLower) {
+    const tagValue = record.tag ?? '';
+    let tagString = typeof tagValue === 'string' ? tagValue : JSON.stringify(tagValue);
+    if (typeof tagString !== 'string') {
+      tagString = '';
+    }
+    if (!tagString.toLowerCase().includes(grepLower)) {
+      return;
+    }
+  }
+
+  writeRecord(record);
+});
+
+rl.on('close', () => {
+  // no-op, rely on process exit.
+});

--- a/tests/fixtures/trace-sample.jsonl
+++ b/tests/fixtures/trace-sample.jsonl
@@ -1,0 +1,8 @@
+{"prim_id":"tf:resource/write-object@1","effect":"Storage.Write","tag":{"resource":"inventory","object":"orders-2024"}}
+{"prim_id":"tf:resource/write-object@1","effect":"Storage.Write","tag":{"resource":"inventory","object":"returns-2024"}}
+{"prim_id":"tf:resource/publish-event@1","effect":"Network.Out","tag":{"topic":"Orders.Created","payload":{"count":12}}}
+{"prim_id":"tf:resource/publish-event@2","effect":"Network.Out","tag":{"topic":"payments","payload":{"count":3}}}
+{"prim_id":"tf:service/compute@1","effect":"Pure","tag":{"step":"normalize"}}
+{"prim_id":"tf:service/log@1","effect":"Observability.Log","tag":"emitting metrics"}
+{"prim_id":"tf:resource/publish-event@3","effect":"Network.Out","tag":{"topic":"ORDERS-archived","status":"ok"}}
+{"prim_id":"tf:service/compute@2","effect":"Pure","tag":{"steps":["plan","order"]}}

--- a/tests/trace-filter.test.mjs
+++ b/tests/trace-filter.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(new URL('../packages/tf-l0-tools/trace-filter.mjs', import.meta.url));
+const fixtureUrl = new URL('./fixtures/trace-sample.jsonl', import.meta.url);
+
+async function runCli(args, input) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...(args ?? [])], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`trace-filter exited with code ${code}: ${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+
+    if (input) {
+      child.stdin.write(input);
+    }
+    child.stdin.end();
+  });
+}
+
+test('filters by prim id', async () => {
+  const fixture = await readFile(fixtureUrl, 'utf8');
+  const { stdout } = await runCli(['--prim=tf:resource/write-object@1'], fixture);
+  const lines = stdout.trim().split('\n');
+  assert.equal(lines.length, 2);
+  const prims = lines.map((line) => JSON.parse(line).prim_id);
+  assert.deepEqual(new Set(prims), new Set(['tf:resource/write-object@1']));
+});
+
+test('filters by effect and tag grep', async () => {
+  const fixture = await readFile(fixtureUrl, 'utf8');
+  const { stdout } = await runCli(['--effect=Network.Out', '--grep=orders'], fixture);
+  const lines = stdout.trim().split('\n');
+  assert.equal(lines.length, 2);
+  for (const line of lines) {
+    const record = JSON.parse(line);
+    assert.equal(record.effect, 'Network.Out');
+    const tagString = typeof record.tag === 'string' ? record.tag : JSON.stringify(record.tag);
+    assert.ok(tagString.toLowerCase().includes('orders'));
+  }
+});
+
+test('pretty output contains indentation', async () => {
+  const fixture = await readFile(fixtureUrl, 'utf8');
+  const { stdout } = await runCli(['--prim=tf:service/log@1', '--pretty'], fixture);
+  assert.match(stdout, /\{\n\s+"prim_id"/);
+  assert.match(stdout, /\n\s+"tag"/);
+});
+
+test('ignores invalid JSON lines without crashing', async () => {
+  const input = '{"prim_id":"keep-me","effect":"Pure"}\nnot json at all\n{"prim_id":"discard-me","effect":"Pure"}\n';
+  const { stdout } = await runCli(['--prim=keep-me'], input);
+  const lines = stdout.trim().split('\n');
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.prim_id, 'keep-me');
+});


### PR DESCRIPTION
## Summary
- add a standalone trace-filter CLI that streams JSONL traces and filters by prim, effect, or tag substring with optional pretty printing
- add sample trace fixtures and node:test coverage to validate filtering, pretty output, and robustness to malformed input
- document the new CLI usage in the 0.4 quick start README block

## Testing
- pnpm run a0
- pnpm run a1
- pnpm test *(fails: existing workspace packages @tf-lang/adapters-ts-execution and @tf-lang/coverage-generator test targets)*
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf2742e3c483209d39de06552cecae