### PR TITLE
Add transaction policy checker and CLI

### DIFF
--- a/examples/flows/txn_fail_missing_key.tf
+++ b/examples/flows/txn_fail_missing_key.tf
@@ -1,0 +1,3 @@
+txn{
+  write-object(uri="res://kv/bucket", key="x", value="1")
+}

--- a/examples/flows/txn_ok.tf
+++ b/examples/flows/txn_ok.tf
@@ -1,0 +1,4 @@
+txn{
+  compare-and-swap(uri="res://kv/bucket", key="x", value="1", ifMatch=0);
+  write-object(uri="res://kv/bucket", key="y", value="2", idempotency_key="abc-123")
+}

--- a/examples/flows/write_outside_txn.tf
+++ b/examples/flows/write_outside_txn.tf
@@ -1,0 +1,1 @@
+write-object(uri="res://kv/bucket", key="z", value="3")

--- a/packages/tf-compose/bin/tf-policy.mjs
+++ b/packages/tf-compose/bin/tf-policy.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parseDSL } from '../src/parser.mjs';
+import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+import { checkTransactions } from '../../tf-l0-check/src/txn.mjs';
+
+async function loadCatalog() {
+  try {
+    return JSON.parse(await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8'));
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs;
+
+function argValue(flag) {
+  const idx = args.indexOf(flag);
+  if (idx >= 0) return args[idx + 1] ?? null;
+  return null;
+}
+
+const cmd = args[0];
+if (cmd !== 'check') {
+  console.error('Usage: tf-policy check <flow.tf> [--forbid-outside] [-o out.json]');
+  process.exit(2);
+}
+
+const file = args[1];
+if (!file) {
+  console.error('Missing flow path.');
+  process.exit(2);
+}
+
+const forbidOutside = args.includes('--forbid-outside');
+const out = argValue('-o') || argValue('--out');
+
+const src = await readFile(file, 'utf8');
+const ir = parseDSL(src);
+const catalog = await loadCatalog();
+
+const verdict = checkTransactions(ir, catalog, { forbidWritesOutsideTxn: forbidOutside });
+const payload = canonicalize({ ok: Boolean(verdict.ok), reasons: verdict.reasons || [] }) + '\n';
+
+if (out) {
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, payload, 'utf8');
+} else {
+  process.stdout.write(payload);
+}
+
+process.exit(verdict.ok ? 0 : 1);

--- a/packages/tf-l0-check/src/txn.mjs
+++ b/packages/tf-l0-check/src/txn.mjs
@@ -1,0 +1,77 @@
+const DEFAULT_OPTS = {
+  requireIdempotencyKeyInTxn: true,
+  forbidWritesOutsideTxn: false
+};
+
+function lookupPrimitive(node, catalog = {}) {
+  const primitives = Array.isArray(catalog.primitives) ? catalog.primitives : [];
+  const name = (node.prim || '').toLowerCase();
+  return primitives.find(p => {
+    const id = p.id || '';
+    return p.name === name || id.endsWith(`/${name}@1`);
+  }) || null;
+}
+
+function hasStorageWriteEffect(primEntry) {
+  if (!primEntry) return false;
+  const effects = Array.isArray(primEntry.effects) ? primEntry.effects : [];
+  return effects.includes('Storage.Write');
+}
+
+function isStorageWrite(node, catalog = {}) {
+  if (!node || node.node !== 'Prim') return false;
+  const name = (node.prim || '').toLowerCase();
+  if (/^(write-object|delete-object|compare-and-swap)$/.test(name)) {
+    return true;
+  }
+  const primEntry = lookupPrimitive(node, catalog);
+  return hasStorageWriteEffect(primEntry);
+}
+
+function hasIdempotencyKey(node) {
+  const key = node?.args?.idempotency_key;
+  return typeof key === 'string' && key.length > 0;
+}
+
+export function checkTransactions(ir, catalog, opts = DEFAULT_OPTS) {
+  const options = { ...DEFAULT_OPTS, ...(opts || {}) };
+  const reasons = [];
+
+  function visit(node, insideTxn) {
+    if (!node || typeof node !== 'object') return;
+
+    if (node.node === 'Region') {
+      const isTxn = (node.kind || '').toLowerCase() === 'transaction';
+      const nextInside = insideTxn || isTxn;
+      for (const child of node.children || []) {
+        visit(child, nextInside);
+      }
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      if (isStorageWrite(node, catalog)) {
+        const name = (node.prim || '').toLowerCase();
+        if (insideTxn) {
+          const isCas = name === 'compare-and-swap';
+          if (options.requireIdempotencyKeyInTxn && !isCas && !hasIdempotencyKey(node)) {
+            reasons.push(`txn: ${name} requires idempotency_key or compare-and-swap`);
+          }
+        } else if (options.forbidWritesOutsideTxn) {
+          reasons.push(`policy: ${name} outside transaction`);
+        }
+      }
+      return;
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child, insideTxn);
+      }
+    }
+  }
+
+  visit(ir, false);
+
+  return { ok: reasons.length === 0, reasons };
+}

--- a/tests/txn-policy.test.mjs
+++ b/tests/txn-policy.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+async function runPolicy(flowPath, extraArgs = []) {
+  try {
+    const result = await execFileAsync(
+      'node',
+      ['packages/tf-compose/bin/tf-policy.mjs', 'check', flowPath, ...extraArgs],
+      { cwd: repoRoot }
+    );
+    return { code: 0, stdout: result.stdout };
+  } catch (error) {
+    return { code: error.code ?? 1, stdout: error.stdout ?? '' };
+  }
+}
+
+function parseOutput(stdout) {
+  try {
+    return JSON.parse(stdout);
+  } catch (err) {
+    assert.fail(`Failed to parse JSON output: ${err?.message || err}`);
+  }
+}
+
+test('txn policy passes for idempotent writes inside txn', async () => {
+  const { code, stdout } = await runPolicy('examples/flows/txn_ok.tf');
+  assert.equal(code, 0);
+  const payload = parseOutput(stdout);
+  assert.equal(payload.ok, true);
+  assert.deepEqual(payload.reasons, []);
+});
+
+test('txn policy flags missing idempotency key inside txn', async () => {
+  const { code, stdout } = await runPolicy('examples/flows/txn_fail_missing_key.tf');
+  assert.notEqual(code, 0);
+  const payload = parseOutput(stdout);
+  assert.equal(payload.ok, false);
+  assert.ok(payload.reasons.some((r) => r.includes('requires idempotency_key')));
+});
+
+test('txn policy forbids writes outside txn when flagged', async () => {
+  const { code, stdout } = await runPolicy('examples/flows/write_outside_txn.tf', ['--forbid-outside']);
+  assert.notEqual(code, 0);
+  const payload = parseOutput(stdout);
+  assert.equal(payload.ok, false);
+  assert.ok(payload.reasons.some((r) => r.includes('outside transaction')));
+});


### PR DESCRIPTION
## Summary
- add a transaction policy checker that enforces idempotency metadata inside txn regions and flags optional outside writes
- introduce a dedicated `tf-policy` CLI to run the policy checks and emit canonical JSON reports
- add example flows and tests covering compliant, missing idempotency, and out-of-transaction write scenarios

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf2f7980d88320a30b7951369938eb