### PR TITLE
Add in-memory runtime runner for TS codegen

### DIFF
--- a/examples/flows/run_publish.tf
+++ b/examples/flows/run_publish.tf
@@ -1,0 +1,3 @@
+authorize{
+  publish(topic="orders", key="abc", payload="{}")
+}

--- a/examples/flows/run_storage_ok.tf
+++ b/examples/flows/run_storage_ok.tf
@@ -1,0 +1,6 @@
+authorize{
+  seq{
+    write-object(uri="res://kv/run", key="a", value="1");
+    write-object(uri="res://kv/run", key="b", value="2")
+  }
+}

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto';
+
+const storage = new Map();
+const metricsLog = [];
+const topicQueues = new Map();
+
+function keyFor(uri = '', key = '') {
+  return `${uri}#${key}`;
+}
+
+function register(target, domain, name, fn) {
+  const base = name.toLowerCase();
+  const names = [
+    base,
+    `${domain}/${base}`,
+    `tf:${domain}/${base}@1`
+  ];
+  for (const n of names) {
+    target[n] = fn;
+  }
+}
+
+function ensureTopic(topic) {
+  if (!topicQueues.has(topic)) {
+    topicQueues.set(topic, []);
+  }
+  return topicQueues.get(topic);
+}
+
+async function writeObject(args = {}) {
+  const uri = String(args.uri ?? 'res://unknown');
+  const key = String(args.key ?? '');
+  const entry = storage.get(keyFor(uri, key));
+  const nextEtag = (entry?.etag ?? 0) + 1;
+  const value = args.value;
+  storage.set(keyFor(uri, key), { value, etag: nextEtag });
+  return { ok: true, etag: nextEtag, value };
+}
+
+async function readObject(args = {}) {
+  const uri = String(args.uri ?? 'res://unknown');
+  const key = String(args.key ?? '');
+  const entry = storage.get(keyFor(uri, key));
+  if (!entry) {
+    return { ok: false, value: null, etag: null };
+  }
+  return { ok: true, value: entry.value, etag: entry.etag };
+}
+
+async function compareAndSwap(args = {}) {
+  const uri = String(args.uri ?? 'res://unknown');
+  const key = String(args.key ?? '');
+  const ifMatch = args.ifMatch;
+  const current = storage.get(keyFor(uri, key));
+  const currentEtag = current?.etag ?? null;
+  const matches = ifMatch !== undefined && ifMatch === currentEtag;
+  if (!matches) {
+    return { ok: false, current: current?.value ?? null, etag: currentEtag };
+  }
+  const nextEtag = (currentEtag ?? 0) + 1;
+  const value = args.value;
+  storage.set(keyFor(uri, key), { value, etag: nextEtag });
+  return { ok: true, value, etag: nextEtag };
+}
+
+async function hashValue(args = {}) {
+  const input = 'value' in args ? args.value : args;
+  const digest = createHash('sha256')
+    .update(JSON.stringify(input))
+    .digest('hex');
+  return `sha256:${digest}`;
+}
+
+async function emitMetric(args = {}) {
+  const entry = { ...args, ts: Date.now() };
+  metricsLog.push(entry);
+  if (process?.env?.DEV_PROOFS) {
+    console.log('[metric]', JSON.stringify(entry));
+  }
+  return { ok: true };
+}
+
+async function publish(args = {}) {
+  const topic = String(args.topic ?? 'default');
+  const queue = ensureTopic(topic);
+  queue.push({ key: args.key ?? null, payload: args.payload ?? null, ts: Date.now() });
+  return { ok: true };
+}
+
+const adapters = {};
+register(adapters, 'resource', 'write-object', writeObject);
+register(adapters, 'resource', 'read-object', readObject);
+register(adapters, 'resource', 'compare-and-swap', compareAndSwap);
+register(adapters, 'information', 'hash', hashValue);
+register(adapters, 'observability', 'emit-metric', emitMetric);
+register(adapters, 'network', 'publish', publish);
+
+export const state = {
+  storage,
+  metrics: metricsLog,
+  topics: topicQueues
+};
+
+export default Object.assign({}, adapters, { state });

--- a/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
@@ -1,0 +1,121 @@
+const registry = [];
+const metaByName = new Map();
+
+function registerMeta(domain, name, primId, effects = []) {
+  const entry = {
+    domain,
+    name,
+    prim_id: primId,
+    effects: effects.slice(),
+    names: []
+  };
+  const variants = [
+    name.toLowerCase(),
+    `${domain}/${name}`.toLowerCase(),
+    `tf:${domain}/${name}@1`.toLowerCase()
+  ];
+  entry.names = variants;
+  for (const variant of variants) {
+    metaByName.set(variant, entry);
+  }
+  registry.push(entry);
+}
+
+registerMeta('resource', 'write-object', 'tf:resource/write-object@1', ['Storage.Write']);
+registerMeta('resource', 'read-object', 'tf:resource/read-object@1', ['Storage.Read']);
+registerMeta('resource', 'compare-and-swap', 'tf:resource/compare-and-swap@1', ['Storage.Write']);
+registerMeta('information', 'hash', 'tf:information/hash@1', ['Pure']);
+registerMeta('observability', 'emit-metric', 'tf:observability/emit-metric@1', ['Observability']);
+registerMeta('network', 'publish', 'tf:network/publish@1', ['Network.Out']);
+
+function resolveMeta(name) {
+  const lower = (name || '').toLowerCase();
+  if (metaByName.has(lower)) {
+    return metaByName.get(lower);
+  }
+  const base = lower.split('/').pop()?.split('@')[0] || lower;
+  if (metaByName.has(base)) {
+    return metaByName.get(base);
+  }
+  const fallback = registry.find(entry => entry.name === base);
+  if (fallback) {
+    return fallback;
+  }
+  return { prim_id: name, effects: [], names: [lower, base].filter(Boolean) };
+}
+
+function resolveAdapter(adapters, name) {
+  const meta = resolveMeta(name);
+  const candidates = Array.from(new Set([...(meta.names || []), (name || '').toLowerCase()]));
+  for (const candidate of candidates) {
+    const fn = adapters?.[candidate];
+    if (typeof fn === 'function') {
+      return fn;
+    }
+  }
+  return null;
+}
+
+function nowTs() {
+  try {
+    const clock = globalThis?.__tf_clock;
+    if (clock && typeof clock.nowNs === 'function') {
+      const raw = clock.nowNs();
+      if (typeof raw === 'bigint') {
+        return Number(raw / 1_000_000n);
+      }
+      if (typeof raw === 'number') {
+        return Math.floor(raw / 1_000_000);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return Date.now();
+}
+
+async function execNode(node, adapters, ctx) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  if (node.node === 'Prim') {
+    const fn = resolveAdapter(adapters, node.prim);
+    if (!fn) {
+      throw new Error(`No adapter for primitive: ${node.prim}`);
+    }
+    const meta = resolveMeta(node.prim);
+    const ts = nowTs();
+    const result = await fn(node.args || {});
+    ctx.ops += 1;
+    for (const effect of meta.effects || []) {
+      ctx.effects.add(effect);
+    }
+    console.log(JSON.stringify({ prim_id: meta.prim_id || node.prim, args: node.args || {}, ts }));
+    return result;
+  }
+  if (node.node === 'Seq' || node.node === 'Region') {
+    let acc = null;
+    for (const child of node.children || []) {
+      acc = await execNode(child, adapters, ctx);
+    }
+    return acc;
+  }
+  if (node.node === 'Par') {
+    const results = await Promise.all((node.children || []).map(child => execNode(child, adapters, ctx)));
+    return results;
+  }
+  if (Array.isArray(node.children)) {
+    let acc = null;
+    for (const child of node.children) {
+      acc = await execNode(child, adapters, ctx);
+    }
+    return acc;
+  }
+  return null;
+}
+
+export async function runIR(ir, adapters) {
+  const ctx = { ops: 0, effects: new Set() };
+  await execNode(ir, adapters, ctx);
+  return { ok: true, ops: ctx.ops, effects: Array.from(ctx.effects) };
+}


### PR DESCRIPTION
## Summary
- add in-memory runtime adapters for resource, information, observability, and network primitives to support smoke runs
- create a minimal IR runner that executes Prim/Seq/Par nodes and emits trace lines
- extend the TS generator to bundle the runtime, emit run.mjs with status output, and add smoke example flows

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run tf emit examples/flows/run_storage_ok.tf --lang ts --out out/0.4/codegen-ts/run_storage_ok
- pnpm run tf emit examples/flows/run_publish.tf --lang ts --out out/0.4/codegen-ts/run_publish
- node out/0.4/codegen-ts/run_storage_ok/run.mjs
- node out/0.4/codegen-ts/run_publish/run.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf2f5adcfc8320a42dea349fe8f8f2