### PR TITLE
Add transaction policy lint and CLI

### DIFF
--- a/examples/flows/txn_fail_missing_key.tf
+++ b/examples/flows/txn_fail_missing_key.tf
@@ -1,0 +1,3 @@
+txn{
+  write-object(uri="res://kv/bucket", key="x", value="1")
+}

--- a/examples/flows/txn_ok.tf
+++ b/examples/flows/txn_ok.tf
@@ -1,0 +1,4 @@
+txn{
+  compare-and-swap(uri="res://kv/bucket", key="x", value="1", ifMatch=0);
+  write-object(uri="res://kv/bucket", key="y", value="2", idempotency_key="abc-123")
+}

--- a/examples/flows/write_outside_txn.tf
+++ b/examples/flows/write_outside_txn.tf
@@ -1,0 +1,1 @@
+write-object(uri="res://kv/bucket", key="z", value="3")

--- a/packages/tf-compose/bin/tf-policy.mjs
+++ b/packages/tf-compose/bin/tf-policy.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parseDSL } from '../src/parser.mjs';
+import { checkTransactions } from '../../tf-l0-check/src/txn.mjs';
+
+async function loadCatalog() {
+  try {
+    const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs;
+
+function arg(name) {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : null;
+}
+
+function hasFlag(name) {
+  return args.includes(name);
+}
+
+const cmd = args[0];
+if (!cmd || cmd !== 'check') {
+  console.error('Usage: tf-policy check <flow.tf> [--forbid-outside] [-o out.json]');
+  process.exit(2);
+}
+
+const file = args[1];
+if (!file) {
+  console.error('Missing flow path.');
+  process.exit(2);
+}
+
+const out = arg('-o') || arg('--out');
+const forbidOutside = hasFlag('--forbid-outside');
+
+const src = await readFile(file, 'utf8');
+const ir = parseDSL(src);
+const catalog = await loadCatalog();
+
+const verdict = checkTransactions(ir, catalog, {
+  forbidWritesOutsideTxn: forbidOutside
+});
+
+const payload = JSON.stringify({ ok: verdict.ok, reasons: verdict.reasons || [] }, null, 2) + '\n';
+
+if (out) {
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, payload, 'utf8');
+} else {
+  process.stdout.write(payload);
+}
+
+process.exit(verdict.ok ? 0 : 1);

--- a/packages/tf-l0-check/src/txn.mjs
+++ b/packages/tf-l0-check/src/txn.mjs
@@ -1,0 +1,84 @@
+const DEFAULT_OPTS = {
+  requireIdempotencyKeyInTxn: true,
+  forbidWritesOutsideTxn: false
+};
+
+export function checkTransactions(ir, catalog, opts = DEFAULT_OPTS) {
+  const reasons = [];
+  const options = { ...DEFAULT_OPTS, ...(opts || {}) };
+
+  function visit(node, insideTxn) {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+
+    if (node.node === 'Region') {
+      const nextInside = insideTxn || node.kind === 'Transaction';
+      for (const child of node.children || []) {
+        visit(child, nextInside);
+      }
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      handlePrim(node, insideTxn);
+      return;
+    }
+
+    for (const child of node.children || []) {
+      visit(child, insideTxn);
+    }
+  }
+
+  function handlePrim(node, insideTxn) {
+    if (!isStorageWrite(node, catalog)) {
+      return;
+    }
+
+    const primName = (node.prim || '').toLowerCase();
+
+    if (insideTxn) {
+      if (!options.requireIdempotencyKeyInTxn) {
+        return;
+      }
+
+      if (primName === 'compare-and-swap') {
+        return;
+      }
+
+      const key = node.args?.idempotency_key;
+      if (typeof key !== 'string' || key.length === 0) {
+        reasons.push(`txn: ${primName} requires idempotency_key or compare-and-swap`);
+      }
+      return;
+    }
+
+    if (options.forbidWritesOutsideTxn) {
+      reasons.push(`policy: ${primName} outside transaction`);
+    }
+  }
+
+  visit(ir, false);
+  return { ok: reasons.length === 0, reasons };
+}
+
+function isStorageWrite(node, catalog) {
+  const primName = (node.prim || '').toLowerCase();
+  const effects = lookupEffects(primName, catalog);
+  if ((effects || []).includes('Storage.Write')) {
+    return true;
+  }
+  return /^(write-object|delete-object|compare-and-swap)$/.test(primName);
+}
+
+function lookupEffects(primName, catalog) {
+  if (!catalog || !catalog.primitives) {
+    return [];
+  }
+  const hit = catalog.primitives.find(p => {
+    const name = (p.name || '').toLowerCase();
+    const id = (p.id || '').toLowerCase();
+    return name === primName || id.endsWith(`/${primName}@1`);
+  });
+  return hit?.effects || [];
+}

--- a/tests/txn-policy.test.mjs
+++ b/tests/txn-policy.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { checkTransactions } from '../packages/tf-l0-check/src/txn.mjs';
+
+const exec = promisify(execFile);
+
+async function loadCatalog() {
+  try {
+    const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+test('transaction policy accepts idempotent writes', async () => {
+  const src = await readFile('examples/flows/txn_ok.tf', 'utf8');
+  const ir = parseDSL(src);
+  const verdict = checkTransactions(ir, await loadCatalog());
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('transaction policy rejects missing idempotency key', async () => {
+  const src = await readFile('examples/flows/txn_fail_missing_key.tf', 'utf8');
+  const ir = parseDSL(src);
+  const verdict = checkTransactions(ir, await loadCatalog());
+  assert.equal(verdict.ok, false);
+  assert(verdict.reasons.some(r => r.includes('requires idempotency_key')));
+});
+
+test('policy CLI flags writes outside transactions when forbidden', async () => {
+  try {
+    await exec('node', [
+      'packages/tf-compose/bin/tf-policy.mjs',
+      'check',
+      'examples/flows/write_outside_txn.tf',
+      '--forbid-outside'
+    ]);
+    assert.fail('CLI should fail for writes outside transactions');
+  } catch (err) {
+    const stdout = err?.stdout || '';
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, false);
+    assert(payload.reasons.some(r => r.includes('outside transaction')));
+  }
+});


### PR DESCRIPTION
## Summary
- add a transaction policy linter that enforces idempotency keys inside txn regions and optional write bans outside
- introduce a `tf-policy` CLI entry point and provide sample flows for success and failure cases
- cover the new policy behavior and CLI with dedicated tests

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf2f7980d88320a30b7951369938eb