### PR TITLE
Add in-memory runtime and smoke runner generation

### DIFF
--- a/examples/flows/run_publish.tf
+++ b/examples/flows/run_publish.tf
@@ -1,0 +1,1 @@
+publish(topic="events", key="demo", payload="{}")

--- a/examples/flows/run_storage_ok.tf
+++ b/examples/flows/run_storage_ok.tf
@@ -1,0 +1,4 @@
+seq{
+  write-object(uri="res://kv/demo", key="alpha", value="1");
+  write-object(uri="res://kv/demo", key="beta", value="2")
+}

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -1,0 +1,80 @@
+import { createHash } from 'node:crypto';
+
+const storage = new Map();
+const metrics = [];
+const topics = new Map();
+
+function keyFor(uri = '', key = '') {
+  return `${uri}#${key}`;
+}
+
+function ensureRecord(uri, key) {
+  const k = keyFor(uri, key);
+  if (!storage.has(k)) {
+    storage.set(k, { value: undefined, etag: 0 });
+  }
+  return storage.get(k);
+}
+
+function nextEtag(record) {
+  const current = typeof record?.etag === 'number' ? record.etag : 0;
+  return current + 1;
+}
+
+function toCanonicalTopic(args = {}) {
+  return args.topic || args.uri || 'default';
+}
+
+const adapters = {
+  'tf:resource/write-object@1': async (args = {}) => {
+    const { uri = '', key = '', value } = args;
+    const record = ensureRecord(uri, key);
+    const etag = nextEtag(record);
+    storage.set(keyFor(uri, key), { value, etag });
+    return { ok: true, etag };
+  },
+  'tf:resource/read-object@1': async (args = {}) => {
+    const { uri = '', key = '' } = args;
+    const record = storage.get(keyFor(uri, key));
+    if (!record) {
+      return { found: false, value: undefined, etag: 0 };
+    }
+    return { found: true, value: record.value, etag: record.etag };
+  },
+  'tf:resource/compare-and-swap@1': async (args = {}) => {
+    const { uri = '', key = '', value, new_value, newValue, ifMatch } = args;
+    const record = storage.get(keyFor(uri, key));
+    const currentEtag = record?.etag ?? 0;
+    if (ifMatch !== currentEtag) {
+      return { ok: false, etag: currentEtag, conflict: true };
+    }
+    const nextValue = new_value ?? newValue ?? value;
+    const etag = currentEtag + 1;
+    storage.set(keyFor(uri, key), { value: nextValue, etag });
+    return { ok: true, etag, value: nextValue };
+  },
+  'tf:information/hash@1': async (args = {}) => {
+    const input = Object.prototype.hasOwnProperty.call(args, 'value') ? args.value : args.input ?? args.data ?? null;
+    const payload = JSON.stringify(input);
+    const digest = createHash('sha256').update(payload).digest('hex');
+    return { hash: `sha256:${digest}` };
+  },
+  'tf:observability/emit-metric@1': async (args = {}) => {
+    metrics.push({ ts: Date.now(), args });
+    if (process.env.DEV_PROOFS) {
+      console.log('[metric]', JSON.stringify(args));
+    }
+    return { ok: true };
+  },
+  'tf:network/publish@1': async (args = {}) => {
+    const topic = toCanonicalTopic(args);
+    const queue = topics.get(topic) || [];
+    queue.push({ ts: Date.now(), args });
+    topics.set(topic, queue);
+    return { ok: true };
+  }
+};
+
+export default adapters;
+export { storage, metrics, topics };
+

--- a/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
@@ -1,0 +1,113 @@
+const PRIM_ALIASES = {
+  'write-object': 'tf:resource/write-object@1',
+  'tf:resource/write-object@1': 'tf:resource/write-object@1',
+  'read-object': 'tf:resource/read-object@1',
+  'tf:resource/read-object@1': 'tf:resource/read-object@1',
+  'compare-and-swap': 'tf:resource/compare-and-swap@1',
+  'tf:resource/compare-and-swap@1': 'tf:resource/compare-and-swap@1',
+  'hash': 'tf:information/hash@1',
+  'tf:information/hash@1': 'tf:information/hash@1',
+  'emit-metric': 'tf:observability/emit-metric@1',
+  'tf:observability/emit-metric@1': 'tf:observability/emit-metric@1',
+  'publish': 'tf:network/publish@1',
+  'tf:network/publish@1': 'tf:network/publish@1'
+};
+
+const PRIM_EFFECTS = {
+  'tf:resource/write-object@1': ['Storage.Write'],
+  'tf:resource/read-object@1': ['Storage.Read'],
+  'tf:resource/compare-and-swap@1': ['Storage.Write'],
+  'tf:information/hash@1': ['Pure'],
+  'tf:observability/emit-metric@1': ['Observability'],
+  'tf:network/publish@1': ['Network.Out']
+};
+
+function canonicalPrim(prim) {
+  if (!prim) return prim;
+  const lowered = typeof prim === 'string' ? prim.toLowerCase() : prim;
+  return PRIM_ALIASES[lowered] || prim;
+}
+
+function nowTimestamp() {
+  const clock = globalThis.__tf_clock;
+  try {
+    if (clock && typeof clock.nowMs === 'function') {
+      return Number(clock.nowMs());
+    }
+    if (clock && typeof clock.nowNs === 'function') {
+      const ns = clock.nowNs();
+      if (typeof ns === 'bigint') {
+        return Number(ns / 1_000_000n);
+      }
+      return Number(ns) / 1_000_000;
+    }
+  } catch {
+    // fall back to Date.now
+  }
+  return Date.now();
+}
+
+async function evalNode(node, ctx) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+
+  if (node.node === 'Prim') {
+    return await execPrim(node, ctx);
+  }
+
+  if (node.node === 'Seq') {
+    let last = null;
+    for (const child of node.children || []) {
+      last = await evalNode(child, ctx);
+    }
+    return last;
+  }
+
+  if (node.node === 'Par') {
+    const promises = (node.children || []).map(child => evalNode(child, ctx));
+    return await Promise.all(promises);
+  }
+
+  if (node.node === 'Region' || Array.isArray(node.children)) {
+    let last = null;
+    for (const child of node.children || []) {
+      last = await evalNode(child, ctx);
+    }
+    return last;
+  }
+
+  return null;
+}
+
+async function execPrim(node, ctx) {
+  const primId = canonicalPrim(node.prim);
+  const handler = ctx.adapters[primId] || ctx.adapters[node.prim];
+  if (typeof handler !== 'function') {
+    throw new Error(`No adapter for primitive: ${node.prim}`);
+  }
+  const args = node.args || {};
+  const ts = nowTimestamp();
+  const result = await handler(args, ctx);
+  ctx.ops++;
+  const effects = PRIM_EFFECTS[primId] || [];
+  for (const eff of effects) ctx.effects.add(eff);
+  const line = { prim_id: primId, args, ts };
+  console.log(JSON.stringify(line));
+  return result;
+}
+
+export async function runIR(ir, adapters) {
+  const ctx = {
+    adapters: adapters || {},
+    ops: 0,
+    effects: new Set()
+  };
+  await evalNode(ir, ctx);
+  return {
+    ok: true,
+    ops: ctx.ops,
+    effects: Array.from(ctx.effects)
+  };
+}
+


### PR DESCRIPTION
## Summary
- add an in-memory adapter set for core primitives and a lightweight IR interpreter
- extend the TS generator to copy the runtime bundle and emit a runnable smoke script
- add example flows to exercise storage writes and publish through the smoke runner

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run tf -- emit examples/flows/run_storage_ok.tf --lang ts --out out/0.4/codegen-ts/run_storage_ok
- pnpm run tf -- emit examples/flows/run_publish.tf --lang ts --out out/0.4/codegen-ts/run_publish
- node out/0.4/codegen-ts/run_storage_ok/run.mjs
- node out/0.4/codegen-ts/run_publish/run.mjs


------
https://chatgpt.com/codex/tasks/task_e_68cf2f5adcfc8320a42dea349fe8f8f2