### PR TITLE
Add capability validation to TS runner and trace summary CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ npm run tf -- canon examples/flows/signing.tf -o out/0.4/ir/signing.canon.json
 # Generate TS skeleton for the flow
 npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/signing
 
+# Execute generated runners with capability manifests and summarize traces
+npm run tf -- emit --lang ts examples/flows/run_storage_ok.tf --out out/0.4/codegen-ts/run_storage_ok
+node out/0.4/codegen-ts/run_storage_ok/run.mjs --caps caps.json
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --pretty
+
 # Generate capability manifest
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json

--- a/packages/tf-l0-codegen-ts/scripts/generate.mjs
+++ b/packages/tf-l0-codegen-ts/scripts/generate.mjs
@@ -1,34 +1,131 @@
-import { writeFile, mkdir, copyFile } from 'node:fs/promises';
+import { writeFile, mkdir, copyFile, readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
-export async function generate(ir, { outDir }) {
-  await mkdir(join(outDir, 'src'), { recursive: true });
-  await writeFile(join(outDir, 'package.json'), JSON.stringify({ name:"tf-generated", private:true, type:"module", scripts:{ start:"node ./dist/pipeline.mjs" }, dependencies:{} }, null, 2) + '\n', 'utf8');
-  const adapters = genAdapters(ir); await writeFile(join(outDir,'src','adapters.ts'), adapters, 'utf8');
-  const pipeline = genPipeline(ir); await writeFile(join(outDir,'src','pipeline.ts'), pipeline, 'utf8');
-  await writeFile(join(outDir,'src','trace.ts'), traceUtil(), 'utf8');
-  await writeFile(join(outDir,'src','determinism.ts'), determinismUtil(), 'utf8');
-  await writeFile(join(outDir,'src','redaction.ts'), redactionUtil(), 'utf8');
-  await emitRuntime(ir, outDir);
-}
-function prims(ir, out=new Set()){ if(!ir||typeof ir!=='object') return out; if(ir.node==='Prim') out.add(ir.prim); for(const c of (ir.children||[])) prims(c,out); return out; }
-function genAdapters(ir){ const names=Array.from(prims(ir)); const methods=names.map(n=>`  ${to(n)}(input: any): Promise<any>`).join('\n'); const stubs=names.map(n=>stub(n)).join('\n\n'); return `export interface Adapters {\n${methods}\n}\n\n${stubs}\n`; function to(n){ return 'prim_'+n.replace(/[^a-z0-9]/g,'_'); } function stub(n){ const m=to(n); return `export async function ${m}(input:any):Promise<any>{ throw new Error('Not wired: ${m}'); }`; } }
-function genPipeline(ir){ return `import type { Adapters } from './adapters';\nimport { trace } from './trace';\nimport { XorShift32, FixedClock } from './determinism';\nimport type { RedactionPolicy } from './redaction';\n\nexport async function run(adapters: Adapters, input: any, seed: number = 42, clockEpochMs: number = 1690000000000, redaction?: RedactionPolicy): Promise<any> {\n  (globalThis as any).__tf_rng = new XorShift32(seed);\n  (globalThis as any).__tf_clock = new FixedClock(clockEpochMs);\n  (globalThis as any).__tf_redaction = redaction;\n  return await step_${id(ir)}(adapters, input);\n}\n\n${gen(ir)}\n`; function id(node){ return Math.abs(hashCode(JSON.stringify(node))); } function gen(node){ if(node.node==='Prim'){ const m='prim_'+node.prim.replace(/[^a-z0-9]/g,'_'); return `async function step_${id(node)}(adapters: Adapters, input: any){ const span=trace.start('${node.prim}'); const out = await (adapters as any).${m}(input); trace.end(span, input, out, ['TODO-effects']); return out; }`; } if(node.node==='Seq'){ const kids=node.children.map(c=>`acc = await step_${id(c)}(adapters, acc)`).join('\n  '); return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ let acc=input; ${kids}; return acc; }`; } if(node.node==='Par'){ return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ const parts=await Promise.all([${node.children.map(c=>`step_${id(c)}(adapters, input)`).join(', ')}]); return parts; }`; } return `async function step_${id(node)}(){ return null }`; } }
-function traceUtil(){ return `import { applyRedaction } from './redaction';\nfunction rng(){ const r=(globalThis as any).__tf_rng; if(!r) throw new Error('rng not initialized'); return r.next(); }\nfunction nowNs(){ const c=(globalThis as any).__tf_clock; if(!c) throw new Error('clock not initialized'); return c.nowNs(); }\nexport const trace = { start(prim){ return { prim, ts: nowNs(), in: null }; }, end(span, input, output, effects){ const evt = { ts_ns: String(span.ts), flow_id: 'flow', run_id: 'run', node_id: span.prim, prim_id: span.prim, span_id: String((rng()*1e9)>>>0), parent_span_id: '', in_hash: hash(input), out_hash: hash(output), effects }; const safe = applyRedaction(evt, (globalThis as any).__tf_redaction); if (process.env.TF_TRACE_STDOUT==='1') console.log(JSON.stringify(safe)); }, }; function hash(v){ return 'sha256:' + require('node:crypto').createHash('sha256').update(JSON.stringify(v)).digest('hex'); }`; }
-function determinismUtil(){ return `export { XorShift32, FixedClock } from './determinism';`; }
-function redactionUtil(){ return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`; }
-function hashCode(s){ let h=0; for(let i=0;i<s.length;i++){ h=((h<<5)-h)+s.charCodeAt(i)|0; } return Math.abs(h); }
 
-async function emitRuntime(ir, outDir) {
+import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+import { checkIR } from '../../tf-l0-check/src/check.mjs';
+import { manifestFromVerdict } from '../../tf-l0-check/src/manifest.mjs';
+
+export async function generate(ir, { outDir }) {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const catalogPath = join(moduleDir, '..', '..', 'tf-l0-spec', 'spec', 'catalog.json');
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  const verdict = checkIR(ir, catalog);
+  const manifest = manifestFromVerdict(verdict);
+
+  await mkdir(join(outDir, 'src'), { recursive: true });
+  await writeFile(
+    join(outDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'tf-generated',
+        private: true,
+        type: 'module',
+        scripts: { start: 'node ./dist/pipeline.mjs' },
+        dependencies: {},
+      },
+      null,
+      2
+    ) + '\n',
+    'utf8'
+  );
+
+  const adapters = genAdapters(ir);
+  await writeFile(join(outDir, 'src', 'adapters.ts'), adapters, 'utf8');
+
+  const pipeline = genPipeline(ir);
+  await writeFile(join(outDir, 'src', 'pipeline.ts'), pipeline, 'utf8');
+
+  await writeFile(join(outDir, 'src', 'trace.ts'), traceUtil(), 'utf8');
+  await writeFile(join(outDir, 'src', 'determinism.ts'), determinismUtil(), 'utf8');
+  await writeFile(join(outDir, 'src', 'redaction.ts'), redactionUtil(), 'utf8');
+
+  await emitRuntime(ir, manifest, outDir);
+}
+
+function prims(ir, out = new Set()) {
+  if (!ir || typeof ir !== 'object') return out;
+  if (ir.node === 'Prim') out.add(ir.prim);
+  for (const child of ir.children || []) {
+    prims(child, out);
+  }
+  return out;
+}
+
+function genAdapters(ir) {
+  const names = Array.from(prims(ir));
+  const methodLines = names.map((name) => `  ${to(name)}(input: any): Promise<any>`).join('\n');
+  const stubs = names.map((name) => stub(name)).join('\n\n');
+  return `export interface Adapters {\n${methodLines}\n}\n\n${stubs}\n`;
+
+  function to(name) {
+    return `prim_${name.replace(/[^a-z0-9]/gi, '_')}`;
+  }
+
+  function stub(name) {
+    const method = to(name);
+    return `export async function ${method}(input: any): Promise<any> { throw new Error('Not wired: ${method}'); }`;
+  }
+}
+
+function genPipeline(ir) {
+  return `import type { Adapters } from './adapters';\nimport { trace } from './trace';\nimport { XorShift32, FixedClock } from './determinism';\nimport type { RedactionPolicy } from './redaction';\n\nexport async function run(adapters: Adapters, input: any, seed: number = 42, clockEpochMs: number = 1690000000000, redaction?: RedactionPolicy): Promise<any> {\n  (globalThis as any).__tf_rng = new XorShift32(seed);\n  (globalThis as any).__tf_clock = new FixedClock(clockEpochMs);\n  (globalThis as any).__tf_redaction = redaction;\n  return await step_${id(ir)}(adapters, input);\n}\n\n${gen(ir)}\n`;
+
+  function id(node) {
+    return Math.abs(hashCode(JSON.stringify(node)));
+  }
+
+  function gen(node) {
+    if (node.node === 'Prim') {
+      const method = `prim_${node.prim.replace(/[^a-z0-9]/gi, '_')}`;
+      return `async function step_${id(node)}(adapters: Adapters, input: any) { const span = trace.start('${node.prim}'); const out = await (adapters as any).${method}(input); trace.end(span, input, out, ['TODO-effects']); return out; }`;
+    }
+    if (node.node === 'Seq') {
+      const body = node.children.map((child) => `acc = await step_${id(child)}(adapters, acc);`).join('\n  ');
+      return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any) { let acc = input; ${body}\n  return acc; }`;
+    }
+    if (node.node === 'Par') {
+      const children = node.children.map((child) => `step_${id(child)}(adapters, input)`).join(', ');
+      return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any) { const parts = await Promise.all([${children}]); return parts; }`;
+    }
+    return `async function step_${id(node)}() { return null; }`;
+  }
+}
+
+function traceUtil() {
+  return `import { applyRedaction } from './redaction';\nfunction rng(){ const r=(globalThis as any).__tf_rng; if(!r) throw new Error('rng not initialized'); return r.next(); }\nfunction nowNs(){ const c=(globalThis as any).__tf_clock; if(!c) throw new Error('clock not initialized'); return c.nowNs(); }\nexport const trace = { start(prim){ return { prim, ts: nowNs(), in: null }; }, end(span, input, output, effects){ const evt = { ts_ns: String(span.ts), flow_id: 'flow', run_id: 'run', node_id: span.prim, prim_id: span.prim, span_id: String((rng()*1e9)>>>0), parent_span_id: '', in_hash: hash(input), out_hash: hash(output), effects }; const safe = applyRedaction(evt, (globalThis as any).__tf_redaction); if (process.env.TF_TRACE_STDOUT==='1') console.log(JSON.stringify(safe)); }, }; function hash(v){ return 'sha256:' + require('node:crypto').createHash('sha256').update(JSON.stringify(v)).digest('hex'); }`;
+}
+
+function determinismUtil() {
+  return `export { XorShift32, FixedClock } from './determinism';`;
+}
+
+function redactionUtil() {
+  return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`;
+}
+
+function hashCode(value) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+async function emitRuntime(ir, manifest, outDir) {
   const moduleDir = dirname(fileURLToPath(import.meta.url));
   const runtimeSrc = join(moduleDir, '..', 'src', 'runtime');
   const runtimeOut = join(outDir, 'runtime');
   await mkdir(runtimeOut, { recursive: true });
   await copyFile(join(runtimeSrc, 'inmem.mjs'), join(runtimeOut, 'inmem.mjs'));
   await copyFile(join(runtimeSrc, 'run-ir.mjs'), join(runtimeOut, 'run-ir.mjs'));
+  await copyFile(join(runtimeSrc, 'capabilities.mjs'), join(runtimeOut, 'capabilities.mjs'));
+
   const canonicalIr = JSON.parse(canonicalize(ir));
   const irLiteral = JSON.stringify(canonicalIr, null, 2);
-  const runScript = `import { mkdir, readFile, writeFile } from 'node:fs/promises';\nimport { dirname, join } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport { runIR } from './runtime/run-ir.mjs';\nimport inmem from './runtime/inmem.mjs';\n\nconst ir = ${irLiteral};\n\nconst result = await runIR(ir, inmem);\nconst summary = (() => {\n  const effects = Array.isArray(result?.effects) ? Array.from(new Set(result.effects)) : [];\n  effects.sort();\n  return { ok: Boolean(result?.ok), ops: result?.ops ?? 0, effects };\n})();\n\nconst here = dirname(fileURLToPath(import.meta.url));\nconst statusSelf = join(here, 'status.json');\nawait writeFile(statusSelf, JSON.stringify(summary, null, 2) + '\\n', 'utf8');\n\nasync function mergeStatus(targetPath) {\n  try {\n    await mkdir(dirname(targetPath), { recursive: true });\n  } catch {}\n  let merged = summary;\n  try {\n    const existingRaw = await readFile(targetPath, 'utf8');\n    const existing = JSON.parse(existingRaw);\n    const effects = new Set([\n      ...(Array.isArray(existing?.effects) ? existing.effects : []),\n      ...summary.effects,\n    ]);\n    merged = {\n      ok: Boolean(existing?.ok) && Boolean(summary.ok),\n      ops: (existing?.ops ?? 0) + (summary.ops ?? 0),\n      effects: Array.from(effects).sort(),\n    };\n  } catch (err) {\n    if (!err || err.code !== 'ENOENT') {\n      console.warn('tf run.mjs: unable to merge status file', err);\n      return;\n    }\n  }\n  await writeFile(targetPath, JSON.stringify(merged, null, 2) + '\\n', 'utf8');\n}\n\nif (process.env.TF_STATUS_PATH) {\n  await mergeStatus(process.env.TF_STATUS_PATH);\n}\n`;
+  const manifestLiteral = canonicalize(manifest);
+
+  const runScript = `import { mkdir, readFile, writeFile } from 'node:fs/promises';\nimport { dirname, join } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport { parseArgs } from 'node:util';\nimport { runIR } from './runtime/run-ir.mjs';\nimport { validateCapabilities } from './runtime/capabilities.mjs';\nimport inmem from './runtime/inmem.mjs';\n\nconst MANIFEST = ${manifestLiteral};\nconst ir = ${irLiteral};\n\nconst { values } = parseArgs({\n  options: { caps: { type: 'string' } },\n  allowPositionals: true,\n});\n\nasync function loadCaps() {\n  if (values.caps) {\n    try {\n      const raw = await readFile(values.caps, 'utf8');\n      return JSON.parse(raw);\n    } catch (error) {\n      console.error('tf run.mjs: unable to read --caps file', error);\n      process.exit(1);\n    }\n  }\n  if (process.env.TF_CAPS) {\n    try {\n      return JSON.parse(process.env.TF_CAPS);\n    } catch (error) {\n      console.error('tf run.mjs: unable to parse TF_CAPS env JSON', error);\n      process.exit(1);\n    }\n  }\n  return { effects: [], allow_writes_prefixes: [] };\n}\n\nconst caps = await loadCaps();\nconst validation = validateCapabilities(MANIFEST, caps);\nlet result = { ok: false, ops: 0, effects: [] };\nif (!validation.ok) {\n  console.error(JSON.stringify(validation));\n} else {\n  result = await runIR(ir, inmem);\n}\n\nconst summary = (() => {\n  const effects = Array.isArray(result?.effects) ? Array.from(new Set(result.effects)) : [];\n  effects.sort();\n  return { ok: Boolean(result?.ok), ops: result?.ops ?? 0, effects };\n})();\n\nconsole.log(JSON.stringify(summary));\n\nconst here = dirname(fileURLToPath(import.meta.url));\nconst statusSelf = join(here, 'status.json');\nawait writeFile(statusSelf, JSON.stringify(summary, null, 2) + '\\n', 'utf8');\n\nasync function mergeStatus(targetPath) {\n  try {\n    await mkdir(dirname(targetPath), { recursive: true });\n  } catch {}\n  let merged = summary;\n  try {\n    const existingRaw = await readFile(targetPath, 'utf8');\n    const existing = JSON.parse(existingRaw);\n    const effects = new Set([\n      ...(Array.isArray(existing?.effects) ? existing.effects : []),\n      ...summary.effects,\n    ]);\n    merged = {\n      ok: Boolean(existing?.ok) && Boolean(summary.ok),\n      ops: (existing?.ops ?? 0) + (summary.ops ?? 0),\n      effects: Array.from(effects).sort(),\n    };\n  } catch (err) {\n    if (!err || err.code !== 'ENOENT') {\n      console.warn('tf run.mjs: unable to merge status file', err);\n      return;\n    }\n  }\n  await writeFile(targetPath, JSON.stringify(merged, null, 2) + '\\n', 'utf8');\n}\n\nif (process.env.TF_STATUS_PATH) {\n  await mergeStatus(process.env.TF_STATUS_PATH);\n}\n\nif (!summary.ok) {\n  process.exitCode = 1;\n}\n`;
+
   await writeFile(join(outDir, 'run.mjs'), runScript, 'utf8');
 }

--- a/packages/tf-l0-codegen-ts/src/runtime/capabilities.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/capabilities.mjs
@@ -1,0 +1,40 @@
+export function validateCapabilities(manifest = {}, provided = {}) {
+  const requiredEffects = Array.isArray(manifest?.required_effects)
+    ? manifest.required_effects.filter((value) => typeof value === 'string')
+    : [];
+  const availableEffects = new Set(
+    Array.isArray(provided?.effects)
+      ? provided.effects.filter((value) => typeof value === 'string')
+      : []
+  );
+
+  const missingEffects = Array.from(new Set(requiredEffects.filter((effect) => !availableEffects.has(effect)))).sort();
+
+  const prefixes = Array.isArray(provided?.allow_writes_prefixes)
+    ? provided.allow_writes_prefixes.filter((value) => typeof value === 'string')
+    : [];
+  const writes = Array.isArray(manifest?.footprints_rw?.writes)
+    ? manifest.footprints_rw.writes
+    : [];
+
+  const deniedWrites = new Set();
+  for (const entry of writes) {
+    const uri = entry && typeof entry.uri === 'string' ? entry.uri : null;
+    if (!uri) continue;
+    const allowed = prefixes.some((prefix) => uri.startsWith(prefix));
+    if (!allowed) {
+      deniedWrites.add(uri);
+    }
+  }
+
+  const writeDenied = Array.from(deniedWrites).sort();
+  const ok = missingEffects.length === 0 && writeDenied.length === 0;
+
+  return {
+    ok,
+    missing_effects: missingEffects,
+    write_denied: writeDenied,
+  };
+}
+
+export default validateCapabilities;

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -91,7 +91,7 @@ register('tf:observability/emit-metric@1', ['emit-metric'], 'Observability.EmitM
   return { ok: true };
 });
 
-register('tf:network/publish@1', ['publish'], 'Network.Publish', async (args = {}) => {
+register('tf:network/publish@1', ['publish'], 'Network.Out', async (args = {}) => {
   const topic = args.topic ?? 'default';
   if (!topicQueues.has(topic)) {
     topicQueues.set(topic, []);

--- a/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
@@ -1,3 +1,5 @@
+import { validateCapabilities } from './capabilities.mjs';
+
 let clockWarned = false;
 
 function nowTs() {
@@ -142,6 +144,15 @@ export async function runIR(ir, runtime, options = {}) {
     ops: ctx.ops,
     effects: Array.from(ctx.effects).sort(),
   };
+}
+
+export async function runWithCaps(ir, runtime, caps, manifest) {
+  const verdict = validateCapabilities(manifest, caps);
+  if (!verdict.ok) {
+    console.error(JSON.stringify(verdict));
+    return { ok: false, result: undefined, ops: 0, effects: [] };
+  }
+  return runIR(ir, runtime);
 }
 
 export default runIR;

--- a/packages/tf-l0-tools/trace-summary.mjs
+++ b/packages/tf-l0-tools/trace-summary.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { createInterface } from 'node:readline';
+
+const {
+  values: { top: rawTop, pretty = false, quiet = false, help = false },
+  positionals,
+} = parseArgs({
+  options: {
+    top: { type: 'string' },
+    pretty: { type: 'boolean', default: false },
+    quiet: { type: 'boolean', default: false },
+    help: { type: 'boolean', default: false },
+  },
+  allowPositionals: true,
+});
+
+if (positionals.length > 0) {
+  console.error('trace-summary: unexpected positional arguments:', positionals.join(' '));
+  process.exit(1);
+}
+
+if (help) {
+  console.log('Usage: trace-summary [--top=N] [--pretty] [--quiet]');
+  console.log('Reads trace JSONL from stdin and prints aggregate counts.');
+  process.exit(0);
+}
+
+const top = rawTop === undefined ? Infinity : Number.parseInt(rawTop, 10);
+if (!Number.isFinite(top) || top < 0) {
+  console.error('trace-summary: --top must be a non-negative integer');
+  process.exit(1);
+}
+
+const byPrim = new Map();
+const byEffect = new Map();
+let total = 0;
+let warned = false;
+
+const rl = createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+  try {
+    const record = JSON.parse(trimmed);
+    total += 1;
+    const prim = typeof record.prim_id === 'string' ? record.prim_id : null;
+    const effect = typeof record.effect === 'string' ? record.effect : null;
+    if (prim) increment(byPrim, prim);
+    if (effect) increment(byEffect, effect);
+  } catch (error) {
+    if (!quiet && !warned) {
+      console.error('trace-summary: skipping malformed line');
+      warned = true;
+    }
+  }
+});
+
+rl.on('close', () => {
+  const summary = {
+    total,
+    by_prim: pickTop(byPrim, top),
+    by_effect: pickTop(byEffect, top),
+  };
+  const payload = pretty ? JSON.stringify(summary, null, 2) : JSON.stringify(summary);
+  process.stdout.write(payload);
+  if (pretty) {
+    process.stdout.write('\n');
+  }
+});
+
+function increment(map, key) {
+  const current = map.get(key) ?? 0;
+  map.set(key, current + 1);
+}
+
+function pickTop(map, limit) {
+  const entries = Array.from(map.entries());
+  entries.sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  const slice = Number.isFinite(limit) ? entries.slice(0, limit) : entries;
+  const result = {};
+  for (const [key, value] of slice) {
+    result[key] = value;
+  }
+  return result;
+}

--- a/tests/run-ir.test.mjs
+++ b/tests/run-ir.test.mjs
@@ -46,7 +46,7 @@ test('parallel publish and metric capture distinct effects', async () => {
   };
   const out = await runIR(ir, inmem);
   assert.equal(out.ok, true);
-  assert.deepEqual(out.effects, ['Network.Publish', 'Observability.EmitMetric']);
+  assert.deepEqual(out.effects, ['Network.Out', 'Observability.EmitMetric']);
 });
 
 test('hashing is deterministic for equivalent objects', async () => {

--- a/tests/runner-caps.test.mjs
+++ b/tests/runner-caps.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+async function emitFlow(flowPath) {
+  const base = await mkdtemp(join(tmpdir(), 'tf-runner-'));
+  await execFileAsync('node', [
+    'packages/tf-compose/bin/tf.mjs',
+    'emit',
+    flowPath,
+    '--lang',
+    'ts',
+    '--out',
+    base,
+  ]);
+  return {
+    dir: base,
+    runScript: join(base, 'run.mjs'),
+  };
+}
+
+async function runNode(scriptPath, args = [], options = {}) {
+  try {
+    return await execFileAsync('node', [scriptPath, ...args], options);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'stdout' in error) {
+      return {
+        stdout: error.stdout ?? '',
+        stderr: error.stderr ?? '',
+        code: error.code ?? 1,
+      };
+    }
+    throw error;
+  }
+}
+
+function parseSummary(stdout) {
+  const lines = String(stdout)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  assert(lines.length > 0, 'expected summary output');
+  const last = lines[lines.length - 1];
+  return JSON.parse(last);
+}
+
+const storageCaps = {
+  effects: ['Storage.Write', 'Pure', 'Observability'],
+  allow_writes_prefixes: ['res://kv/'],
+};
+
+const publishCaps = {
+  effects: ['Network.Out', 'Pure', 'Observability'],
+  allow_writes_prefixes: [],
+};
+
+test('generated runner accepts sufficient capabilities', async () => {
+  const { runScript, dir } = await emitFlow('examples/flows/run_storage_ok.tf');
+  const capsPath = join(dir, 'caps.json');
+  await writeFile(capsPath, JSON.stringify(storageCaps), 'utf8');
+  const { stdout } = await runNode(runScript, ['--caps', capsPath]);
+  const summary = parseSummary(stdout);
+  assert.equal(summary.ok, true);
+  assert.equal(summary.ops > 0, true);
+  assert(summary.effects.includes('Storage.Write'));
+});
+
+test('generated runner rejects insufficient capabilities', async () => {
+  const { runScript, dir } = await emitFlow('examples/flows/run_publish.tf');
+  const capsPath = join(dir, 'caps-deny.json');
+  await writeFile(
+    capsPath,
+    JSON.stringify({ effects: [], allow_writes_prefixes: [] }),
+    'utf8'
+  );
+  const { stdout, stderr } = await runNode(runScript, ['--caps', capsPath]);
+  const summary = parseSummary(stdout);
+  assert.equal(summary.ok, false);
+  assert.match(stderr, /missing_effects|write_denied/);
+});
+
+test('generated runner accepts publish capabilities', async () => {
+  const { runScript, dir } = await emitFlow('examples/flows/run_publish.tf');
+  const capsPath = join(dir, 'caps-ok.json');
+  await writeFile(capsPath, JSON.stringify(publishCaps), 'utf8');
+  const { stdout } = await runNode(runScript, ['--caps', capsPath]);
+  const summary = parseSummary(stdout);
+  assert.equal(summary.ok, true);
+  assert(summary.effects.includes('Network.Out'));
+});


### PR DESCRIPTION
## Summary
- embed the TF catalog manifest during TS code generation and emit runners that validate capabilities before executing IR
- add reusable capability checks in the runtime, adjust publish effects, and wire manifest-driven summaries and docs
- provide a trace-summary CLI plus automated runner capability tests to help reviewers inspect traces quickly

## Testing
- pnpm run a0
- pnpm run a1
- pnpm -w -r test *(fails: @tf-lang/trace2tags@0.1.0 test: `vitest run`)*
- pnpm run test:l0


------
https://chatgpt.com/codex/tasks/task_e_68cf39655f248320a1040787f590eebd