### PR TITLE
Add manifest schema and validator tooling

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -14,3 +14,8 @@ conflict detection stay runnable while curation continues.
 Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
 Seed overlays remain authoritative for existing effects or qos values.
 Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+
+### Manifest compatibility
+For the 0.4 release we emit both the legacy manifest fields (`effects`, flat `footprints`) and the new shape (`required_effects`, structured `footprints_rw`, `qos`).
+The schema-backed validator accepts either shape so downstream tooling can migrate at its own pace.
+Use `node scripts/validate-manifest.mjs <file>` to confirm a manifest satisfies the compatibility contract.

--- a/schemas/manifest.v0.4.schema.json
+++ b/schemas/manifest.v0.4.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tf-lang.dev/schemas/manifest.v0.4.schema.json",
+  "title": "TF Capability Manifest v0.4",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/legacyManifest" },
+    { "$ref": "#/$defs/newManifest" }
+  ],
+  "$defs": {
+    "footprintEntry": {
+      "type": "object",
+      "properties": {
+        "uri": { "type": "string" },
+        "mode": {
+          "type": "string",
+          "enum": ["read", "write"]
+        },
+        "notes": { "type": "string" }
+      },
+      "required": ["uri", "mode"],
+      "additionalProperties": false
+    },
+    "footprintReadEntry": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "properties": {
+            "mode": { "const": "read" }
+          }
+        }
+      ]
+    },
+    "footprintWriteEntry": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "properties": {
+            "mode": { "const": "write" }
+          }
+        }
+      ]
+    },
+    "legacyManifest": {
+      "type": "object",
+      "properties": {
+        "effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/footprintEntry" }
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["effects", "footprints", "scopes"],
+      "not": {
+        "anyOf": [
+          { "required": ["required_effects"] },
+          { "required": ["footprints_rw"] },
+          { "required": ["qos"] }
+        ]
+      }
+    },
+    "newManifest": {
+      "type": "object",
+      "properties": {
+        "required_effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints_rw": {
+          "type": "object",
+          "properties": {
+            "reads": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/footprintReadEntry" }
+            },
+            "writes": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/footprintWriteEntry" }
+            }
+          },
+          "required": ["reads", "writes"],
+          "additionalProperties": false
+        },
+        "qos": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {},
+              "maxProperties": 0
+            },
+            {
+              "type": "object",
+              "properties": {
+                "delivery_guarantee": {
+                  "type": "string",
+                  "enum": ["at-least-once"]
+                },
+                "ordering": {
+                  "type": "string",
+                  "enum": ["per-key"]
+                }
+              },
+              "required": ["delivery_guarantee", "ordering"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": ["required_effects", "footprints_rw", "qos"]
+    }
+  }
+}

--- a/scripts/validate-manifest.mjs
+++ b/scripts/validate-manifest.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const [,, manifestPath] = process.argv;
+
+if (!manifestPath) {
+  console.error('Usage: node scripts/validate-manifest.mjs <manifest.json>');
+  process.exit(1);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(__dirname, '../schemas/manifest.v0.4.schema.json');
+
+async function main() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const validate = ajv.compile(schema);
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+  const valid = validate(manifest);
+  if (valid) {
+    console.log('Manifest OK');
+    return;
+  }
+
+  console.error('Manifest validation failed.');
+  if (validate.errors) {
+    const details = ajv.errorsText(validate.errors, { separator: '\n' });
+    console.error(details);
+  }
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Manifest validation failed.');
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(__dirname, '../schemas/manifest.v0.4.schema.json');
+const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+function assertValid(manifest) {
+  const result = validate(manifest);
+  assert.equal(result, true, JSON.stringify(validate.errors, null, 2));
+}
+
+function assertInvalid(manifest) {
+  const result = validate(manifest);
+  assert.equal(result, false, 'Expected manifest to be invalid');
+}
+
+test('publish flow manifest validates as new shape', async () => {
+  const { stdout } = await execFileAsync('node', [
+    'packages/tf-compose/bin/tf-manifest.mjs',
+    'examples/flows/manifest_publish.tf'
+  ]);
+  const manifest = JSON.parse(stdout);
+  assertValid(manifest);
+  assert.ok(Array.isArray(manifest.required_effects));
+  assert.ok(manifest.footprints_rw && Array.isArray(manifest.footprints_rw.reads));
+  assert.ok(manifest.qos && manifest.qos.delivery_guarantee === 'at-least-once');
+});
+
+test('storage flow manifest validates as new shape', async () => {
+  const { stdout } = await execFileAsync('node', [
+    'packages/tf-compose/bin/tf-manifest.mjs',
+    'examples/flows/manifest_storage.tf'
+  ]);
+  const manifest = JSON.parse(stdout);
+  assertValid(manifest);
+  assert.ok(Array.isArray(manifest.required_effects));
+  assert.ok(manifest.footprints_rw && Array.isArray(manifest.footprints_rw.writes));
+});
+
+test('legacy manifest shape validates', () => {
+  const legacyManifest = {
+    effects: ['Network.Out'],
+    footprints: [
+      { uri: 'storage://bucket/object', mode: 'read' },
+      { uri: 'storage://bucket/object', mode: 'write' }
+    ],
+    scopes: []
+  };
+  assertValid(legacyManifest);
+});
+
+test('missing footprint mode fails validation', () => {
+  const badManifest = {
+    effects: ['Network.Out'],
+    footprints: [
+      { uri: 'storage://bucket/object' }
+    ],
+    scopes: []
+  };
+  assertInvalid(badManifest);
+});


### PR DESCRIPTION
## Summary
- add a manifest v0.4 JSON Schema that permits both the legacy and new field layouts
- provide an Ajv-powered CLI helper for validating manifests against the schema
- cover the schema with targeted tests and document the compatibility contract

## Testing
- pnpm run a0
- pnpm run a1
- node scripts/validate-manifest.mjs out/0.4/manifests/publish.json
- node scripts/validate-manifest.mjs out/0.4/manifests/storage.json
- node --test tests/manifest-schema.test.mjs
- pnpm test *(fails: @tf-lang/trace2tags@0.1.0 test: `vitest run`)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2732251083208303c74ba4988af4