### PR TITLE
Add transaction policy checker and CLI

### DIFF
--- a/examples/flows/txn_fail_missing_key.tf
+++ b/examples/flows/txn_fail_missing_key.tf
@@ -1,0 +1,3 @@
+txn{
+  write-object(uri="res://kv/bucket", key="x", value="1")
+}

--- a/examples/flows/txn_ok.tf
+++ b/examples/flows/txn_ok.tf
@@ -1,0 +1,4 @@
+txn{
+  compare-and-swap(uri="res://kv/bucket", key="x", value="1", ifMatch=0);
+  write-object(uri="res://kv/bucket", key="y", value="2", idempotency_key="abc-123")
+}

--- a/examples/flows/write_outside_txn.tf
+++ b/examples/flows/write_outside_txn.tf
@@ -1,0 +1,1 @@
+write-object(uri="res://kv/bucket", key="z", value="3")

--- a/packages/tf-compose/bin/tf-policy.mjs
+++ b/packages/tf-compose/bin/tf-policy.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const usage = 'Usage: node packages/tf-compose/bin/tf-policy.mjs check <flow.tf> [--forbid-outside] [-o out.json]';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      'forbid-outside': { type: 'boolean' },
+      out: { type: 'string', short: 'o' }
+    },
+    allowPositionals: true
+  });
+
+  if (positionals.length === 0) {
+    throw new Error('Missing command');
+  }
+
+  const command = positionals[0];
+  if (command !== 'check') {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  if (positionals.length < 2) {
+    throw new Error('Missing flow path');
+  }
+  if (positionals.length > 2) {
+    throw new Error(`Unexpected argument: ${positionals[2]}`);
+  }
+
+  const flowPath = positionals[1];
+  const outPath = values.out;
+  const forbidOutside = Boolean(values['forbid-outside']);
+
+  const [{ parseDSL }, { checkTransactions }] = await Promise.all([
+    import('../src/parser.mjs'),
+    import('../../tf-l0-check/src/txn.mjs')
+  ]);
+
+  let flowSource;
+  try {
+    flowSource = await readFile(flowPath, 'utf8');
+  } catch (err) {
+    throw new Error(`Failed to read flow at ${flowPath}: ${err.message}`);
+  }
+
+  const ir = parseDSL(flowSource);
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const catalogPath = path.resolve(
+    scriptDir,
+    '..',
+    '..',
+    'tf-l0-spec/spec/catalog.json'
+  );
+
+  let catalog;
+  try {
+    catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  } catch (err) {
+    throw new Error(`Failed to load catalog at ${catalogPath}: ${err.message}`);
+  }
+
+  const verdict = checkTransactions(ir, catalog, {
+    forbidWritesOutsideTxn: forbidOutside
+  });
+
+  const payload = {
+    ok: Boolean(verdict?.ok),
+    reasons: [...(verdict?.reasons || [])]
+  };
+
+  const json = JSON.stringify(payload, ['ok', 'reasons']);
+
+  if (outPath) {
+    await mkdir(path.dirname(outPath), { recursive: true });
+    await writeFile(outPath, `${json}\n`, 'utf8');
+  } else {
+    process.stdout.write(`${json}\n`);
+  }
+
+  if (!payload.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main(process.argv).catch((err) => {
+  console.error(err.message || err);
+  console.error(usage);
+  process.exit(1);
+});

--- a/packages/tf-l0-check/src/txn.mjs
+++ b/packages/tf-l0-check/src/txn.mjs
@@ -1,0 +1,85 @@
+const DEFAULT_OPTS = {
+  requireIdempotencyKeyInTxn: true,
+  forbidWritesOutsideTxn: false
+};
+
+export function checkTransactions(ir, catalog, opts = {}) {
+  const options = { ...DEFAULT_OPTS, ...(opts || {}) };
+  const reasons = [];
+
+  function visit(node, insideTxn = false) {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+
+    if (node.node === 'Region') {
+      const nextInside = insideTxn || node.kind === 'Transaction';
+      for (const child of node.children || []) {
+        visit(child, nextInside);
+      }
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      handlePrim(node, insideTxn);
+      return;
+    }
+
+    for (const child of node.children || []) {
+      visit(child, insideTxn);
+    }
+  }
+
+  function handlePrim(node, insideTxn) {
+    if (!isStorageWrite(node)) {
+      return;
+    }
+
+    const primName = (node.prim || '').toLowerCase();
+
+    if (insideTxn) {
+      if (!options.requireIdempotencyKeyInTxn) {
+        return;
+      }
+      const isCompareAndSwap = primName === 'compare-and-swap';
+      const idemKey = node?.args?.idempotency_key;
+      const hasIdemKey = typeof idemKey === 'string' && idemKey.length > 0;
+      if (!isCompareAndSwap && !hasIdemKey) {
+        reasons.push(`txn: ${primName} requires idempotency_key or compare-and-swap`);
+      }
+      return;
+    }
+
+    if (options.forbidWritesOutsideTxn) {
+      reasons.push(`policy: ${primName} outside transaction`);
+    }
+  }
+
+  function isStorageWrite(node) {
+    const name = (node.prim || '').toLowerCase();
+    if (!name) {
+      return false;
+    }
+
+    const entry = lookupCatalogPrimitive(name);
+    const effects = Array.isArray(entry?.effects) ? entry.effects : [];
+    if (effects.some((effect) => String(effect).toLowerCase() === 'storage.write'.toLowerCase())) {
+      return true;
+    }
+
+    return /^(write-object|delete-object|compare-and-swap)$/.test(name);
+  }
+
+  function lookupCatalogPrimitive(name) {
+    const primitives = Array.isArray(catalog?.primitives) ? catalog.primitives : [];
+    return (
+      primitives.find((p) => (p.name || '').toLowerCase() === name) ||
+      primitives.find((p) => (p.id || '').toLowerCase().endsWith(`/${name}@1`)) ||
+      null
+    );
+  }
+
+  visit(ir, false);
+
+  return { ok: reasons.length === 0, reasons };
+}

--- a/tests/txn-policy.test.mjs
+++ b/tests/txn-policy.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkTransactions } = await import('../packages/tf-l0-check/src/txn.mjs');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const catalogPath = path.resolve(repoRoot, 'packages/tf-l0-spec/spec/catalog.json');
+
+async function loadCatalog() {
+  const contents = await readFile(catalogPath, 'utf8');
+  return JSON.parse(contents);
+}
+
+const catalog = await loadCatalog();
+
+async function readFlow(relativePath) {
+  return readFile(path.resolve(repoRoot, relativePath), 'utf8');
+}
+
+async function runPolicyCli(args) {
+  const cliPath = path.resolve(repoRoot, 'packages/tf-compose/bin/tf-policy.mjs');
+  const child = spawn(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  const stdoutChunks = [];
+  const stderrChunks = [];
+
+  child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+  child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+  const code = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+
+  return {
+    code,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8')
+  };
+}
+
+test('transaction writes inside txn require idempotency key', async () => {
+  const src = await readFlow('examples/flows/txn_ok.tf');
+  const ir = parseDSL(src);
+  const verdict = checkTransactions(ir, catalog);
+
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('missing idempotency key in txn is flagged', async () => {
+  const src = await readFlow('examples/flows/txn_fail_missing_key.tf');
+  const ir = parseDSL(src);
+  const verdict = checkTransactions(ir, catalog);
+
+  assert.equal(verdict.ok, false);
+  assert.ok(verdict.reasons.some((r) => r.includes('requires idempotency_key')));
+});
+
+test('policy CLI forbids writes outside txn when requested', async () => {
+  const result = await runPolicyCli([
+    'check',
+    'examples/flows/write_outside_txn.tf',
+    '--forbid-outside'
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, false);
+  assert.ok(parsed.reasons.some((r) => r.includes('outside transaction')));
+});


### PR DESCRIPTION
## Summary
- add a transaction policy checker that enforces idempotency keys inside txn regions and optional write restrictions outside
- wire a standalone tf-policy CLI for running the policy checks and provide example flows for passing/failing scenarios
- cover the new behavior with automated tests exercising both the checker API and the CLI

## Testing
- pnpm run a0
- pnpm run a1
- node packages/tf-compose/bin/tf-policy.mjs check examples/flows/txn_ok.tf
- node packages/tf-compose/bin/tf-policy.mjs check examples/flows/txn_fail_missing_key.tf
- node packages/tf-compose/bin/tf-policy.mjs check examples/flows/write_outside_txn.tf --forbid-outside
- pnpm test *(fails: @tf-lang/trace2tags@0.1.0 test: `vitest run`)*
- pnpm run test:l0


------
https://chatgpt.com/codex/tasks/task_e_68cf2f7980d88320a30b7951369938eb