### PR TITLE
Add manifest schema and validator

### DIFF
--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -14,3 +14,7 @@ conflict detection stay runnable while curation continues.
 Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
 Seed overlays remain authoritative for existing effects or qos values.
 Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+
+### Manifest compatibility
+For v0.4 manifests we emit both the legacy `effects`/`footprints` shape and the new `required_effects`/`footprints_rw` plus `qos` block so downstream tools stay compatible.
+The JSON schema and validator accept either layout, making it safe to mix old and new consumers during the rollout.

--- a/schemas/manifest.v0.4.schema.json
+++ b/schemas/manifest.v0.4.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tf-lang.dev/schemas/manifest/v0.4",
+  "title": "TF capability manifest",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/legacyManifest" },
+    { "$ref": "#/$defs/newManifest" }
+  ],
+  "$defs": {
+    "legacyManifest": {
+      "type": "object",
+      "required": ["effects", "footprints", "scopes"],
+      "properties": {
+        "effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/footprintEntry" }
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "not": {
+        "required": ["required_effects"]
+      }
+    },
+    "newManifest": {
+      "type": "object",
+      "required": ["required_effects", "footprints_rw", "qos"],
+      "properties": {
+        "required_effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "footprints_rw": {
+          "type": "object",
+          "required": ["reads", "writes"],
+          "properties": {
+            "reads": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/readFootprint" }
+            },
+            "writes": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/writeFootprint" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "qos": {
+          "type": "object",
+          "properties": {
+            "delivery_guarantee": {
+              "type": "string",
+              "enum": ["at-least-once"]
+            },
+            "ordering": {
+              "type": "string",
+              "enum": ["per-key"]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "footprintEntry": {
+      "type": "object",
+      "required": ["uri", "mode"],
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "mode": { "type": "string", "enum": ["read", "write"] },
+        "notes": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "readFootprint": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "type": "object",
+          "properties": { "mode": { "const": "read" } }
+        }
+      ]
+    },
+    "writeFootprint": {
+      "allOf": [
+        { "$ref": "#/$defs/footprintEntry" },
+        {
+          "type": "object",
+          "properties": { "mode": { "const": "write" } }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/validate-manifest.mjs
+++ b/scripts/validate-manifest.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const usage = 'Usage: node scripts/validate-manifest.mjs <manifest.json>';
+
+async function loadSchema() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const schemaPath = path.resolve(scriptDir, '..', 'schemas', 'manifest.v0.4.schema.json');
+  try {
+    const schemaSource = await readFile(schemaPath, 'utf8');
+    return JSON.parse(schemaSource);
+  } catch (err) {
+    throw new Error(`Failed to load schema from ${schemaPath}: ${err.message}`);
+  }
+}
+
+async function loadManifest(manifestPath) {
+  try {
+    const manifestSource = await readFile(manifestPath, 'utf8');
+    return JSON.parse(manifestSource);
+  } catch (err) {
+    throw new Error(`Failed to read manifest at ${manifestPath}: ${err.message}`);
+  }
+}
+
+function formatErrors(errors = []) {
+  return errors
+    .map((error) => {
+      const instancePath = error.instancePath || '(root)';
+      return `${instancePath} ${error.message}`;
+    })
+    .join('\n');
+}
+
+async function main(argv) {
+  const manifestPath = argv[2];
+  if (!manifestPath) {
+    console.error(usage);
+    process.exit(1);
+    return;
+  }
+
+  const schema = await loadSchema();
+  const ajv = new Ajv2020({ allErrors: true });
+  const validate = ajv.compile(schema);
+  const manifest = await loadManifest(manifestPath);
+
+  const valid = validate(manifest);
+  if (valid) {
+    console.log('Manifest OK');
+    return;
+  }
+
+  console.error('Manifest validation failed:');
+  const details = formatErrors(validate.errors);
+  if (details) {
+    console.error(details);
+  }
+  process.exit(1);
+}
+
+main(process.argv).catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const schemaPath = path.resolve(__dirname, '..', 'schemas', 'manifest.v0.4.schema.json');
+const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+const ajv = new Ajv2020({ allErrors: true });
+const validate = ajv.compile(schema);
+
+function ensureValid(manifest, context) {
+  const valid = validate(manifest);
+  if (!valid) {
+    const message = (validate.errors ?? [])
+      .map((error) => `${error.instancePath || '(root)'} ${error.message}`)
+      .join('\n');
+    assert.fail(`${context}:\n${message}`);
+  }
+}
+
+function ensureInvalid(manifest, context) {
+  const valid = validate(manifest);
+  if (valid) {
+    assert.fail(`${context}: expected validation to fail`);
+  }
+}
+
+async function loadManifest(flowPath) {
+  const { stdout } = await execFileAsync('node', [
+    'packages/tf-compose/bin/tf-manifest.mjs',
+    flowPath
+  ]);
+  return JSON.parse(stdout);
+}
+
+test('publish manifest validates with new fields present', async () => {
+  const manifest = await loadManifest('examples/flows/manifest_publish.tf');
+  assert.ok(Array.isArray(manifest.required_effects), 'required_effects missing');
+  assert.ok(manifest.footprints_rw && typeof manifest.footprints_rw === 'object', 'footprints_rw missing');
+  assert.ok(manifest.qos && typeof manifest.qos === 'object', 'qos missing');
+  ensureValid(manifest, 'publish manifest should validate');
+});
+
+test('storage manifest validates with new fields present', async () => {
+  const manifest = await loadManifest('examples/flows/manifest_storage.tf');
+  assert.ok(Array.isArray(manifest.required_effects), 'required_effects missing');
+  assert.ok(manifest.footprints_rw && typeof manifest.footprints_rw === 'object', 'footprints_rw missing');
+  assert.ok(manifest.qos && typeof manifest.qos === 'object', 'qos missing');
+  ensureValid(manifest, 'storage manifest should validate');
+});
+
+test('legacy-only manifest validates', () => {
+  const legacyManifest = {
+    effects: ['Network.Out'],
+    footprints: [
+      { uri: 'https://example.com/resource', mode: 'read' }
+    ],
+    scopes: []
+  };
+  ensureValid(legacyManifest, 'legacy manifest should validate');
+});
+
+test('footprint without mode fails validation', () => {
+  const badManifest = {
+    effects: ['Network.Out'],
+    footprints: [
+      { uri: 'https://example.com/resource' }
+    ],
+    scopes: []
+  };
+  ensureInvalid(badManifest, 'footprint without mode should fail');
+});


### PR DESCRIPTION
## Summary
- add a JSON Schema for manifests that accepts both the legacy and v0.4 layouts
- add an Ajv-powered CLI to validate manifests against the new schema
- cover manifests with node:test checks and update docs about compatibility

## Testing
- pnpm run a0
- pnpm run a1
- node scripts/validate-manifest.mjs out/0.4/manifests/publish.json
- node scripts/validate-manifest.mjs out/0.4/manifests/storage.json
- pnpm run test:l0


------
https://chatgpt.com/codex/tasks/task_e_68cf2732251083208303c74ba4988af4