### PR TITLE
Add JS smoke runner runtime for TS codegen

### DIFF
--- a/examples/flows/run_publish.tf
+++ b/examples/flows/run_publish.tf
@@ -1,0 +1,1 @@
+authorize{ publish(topic="orders", key="abc", payload="{}") }

--- a/examples/flows/run_storage_ok.tf
+++ b/examples/flows/run_storage_ok.tf
@@ -1,0 +1,6 @@
+authorize{
+  seq{
+    write-object(uri="res://kv/bucket", key="a", value="1");
+    write-object(uri="res://kv/bucket", key="b", value="2")
+  }
+}

--- a/packages/tf-l0-codegen-ts/scripts/generate.mjs
+++ b/packages/tf-l0-codegen-ts/scripts/generate.mjs
@@ -1,5 +1,7 @@
-import { writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { writeFile, mkdir, readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
 export async function generate(ir, { outDir }) {
   await mkdir(join(outDir, 'src'), { recursive: true });
   await writeFile(join(outDir, 'package.json'), JSON.stringify({ name:"tf-generated", private:true, type:"module", scripts:{ start:"node ./dist/pipeline.mjs" }, dependencies:{} }, null, 2) + '\n', 'utf8');
@@ -8,6 +10,7 @@ export async function generate(ir, { outDir }) {
   await writeFile(join(outDir,'src','trace.ts'), traceUtil(), 'utf8');
   await writeFile(join(outDir,'src','determinism.ts'), determinismUtil(), 'utf8');
   await writeFile(join(outDir,'src','redaction.ts'), redactionUtil(), 'utf8');
+  await emitRuntime(ir, outDir);
 }
 function prims(ir, out=new Set()){ if(!ir||typeof ir!=='object') return out; if(ir.node==='Prim') out.add(ir.prim); for(const c of (ir.children||[])) prims(c,out); return out; }
 function genAdapters(ir){ const names=Array.from(prims(ir)); const methods=names.map(n=>`  ${to(n)}(input: any): Promise<any>`).join('\n'); const stubs=names.map(n=>stub(n)).join('\n\n'); return `export interface Adapters {\n${methods}\n}\n\n${stubs}\n`; function to(n){ return 'prim_'+n.replace(/[^a-z0-9]/g,'_'); } function stub(n){ const m=to(n); return `export async function ${m}(input:any):Promise<any>{ throw new Error('Not wired: ${m}'); }`; } }
@@ -16,3 +19,21 @@ function traceUtil(){ return `import { applyRedaction } from './redaction';\nfun
 function determinismUtil(){ return `export { XorShift32, FixedClock } from './determinism';`; }
 function redactionUtil(){ return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`; }
 function hashCode(s){ let h=0; for(let i=0;i<s.length;i++){ h=((h<<5)-h)+s.charCodeAt(i)|0; } return Math.abs(h); }
+
+async function emitRuntime(ir, outDir) {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const runtimeDir = join(outDir, 'runtime');
+  await mkdir(runtimeDir, { recursive: true });
+  await copyRuntimeFile(here, 'inmem.mjs', runtimeDir);
+  await copyRuntimeFile(here, 'run-ir.mjs', runtimeDir);
+
+  const irJson = canonicalize(ir);
+  const runSource = `import { mkdir, writeFile } from 'node:fs/promises';\nimport { dirname, join, resolve } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport { runIR } from './runtime/run-ir.mjs';\nimport adapters from './runtime/inmem.mjs';\n\nconst ir = ${irJson};\n\nconst result = await runIR(ir, adapters);\n\nconst here = fileURLToPath(new URL('.', import.meta.url));\nconst summary = { ok: true, ops: result.ops, effects: result.effects };\nconst targets = [\n  resolve(here, '..', '..', 'example', 'run', 'status.json'),\n  join(here, 'status.json'),\n];\nfor (const target of targets) {\n  await mkdir(dirname(target), { recursive: true });\n  await writeFile(target, JSON.stringify(summary, null, 2) + '\\n', 'utf8');\n}\n`;
+  await writeFile(join(outDir, 'run.mjs'), runSource, 'utf8');
+}
+
+async function copyRuntimeFile(baseDir, fileName, runtimeDir) {
+  const srcPath = resolve(baseDir, '../src/runtime', fileName);
+  const contents = await readFile(srcPath, 'utf8');
+  await writeFile(join(runtimeDir, fileName), contents, 'utf8');
+}

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -1,0 +1,107 @@
+import { createHash } from 'node:crypto';
+
+const store = new Map();
+let nextEtag = 1;
+const metricsLog = [];
+const topicQueues = new Map();
+
+function keyFor(uri, key) {
+  if (typeof uri !== 'string' || !uri) {
+    throw new Error('write-object requires a uri');
+  }
+  if (typeof key !== 'string' || !key) {
+    throw new Error('write-object requires a key');
+  }
+  return `${uri}#${key}`;
+}
+
+function currentTimeMs() {
+  const clock = globalThis.__tf_clock;
+  if (clock && typeof clock.nowNs === 'function') {
+    try {
+      const ns = clock.nowNs();
+      if (typeof ns === 'bigint') {
+        return Number(ns / 1_000_000n);
+      }
+      if (typeof ns === 'number') {
+        return Math.floor(ns / 1_000_000);
+      }
+    } catch {
+      // fall back below
+    }
+  }
+  return Date.now();
+}
+
+async function writeObject(args = {}) {
+  const { uri, key, value } = args;
+  const storageKey = keyFor(uri, key);
+  const etag = nextEtag++;
+  store.set(storageKey, { value, etag });
+  return { ok: true, etag };
+}
+
+async function readObject(args = {}) {
+  const { uri, key } = args;
+  const storageKey = keyFor(uri, key);
+  const entry = store.get(storageKey);
+  if (!entry) {
+    return { ok: false, value: undefined, etag: null };
+  }
+  return { ok: true, value: entry.value, etag: entry.etag };
+}
+
+async function compareAndSwap(args = {}) {
+  const { uri, key, value, ifMatch } = args;
+  const storageKey = keyFor(uri, key);
+  const entry = store.get(storageKey);
+  const currentEtag = entry?.etag ?? null;
+  if (currentEtag !== ifMatch) {
+    return { ok: false, etag: currentEtag, value: entry?.value };
+  }
+  const etag = nextEtag++;
+  store.set(storageKey, { value, etag });
+  return { ok: true, etag, value };
+}
+
+async function hash(args) {
+  const input = args?.value ?? args?.input ?? args;
+  const serialized = JSON.stringify(input);
+  const digest = createHash('sha256').update(serialized).digest('hex');
+  return { ok: true, hash: `sha256:${digest}` };
+}
+
+async function emitMetric(args = {}) {
+  const payload = { ...args, ts: currentTimeMs() };
+  metricsLog.push(payload);
+  if (process?.env?.DEV_PROOFS) {
+    console.log('[metric]', JSON.stringify(payload));
+  }
+  return { ok: true };
+}
+
+async function publish(args = {}) {
+  const { topic, key, payload } = args;
+  if (typeof topic !== 'string' || !topic) {
+    throw new Error('publish requires topic');
+  }
+  const queue = topicQueues.get(topic) ?? [];
+  queue.push({ key, payload, ts: currentTimeMs() });
+  topicQueues.set(topic, queue);
+  return { ok: true, size: queue.length };
+}
+
+const adapters = {
+  'tf:resource/write-object@1': writeObject,
+  'tf:resource/read-object@1': readObject,
+  'tf:resource/compare-and-swap@1': compareAndSwap,
+  'tf:information/hash@1': hash,
+  'tf:observability/emit-metric@1': emitMetric,
+  'tf:network/publish@1': publish,
+};
+
+export const storage = store;
+export const metrics = metricsLog;
+export const topics = topicQueues;
+
+export default adapters;

--- a/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
@@ -1,0 +1,102 @@
+const PRIM_IDS = {
+  'write-object': 'tf:resource/write-object@1',
+  'read-object': 'tf:resource/read-object@1',
+  'compare-and-swap': 'tf:resource/compare-and-swap@1',
+  'hash': 'tf:information/hash@1',
+  'emit-metric': 'tf:observability/emit-metric@1',
+  'publish': 'tf:network/publish@1',
+};
+
+const EFFECTS = {
+  'tf:resource/write-object@1': 'Storage.Write',
+  'tf:resource/read-object@1': 'Storage.Read',
+  'tf:resource/compare-and-swap@1': 'Storage.Write',
+  'tf:observability/emit-metric@1': 'Observability',
+  'tf:network/publish@1': 'Network.Out',
+};
+
+function nowMs() {
+  const clock = globalThis.__tf_clock;
+  if (clock && typeof clock.nowNs === 'function') {
+    try {
+      const ns = clock.nowNs();
+      if (typeof ns === 'bigint') {
+        return Number(ns / 1_000_000n);
+      }
+      if (typeof ns === 'number') {
+        return Math.floor(ns / 1_000_000);
+      }
+    } catch {
+      // fall back to Date.now
+    }
+  }
+  return Date.now();
+}
+
+function toPrimId(node) {
+  const raw = (node?.prim || '').toLowerCase();
+  if (raw.startsWith('tf:')) return raw;
+  return PRIM_IDS[raw] || raw;
+}
+
+async function executeNode(node, ctx) {
+  if (!node || typeof node !== 'object') return null;
+
+  if (node.node === 'Prim') {
+    return executePrim(node, ctx);
+  }
+
+  if (node.node === 'Seq' || node.node === 'Region') {
+    let last = null;
+    for (const child of node.children || []) {
+      last = await executeNode(child, ctx);
+    }
+    return last;
+  }
+
+  if (node.node === 'Par') {
+    const promises = (node.children || []).map((child) => executeNode(child, ctx));
+    return Promise.all(promises);
+  }
+
+  if (Array.isArray(node.children)) {
+    let last = null;
+    for (const child of node.children) {
+      last = await executeNode(child, ctx);
+    }
+    return last;
+  }
+
+  return null;
+}
+
+async function executePrim(node, ctx) {
+  const primId = toPrimId(node);
+  const adapter = ctx.adapters[primId] || ctx.adapters[node.prim];
+  if (typeof adapter !== 'function') {
+    throw new Error(`Missing adapter for primitive ${primId || node.prim}`);
+  }
+  const args = node.args || {};
+  const ts = nowMs();
+  ctx.ops++;
+  const effect = EFFECTS[primId];
+  if (effect) ctx.effects.add(effect);
+  console.log(JSON.stringify({ prim_id: primId, args, ts }));
+  return await adapter(args);
+}
+
+export async function runIR(ir, adapters) {
+  const ctx = {
+    adapters: adapters || {},
+    ops: 0,
+    effects: new Set(),
+  };
+  await executeNode(ir, ctx);
+  return {
+    ok: true,
+    ops: ctx.ops,
+    effects: Array.from(ctx.effects),
+  };
+}
+
+export default runIR;


### PR DESCRIPTION
## Summary
- add an in-memory adapter bundle that covers the storage, hash, metrics, and publish primitives needed for smoke tests
- add a minimal IR interpreter and extend the TS generator to emit a runnable JS bundle with embedded IR and status reporting
- introduce sample flows for storage and publish smoke runs

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run tf emit examples/flows/run_storage_ok.tf --lang ts --out out/0.4/codegen-ts/run_storage_ok
- node out/0.4/codegen-ts/run_storage_ok/run.mjs
- pnpm run tf emit examples/flows/run_publish.tf --lang ts --out out/0.4/codegen-ts/run_publish
- node out/0.4/codegen-ts/run_publish/run.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf2f5adcfc8320a42dea349fe8f8f2