### PR TITLE
Add v0.4 manifest schema with validator and tests

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -18,5 +18,6 @@ Hashing primitives classify as Pure; Crypto is reserved for secret-bearing opera
 ### Manifest compatibility
 For v0.4 manifests we emit both the legacy `effects`/`footprints` fields and the new
 `required_effects`/`footprints_rw`/`qos` structure for downstream compatibility. The
-schema and CLI validator accept either shape so existing consumers can migrate on
-their own schedule.
+two shapes are mutually exclusive, but the schema and CLI validator accept either so
+consumers can migrate on their own schedule. Use
+`node scripts/validate-manifest.mjs <path>` to confirm conformance.

--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -14,3 +14,9 @@ conflict detection stay runnable while curation continues.
 Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
 Seed overlays remain authoritative for existing effects or qos values.
 Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+
+### Manifest compatibility
+For v0.4 manifests we emit both the legacy `effects`/`footprints` fields and the new
+`required_effects`/`footprints_rw`/`qos` structure for downstream compatibility. The
+schema and CLI validator accept either shape so existing consumers can migrate on
+their own schedule.

--- a/schemas/manifest.v0.4.schema.json
+++ b/schemas/manifest.v0.4.schema.json
@@ -66,11 +66,19 @@
           "items": { "$ref": "#/$defs/footprintEntry" }
         },
         "scopes": { "$ref": "#/$defs/stringArray" },
+        "required_effects": false,
         "seed": { "type": "integer" },
         "clock_epoch": { "type": "integer" },
         "catalog_hash": { "type": "string" }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "not": {
+        "type": "object",
+        "required": ["required_effects"],
+        "properties": {
+          "required_effects": true
+        }
+      }
     },
     "newManifest": {
       "type": "object",
@@ -93,16 +101,25 @@
           "additionalProperties": false
         },
         "qos": {
-          "type": "object",
-          "properties": {
-            "delivery_guarantee": {
-              "enum": ["at-least-once"]
+          "oneOf": [
+            {
+              "type": "object",
+              "maxProperties": 0
             },
-            "ordering": {
-              "enum": ["per-key"]
+            {
+              "type": "object",
+              "required": ["delivery_guarantee", "ordering"],
+              "properties": {
+                "delivery_guarantee": {
+                  "enum": ["at-least-once", "exactly-once", "best-effort"]
+                },
+                "ordering": {
+                  "enum": ["per-key", "global", "none"]
+                }
+              },
+              "additionalProperties": false
             }
-          },
-          "additionalProperties": false
+          ]
         },
         "effects": { "$ref": "#/$defs/stringArray" },
         "footprints": {

--- a/schemas/manifest.v0.4.schema.json
+++ b/schemas/manifest.v0.4.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://meta-ontology.local/schemas/manifest.v0.4.schema.json",
+  "title": "Capability Manifest v0.4",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/legacyManifest" },
+    { "$ref": "#/$defs/newManifest" }
+  ],
+  "$defs": {
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "footprintEntry": {
+      "type": "object",
+      "required": ["uri", "mode"],
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": ["read", "write"]
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "readFootprint": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "const": "read"
+            }
+          }
+        }
+      ]
+    },
+    "writeFootprint": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "const": "write"
+            }
+          }
+        }
+      ]
+    },
+    "legacyManifest": {
+      "type": "object",
+      "required": ["effects", "footprints", "scopes"],
+      "properties": {
+        "effects": { "$ref": "#/$defs/stringArray" },
+        "footprints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/footprintEntry" }
+        },
+        "scopes": { "$ref": "#/$defs/stringArray" },
+        "seed": { "type": "integer" },
+        "clock_epoch": { "type": "integer" },
+        "catalog_hash": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "newManifest": {
+      "type": "object",
+      "required": ["required_effects", "footprints_rw", "qos"],
+      "properties": {
+        "required_effects": { "$ref": "#/$defs/stringArray" },
+        "footprints_rw": {
+          "type": "object",
+          "required": ["reads", "writes"],
+          "properties": {
+            "reads": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/readFootprint" }
+            },
+            "writes": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/writeFootprint" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "qos": {
+          "type": "object",
+          "properties": {
+            "delivery_guarantee": {
+              "enum": ["at-least-once"]
+            },
+            "ordering": {
+              "enum": ["per-key"]
+            }
+          },
+          "additionalProperties": false
+        },
+        "effects": { "$ref": "#/$defs/stringArray" },
+        "footprints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/footprintEntry" }
+        },
+        "scopes": { "$ref": "#/$defs/stringArray" },
+        "seed": { "type": "integer" },
+        "clock_epoch": { "type": "integer" },
+        "catalog_hash": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/validate-manifest.mjs
+++ b/scripts/validate-manifest.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import Ajv from 'ajv/dist/2020.js';
+
+async function main() {
+  const [manifestPath] = process.argv.slice(2);
+
+  if (!manifestPath) {
+    console.error('Usage: node scripts/validate-manifest.mjs <manifest.json>');
+    process.exit(1);
+    return;
+  }
+
+  const schemaPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'schemas',
+    'manifest.v0.4.schema.json'
+  );
+
+  const [schemaJSON, manifestJSON] = await Promise.all([
+    readFile(schemaPath, 'utf8'),
+    readFile(manifestPath, 'utf8')
+  ]);
+
+  const schema = JSON.parse(schemaJSON);
+  const manifest = JSON.parse(manifestJSON);
+
+  const ajv = new Ajv({ strict: true, allErrors: true });
+  const validate = ajv.compile(schema);
+
+  if (validate(manifest)) {
+    console.log('Manifest OK');
+    return;
+  }
+
+  console.error('Manifest validation failed.');
+  for (const error of validate.errors ?? []) {
+    console.error(`- ${error.instancePath || '/'}: ${error.message}`);
+  }
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -95,3 +95,39 @@ test('footprint entries require mode', () => {
 
   assertInvalid(badManifest, 'manifest without mode unexpectedly passed');
 });
+
+test('legacy manifest rejects required_effects mixing shapes', () => {
+  const mixedManifest = {
+    effects: ['Network.Out'],
+    footprints: [
+      {
+        uri: 'res://kv/foo',
+        mode: 'read'
+      }
+    ],
+    scopes: [],
+    required_effects: ['Network.Out']
+  };
+
+  assertInvalid(mixedManifest, 'legacy manifest with required_effects unexpectedly passed');
+});
+
+test('new manifest requires qos ordering', () => {
+  const qosMissingOrdering = {
+    required_effects: ['Network.Out'],
+    footprints_rw: {
+      reads: [
+        {
+          uri: 'res://kv/foo',
+          mode: 'read'
+        }
+      ],
+      writes: []
+    },
+    qos: {
+      delivery_guarantee: 'exactly-once'
+    }
+  };
+
+  assertInvalid(qosMissingOrdering, 'manifest without qos ordering unexpectedly passed');
+});

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import Ajv from 'ajv/dist/2020.js';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const schemaPath = path.resolve(repoRoot, 'schemas', 'manifest.v0.4.schema.json');
+
+const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+const ajv = new Ajv({ strict: true, allErrors: true });
+const validate = ajv.compile(schema);
+
+function formatErrors(errors) {
+  return (errors ?? [])
+    .map((error) => `${error.instancePath || '/'} ${error.message ?? ''}`.trim())
+    .join('; ');
+}
+
+function assertValid(manifest, message = 'expected manifest to validate') {
+  if (validate(manifest)) {
+    return;
+  }
+  assert.fail(`${message}: ${formatErrors(validate.errors)}`);
+}
+
+function assertInvalid(manifest, message = 'expected manifest to be rejected') {
+  if (!validate(manifest)) {
+    assert.ok((validate.errors ?? []).length > 0, 'validation failed without errors');
+    return;
+  }
+  assert.fail(message);
+}
+
+async function loadManifest(flowPath) {
+  const { stdout } = await execFileAsync(
+    'node',
+    ['packages/tf-compose/bin/tf-manifest.mjs', flowPath],
+    { cwd: repoRoot }
+  );
+  return JSON.parse(stdout);
+}
+
+test('publish flow manifest validates via new shape', async () => {
+  const manifest = await loadManifest('examples/flows/manifest_publish.tf');
+  assert.ok(Array.isArray(manifest.required_effects) && manifest.required_effects.length > 0);
+  assert.ok(manifest.footprints_rw && 'reads' in manifest.footprints_rw);
+  assert.ok(manifest.qos && manifest.qos.delivery_guarantee);
+  assertValid(manifest, 'publish manifest failed schema validation');
+});
+
+test('storage flow manifest validates via new shape', async () => {
+  const manifest = await loadManifest('examples/flows/manifest_storage.tf');
+  assert.ok(Array.isArray(manifest.required_effects) && manifest.required_effects.length > 0);
+  assertValid(manifest, 'storage manifest failed schema validation');
+});
+
+test('legacy shape with effects/footprints/scopes still validates', () => {
+  const legacyManifest = {
+    effects: ['Network.Out'],
+    footprints: [
+      {
+        uri: 'res://kv/foo',
+        mode: 'read'
+      }
+    ],
+    scopes: []
+  };
+
+  assertValid(legacyManifest, 'legacy manifest rejected');
+});
+
+test('footprint entries require mode', () => {
+  const badManifest = {
+    required_effects: ['Network.Out'],
+    footprints_rw: {
+      reads: [
+        {
+          uri: 'res://kv/foo'
+        }
+      ],
+      writes: []
+    },
+    qos: {
+      delivery_guarantee: 'at-least-once',
+      ordering: 'per-key'
+    }
+  };
+
+  assertInvalid(badManifest, 'manifest without mode unexpectedly passed');
+});


### PR DESCRIPTION
## Summary
- add a JSON Schema for v0.4 capability manifests that accepts the legacy and new layouts
- add a CLI validator around Ajv 2020 to check manifests against the new schema
- cover publish/storage manifests, a legacy object, and a failure case in a new schema test; document the legacy+new compatibility

## Testing
- pnpm run a0
- pnpm run a1
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf -o out/0.4/manifests/publish.json
- node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json
- node scripts/validate-manifest.mjs out/0.4/manifests/publish.json
- node scripts/validate-manifest.mjs out/0.4/manifests/storage.json
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf2732251083208303c74ba4988af4