### PR TITLE
Add trace trace-filter CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json
 # Manifests print to stdout or land under out/0.4/manifests/
+
+# Filter trace output (JSONL) by prim/effect/tag
+cat out/t3/trace/ts.jsonl | node packages/tf-l0-tools/trace-filter.mjs --effect=Network.Out --grep=orders --pretty
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-filter.mjs --prim=tf:resource/write-object@1
 ```
 
 ### Tree

--- a/packages/tf-l0-tools/trace-filter.mjs
+++ b/packages/tf-l0-tools/trace-filter.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import readline from 'node:readline';
+
+const {
+  values: { prim, effect, grep, pretty },
+} = parseArgs({
+  options: {
+    prim: { type: 'string' },
+    effect: { type: 'string' },
+    grep: { type: 'string' },
+    pretty: { type: 'boolean' },
+  },
+});
+
+const grepNeedle = typeof grep === 'string' ? grep.toLowerCase() : undefined;
+const shouldPrettyPrint = Boolean(pretty);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on('line', (line) => {
+  if (!line.trim()) {
+    return;
+  }
+
+  let record;
+  try {
+    record = JSON.parse(line);
+  } catch (err) {
+    return;
+  }
+
+  if (record === null || typeof record !== 'object') {
+    return;
+  }
+
+  if (prim && record?.prim_id !== prim) {
+    return;
+  }
+
+  if (effect && record?.effect !== effect) {
+    return;
+  }
+
+  if (grepNeedle) {
+    const tagValue = record?.tag;
+    let tagString = '';
+    if (typeof tagValue === 'string') {
+      tagString = tagValue;
+    } else if (tagValue !== undefined) {
+      try {
+        const json = JSON.stringify(tagValue);
+        tagString = typeof json === 'string' ? json : String(tagValue ?? '');
+      } catch (err) {
+        tagString = String(tagValue ?? '');
+      }
+    }
+
+    if (!tagString.toLowerCase().includes(grepNeedle)) {
+      return;
+    }
+  }
+
+  const output = shouldPrettyPrint
+    ? JSON.stringify(record, null, 2)
+    : JSON.stringify(record);
+
+  process.stdout.write(`${output}\n`);
+});

--- a/tests/fixtures/trace-sample.jsonl
+++ b/tests/fixtures/trace-sample.jsonl
@@ -1,0 +1,6 @@
+{"prim_id":"tf:resource/write-object@1","effect":"Storage.Write","tag":{"bucket":"cust","object":"profile"}}
+{"prim_id":"tf:resource/write-object@1","effect":"Storage.Write","tag":{"topic":"Orders","status":"queued"}}
+{"prim_id":"tf:resource/publish-event@1","effect":"Network.Out","tag":{"topic":"orders","count":1}}
+{"prim_id":"tf:resource/publish-event@1","effect":"Network.Out","tag":{"topic":"notifications","count":3}}
+{"prim_id":"tf:resource/log@1","effect":"Observability","tag":"log: user action"}
+{"prim_id":"tf:resource/calc@1","effect":"Pure","tag":{"summary":"Compute ORDERS metrics"}}

--- a/tests/trace-filter.test.mjs
+++ b/tests/trace-filter.test.mjs
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { readFile, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = dirname(__dirname);
+const cliPath = join(repoRoot, 'packages', 'tf-l0-tools', 'trace-filter.mjs');
+const fixturePath = join(repoRoot, 'tests', 'fixtures', 'trace-sample.jsonl');
+
+async function runCli(input, args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [cliPath, ...args], {
+      cwd: options.cwd ?? repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.setEncoding('utf8');
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    proc.stderr.setEncoding('utf8');
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`trace-filter exited with code ${code}: ${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+
+    proc.stdin.end(input);
+  });
+}
+
+test('filters by prim id', async () => {
+  const fixture = await readFile(fixturePath, 'utf8');
+  const { stdout } = await runCli(fixture, ['--prim=tf:resource/write-object@1']);
+  const lines = stdout.trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 2, 'expected two write-object records');
+  for (const line of lines) {
+    const record = JSON.parse(line);
+    assert.equal(record.prim_id, 'tf:resource/write-object@1');
+  }
+});
+
+test('filters by effect and tag substring (case-insensitive)', async () => {
+  const fixture = await readFile(fixturePath, 'utf8');
+  const { stdout } = await runCli(fixture, ['--effect=Network.Out', '--grep=orders']);
+  const lines = stdout.trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 1, 'only the orders publish should match');
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.effect, 'Network.Out');
+  assert.match(JSON.stringify(record.tag).toLowerCase(), /orders/);
+});
+
+test('pretty printing expands JSON records', async () => {
+  const fixture = await readFile(fixturePath, 'utf8');
+  const { stdout } = await runCli(fixture, ['--prim=tf:resource/publish-event@1', '--pretty']);
+  assert.match(stdout, /\{\n  "prim_id"/);
+});
+
+test('ignores invalid JSON lines without crashing', async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'trace-filter-'));
+  const malformedPath = join(tmpDir, 'input.jsonl');
+  const payload = ['not json', '{"prim_id":"tf:resource/calc@1","effect":"Pure","tag":null}'];
+  await writeFile(malformedPath, payload.join('\n'), 'utf8');
+  const content = await readFile(malformedPath, 'utf8');
+  const { stdout } = await runCli(content, ['--effect=Pure']);
+  const lines = stdout.trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.prim_id, 'tf:resource/calc@1');
+});
+
+test('CLI works when invoked from tool directory', async () => {
+  const fixture = await readFile(fixturePath, 'utf8');
+  const toolDir = join(repoRoot, 'packages', 'tf-l0-tools');
+  const { stdout } = await runCli(fixture, ['--effect=Pure'], { cwd: toolDir });
+  const lines = stdout.trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.effect, 'Pure');
+});


### PR DESCRIPTION
## Summary
- add a standalone trace-filter CLI for parsing JSONL trace streams with prim, effect, and tag filters
- ship fixtures and node-based tests that exercise filtering, pretty output, and robustness against bad input
- document example usage of the new tool in the 0.4 quickstart block

## Testing
- pnpm test *(fails: existing workspace packages @tf-lang/coverage-generator and @tf-lang/mapper/trace2tags have failing vitest suites)*
- node --test tests/trace-filter.test.mjs
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf2742e3c483209d39de06552cecae