### PR TITLE
Add transaction policy checker and CLI

### DIFF
--- a/examples/flows/txn_fail_missing_key.tf
+++ b/examples/flows/txn_fail_missing_key.tf
@@ -1,0 +1,3 @@
+txn{
+  write-object(uri="res://kv/bucket", key="x", value="1")
+}

--- a/examples/flows/txn_ok.tf
+++ b/examples/flows/txn_ok.tf
@@ -1,0 +1,4 @@
+txn{
+  compare-and-swap(uri="res://kv/bucket", key="x", value="1", ifMatch=0);
+  write-object(uri="res://kv/bucket", key="y", value="2", idempotency_key="abc-123")
+}

--- a/examples/flows/write_outside_txn.tf
+++ b/examples/flows/write_outside_txn.tf
@@ -1,0 +1,1 @@
+write-object(uri="res://kv/bucket", key="z", value="3")

--- a/packages/tf-compose/bin/tf-policy.mjs
+++ b/packages/tf-compose/bin/tf-policy.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parseDSL } from '../src/parser.mjs';
+import { checkTransactions } from '../../tf-l0-check/src/txn.mjs';
+
+async function loadCatalog() {
+  try {
+    return JSON.parse(await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8'));
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+
+if (cmd !== 'check') {
+  console.error('Usage: tf-policy check <flow.tf> [--forbid-outside] [-o out.json]');
+  process.exit(2);
+}
+
+const file = args[1];
+if (!file || file.startsWith('-')) {
+  console.error('Missing flow path.');
+  process.exit(2);
+}
+
+let forbidOutside = false;
+let out = null;
+
+for (let i = 2; i < args.length; i++) {
+  const tok = args[i];
+  if (tok === '--forbid-outside') {
+    forbidOutside = true;
+    continue;
+  }
+  if (tok === '-o' || tok === '--out') {
+    const target = args[i + 1];
+    if (!target) {
+      console.error('Missing value for', tok);
+      process.exit(2);
+    }
+    out = target;
+    i++;
+    continue;
+  }
+  console.error('Unknown argument:', tok);
+  process.exit(2);
+}
+
+let src;
+try {
+  src = await readFile(file, 'utf8');
+} catch (err) {
+  console.error('Failed to read flow:', err.message || err);
+  process.exit(1);
+}
+
+let ir;
+try {
+  ir = parseDSL(src);
+} catch (err) {
+  console.error('Failed to parse flow:', err.message || err);
+  process.exit(1);
+}
+
+const catalog = await loadCatalog();
+const verdict = checkTransactions(ir, catalog, { forbidWritesOutsideTxn: forbidOutside });
+const payload = JSON.stringify(verdict, ['ok', 'reasons'], 2) + '\n';
+
+if (out) {
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, payload, 'utf8');
+} else {
+  process.stdout.write(payload);
+}
+
+process.exit(verdict.ok ? 0 : 1);

--- a/packages/tf-l0-check/src/txn.mjs
+++ b/packages/tf-l0-check/src/txn.mjs
@@ -1,0 +1,82 @@
+export function checkTransactions(ir, catalog, opts = {}) {
+  const {
+    requireIdempotencyKeyInTxn = true,
+    forbidWritesOutsideTxn = false
+  } = opts || {};
+
+  const reasons = [];
+
+  function visit(node, insideTxn) {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+
+    if (node.node === 'Region') {
+      const kind = (node.kind || '').toLowerCase();
+      const nextInside = insideTxn || kind === 'transaction';
+      for (const child of node.children || []) {
+        visit(child, nextInside);
+      }
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      const name = (node.prim || '').toLowerCase();
+      if (!name) {
+        return;
+      }
+
+      if (isStorageWrite(name, catalog)) {
+        if (insideTxn) {
+          if (
+            requireIdempotencyKeyInTxn &&
+            name !== 'compare-and-swap'
+          ) {
+            const key = node.args?.idempotency_key;
+            const hasKey = typeof key === 'string' && key.trim().length > 0;
+            if (!hasKey) {
+              reasons.push(`txn: ${name} requires idempotency_key or compare-and-swap`);
+            }
+          }
+        } else if (forbidWritesOutsideTxn) {
+          reasons.push(`policy: ${name} outside transaction`);
+        }
+      }
+      return;
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child, insideTxn);
+      }
+    }
+  }
+
+  visit(ir, false);
+  return { ok: reasons.length === 0, reasons };
+}
+
+function isStorageWrite(name, catalog) {
+  if (!name) {
+    return false;
+  }
+
+  const primitives = catalog?.primitives || [];
+  const hit = primitives.find(p => {
+    const pname = (p.name || '').toLowerCase();
+    if (pname === name) {
+      return true;
+    }
+    const id = (p.id || '').toLowerCase();
+    return id.endsWith(`/${name}@1`);
+  });
+
+  if (hit && Array.isArray(hit.effects)) {
+    const hasEffect = hit.effects.some(e => (e || '').toLowerCase() === 'storage.write');
+    if (hasEffect) {
+      return true;
+    }
+  }
+
+  return /^(write-object|delete-object|compare-and-swap)$/.test(name);
+}

--- a/tests/txn-policy.test.mjs
+++ b/tests/txn-policy.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkTransactions } = await import('../packages/tf-l0-check/src/txn.mjs');
+
+const catalog = JSON.parse(
+  await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8')
+);
+
+async function loadFlow(path) {
+  const src = await readFile(path, 'utf8');
+  return parseDSL(src);
+}
+
+test('txn policy passes when writes are safe', async () => {
+  const ir = await loadFlow('examples/flows/txn_ok.tf');
+  const verdict = checkTransactions(ir, catalog);
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('missing idempotency_key inside txn fails', async () => {
+  const ir = await loadFlow('examples/flows/txn_fail_missing_key.tf');
+  const verdict = checkTransactions(ir, catalog);
+  assert.equal(verdict.ok, false);
+  assert(verdict.reasons.some(r => r.includes('requires idempotency_key')));
+});
+
+test('writes outside txn fail when forbidden', async () => {
+  const ir = await loadFlow('examples/flows/write_outside_txn.tf');
+  const verdict = checkTransactions(ir, catalog, { forbidWritesOutsideTxn: true });
+  assert.equal(verdict.ok, false);
+  assert(verdict.reasons.some(r => r.includes('outside transaction')));
+});


### PR DESCRIPTION
## Summary
- add a transaction policy checker that validates idempotency keys inside txn regions and optional write restrictions
- introduce a tf-policy CLI that runs the new transaction policy checks and emits canonical JSON
- provide example flows and automated tests covering passing and failing transaction policies

## Testing
- pnpm run a0
- pnpm run a1
- node packages/tf-compose/bin/tf-policy.mjs check examples/flows/txn_ok.tf
- node packages/tf-compose/bin/tf-policy.mjs check examples/flows/txn_fail_missing_key.tf || true
- node packages/tf-compose/bin/tf-policy.mjs check examples/flows/write_outside_txn.tf --forbid-outside || true
- pnpm run test:l0


------
https://chatgpt.com/codex/tasks/task_e_68cf2f7980d88320a30b7951369938eb