### PR TITLE
feat: enforce capabilities in generated runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ npm run tf -- canon examples/flows/signing.tf -o out/0.4/ir/signing.canon.json
 # Generate TS skeleton for the flow
 npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/signing
 
+# Enforce manifest caps + summarize traces
+node out/0.4/codegen-ts/signing/run.mjs --caps caps.json
+TF_CAPS='{"effects":["Pure"],"allow_writes_prefixes":[]}' node out/0.4/codegen-ts/signing/run.mjs
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
+
 # Generate capability manifest
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json

--- a/packages/tf-l0-codegen-ts/scripts/generate.mjs
+++ b/packages/tf-l0-codegen-ts/scripts/generate.mjs
@@ -1,34 +1,135 @@
-import { writeFile, mkdir, copyFile } from 'node:fs/promises';
+import { writeFile, mkdir, copyFile, readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+import { checkIR } from '../../tf-l0-check/src/check.mjs';
+import { manifestFromVerdict } from '../../tf-l0-check/src/manifest.mjs';
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const catalogPath = join(moduleDir, '..', '..', 'tf-l0-spec', 'spec', 'catalog.json');
+
 export async function generate(ir, { outDir }) {
   await mkdir(join(outDir, 'src'), { recursive: true });
-  await writeFile(join(outDir, 'package.json'), JSON.stringify({ name:"tf-generated", private:true, type:"module", scripts:{ start:"node ./dist/pipeline.mjs" }, dependencies:{} }, null, 2) + '\n', 'utf8');
-  const adapters = genAdapters(ir); await writeFile(join(outDir,'src','adapters.ts'), adapters, 'utf8');
-  const pipeline = genPipeline(ir); await writeFile(join(outDir,'src','pipeline.ts'), pipeline, 'utf8');
-  await writeFile(join(outDir,'src','trace.ts'), traceUtil(), 'utf8');
-  await writeFile(join(outDir,'src','determinism.ts'), determinismUtil(), 'utf8');
-  await writeFile(join(outDir,'src','redaction.ts'), redactionUtil(), 'utf8');
-  await emitRuntime(ir, outDir);
-}
-function prims(ir, out=new Set()){ if(!ir||typeof ir!=='object') return out; if(ir.node==='Prim') out.add(ir.prim); for(const c of (ir.children||[])) prims(c,out); return out; }
-function genAdapters(ir){ const names=Array.from(prims(ir)); const methods=names.map(n=>`  ${to(n)}(input: any): Promise<any>`).join('\n'); const stubs=names.map(n=>stub(n)).join('\n\n'); return `export interface Adapters {\n${methods}\n}\n\n${stubs}\n`; function to(n){ return 'prim_'+n.replace(/[^a-z0-9]/g,'_'); } function stub(n){ const m=to(n); return `export async function ${m}(input:any):Promise<any>{ throw new Error('Not wired: ${m}'); }`; } }
-function genPipeline(ir){ return `import type { Adapters } from './adapters';\nimport { trace } from './trace';\nimport { XorShift32, FixedClock } from './determinism';\nimport type { RedactionPolicy } from './redaction';\n\nexport async function run(adapters: Adapters, input: any, seed: number = 42, clockEpochMs: number = 1690000000000, redaction?: RedactionPolicy): Promise<any> {\n  (globalThis as any).__tf_rng = new XorShift32(seed);\n  (globalThis as any).__tf_clock = new FixedClock(clockEpochMs);\n  (globalThis as any).__tf_redaction = redaction;\n  return await step_${id(ir)}(adapters, input);\n}\n\n${gen(ir)}\n`; function id(node){ return Math.abs(hashCode(JSON.stringify(node))); } function gen(node){ if(node.node==='Prim'){ const m='prim_'+node.prim.replace(/[^a-z0-9]/g,'_'); return `async function step_${id(node)}(adapters: Adapters, input: any){ const span=trace.start('${node.prim}'); const out = await (adapters as any).${m}(input); trace.end(span, input, out, ['TODO-effects']); return out; }`; } if(node.node==='Seq'){ const kids=node.children.map(c=>`acc = await step_${id(c)}(adapters, acc)`).join('\n  '); return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ let acc=input; ${kids}; return acc; }`; } if(node.node==='Par'){ return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ const parts=await Promise.all([${node.children.map(c=>`step_${id(c)}(adapters, input)`).join(', ')}]); return parts; }`; } return `async function step_${id(node)}(){ return null }`; } }
-function traceUtil(){ return `import { applyRedaction } from './redaction';\nfunction rng(){ const r=(globalThis as any).__tf_rng; if(!r) throw new Error('rng not initialized'); return r.next(); }\nfunction nowNs(){ const c=(globalThis as any).__tf_clock; if(!c) throw new Error('clock not initialized'); return c.nowNs(); }\nexport const trace = { start(prim){ return { prim, ts: nowNs(), in: null }; }, end(span, input, output, effects){ const evt = { ts_ns: String(span.ts), flow_id: 'flow', run_id: 'run', node_id: span.prim, prim_id: span.prim, span_id: String((rng()*1e9)>>>0), parent_span_id: '', in_hash: hash(input), out_hash: hash(output), effects }; const safe = applyRedaction(evt, (globalThis as any).__tf_redaction); if (process.env.TF_TRACE_STDOUT==='1') console.log(JSON.stringify(safe)); }, }; function hash(v){ return 'sha256:' + require('node:crypto').createHash('sha256').update(JSON.stringify(v)).digest('hex'); }`; }
-function determinismUtil(){ return `export { XorShift32, FixedClock } from './determinism';`; }
-function redactionUtil(){ return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`; }
-function hashCode(s){ let h=0; for(let i=0;i<s.length;i++){ h=((h<<5)-h)+s.charCodeAt(i)|0; } return Math.abs(h); }
+  await writeFile(
+    join(outDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'tf-generated',
+        private: true,
+        type: 'module',
+        scripts: { start: 'node ./dist/pipeline.mjs' },
+        dependencies: {},
+      },
+      null,
+      2
+    ) + '\n',
+    'utf8'
+  );
 
-async function emitRuntime(ir, outDir) {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const adapters = genAdapters(ir);
+  await writeFile(join(outDir, 'src', 'adapters.ts'), adapters, 'utf8');
+
+  const pipeline = genPipeline(ir);
+  await writeFile(join(outDir, 'src', 'pipeline.ts'), pipeline, 'utf8');
+
+  await writeFile(join(outDir, 'src', 'trace.ts'), traceUtil(), 'utf8');
+  await writeFile(join(outDir, 'src', 'determinism.ts'), determinismUtil(), 'utf8');
+  await writeFile(join(outDir, 'src', 'redaction.ts'), redactionUtil(), 'utf8');
+
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  const verdict = checkIR(ir, catalog);
+  const manifest = manifestFromVerdict(verdict);
+
+  await emitRuntime(ir, outDir, manifest);
+}
+
+function prims(ir, out = new Set()) {
+  if (!ir || typeof ir !== 'object') return out;
+  if (ir.node === 'Prim') out.add(ir.prim);
+  for (const child of ir.children || []) {
+    prims(child, out);
+  }
+  return out;
+}
+
+function genAdapters(ir) {
+  const names = Array.from(prims(ir));
+  const methods = names.map((name) => `  ${to(name)}(input: any): Promise<any>`).join('\n');
+  const stubs = names.map((name) => stub(name)).join('\n\n');
+  return `export interface Adapters {\n${methods}\n}\n\n${stubs}\n`;
+
+  function to(name) {
+    return `prim_${name.replace(/[^a-z0-9]/gi, '_')}`;
+  }
+
+  function stub(name) {
+    const method = to(name);
+    return `export async function ${method}(input: any): Promise<any> { throw new Error('Not wired: ${method}'); }`;
+  }
+}
+
+function genPipeline(ir) {
+  return `import type { Adapters } from './adapters';\nimport { trace } from './trace';\nimport { XorShift32, FixedClock } from './determinism';\nimport type { RedactionPolicy } from './redaction';\n\nexport async function run(adapters: Adapters, input: any, seed: number = 42, clockEpochMs: number = 1690000000000, redaction?: RedactionPolicy): Promise<any> {\n  (globalThis as any).__tf_rng = new XorShift32(seed);\n  (globalThis as any).__tf_clock = new FixedClock(clockEpochMs);\n  (globalThis as any).__tf_redaction = redaction;\n  return await step_${id(ir)}(adapters, input);\n}\n\n${gen(ir)}\n`;
+
+  function id(node) {
+    return Math.abs(hashCode(JSON.stringify(node)));
+  }
+
+  function gen(node) {
+    if (node.node === 'Prim') {
+      const method = `prim_${node.prim.replace(/[^a-z0-9]/gi, '_')}`;
+      return `async function step_${id(node)}(adapters: Adapters, input: any) { const span = trace.start('${node.prim}'); const out = await (adapters as any).${method}(input); trace.end(span, input, out, ['TODO-effects']); return out; }`;
+    }
+    if (node.node === 'Seq') {
+      const children = node.children.map((child) => `acc = await step_${id(child)}(adapters, acc)`).join('\n  ');
+      return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any) { let acc = input; ${children}; return acc; }`;
+    }
+    if (node.node === 'Par') {
+      return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any) { const parts = await Promise.all([${node.children
+        .map((child) => `step_${id(child)}(adapters, input)`)
+        .join(', ')}]); return parts; }`;
+    }
+    return `async function step_${id(node)}() { return null }`;
+  }
+}
+
+function traceUtil() {
+  return `import { applyRedaction } from './redaction';\nfunction rng() { const r = (globalThis as any).__tf_rng; if (!r) throw new Error('rng not initialized'); return r.next(); }\nfunction nowNs() { const c = (globalThis as any).__tf_clock; if (!c) throw new Error('clock not initialized'); return c.nowNs(); }\nexport const trace = { start(prim) { return { prim, ts: nowNs(), in: null }; }, end(span, input, output, effects) { const evt = { ts_ns: String(span.ts), flow_id: 'flow', run_id: 'run', node_id: span.prim, prim_id: span.prim, span_id: String((rng() * 1e9) >>> 0), parent_span_id: '', in_hash: hash(input), out_hash: hash(output), effects }; const safe = applyRedaction(evt, (globalThis as any).__tf_redaction); if (process.env.TF_TRACE_STDOUT === '1') console.log(JSON.stringify(safe)); }, }; function hash(v) { return 'sha256:' + require('node:crypto').createHash('sha256').update(JSON.stringify(v)).digest('hex'); }`;
+}
+
+function determinismUtil() {
+  return `export { XorShift32, FixedClock } from './determinism';`;
+}
+
+function redactionUtil() {
+  return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`;
+}
+
+function hashCode(value) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+async function emitRuntime(ir, outDir, manifest) {
   const runtimeSrc = join(moduleDir, '..', 'src', 'runtime');
   const runtimeOut = join(outDir, 'runtime');
+
   await mkdir(runtimeOut, { recursive: true });
   await copyFile(join(runtimeSrc, 'inmem.mjs'), join(runtimeOut, 'inmem.mjs'));
   await copyFile(join(runtimeSrc, 'run-ir.mjs'), join(runtimeOut, 'run-ir.mjs'));
+  await copyFile(join(runtimeSrc, 'capabilities.mjs'), join(runtimeOut, 'capabilities.mjs'));
+
   const canonicalIr = JSON.parse(canonicalize(ir));
   const irLiteral = JSON.stringify(canonicalIr, null, 2);
-  const runScript = `import { mkdir, readFile, writeFile } from 'node:fs/promises';\nimport { dirname, join } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport { runIR } from './runtime/run-ir.mjs';\nimport inmem from './runtime/inmem.mjs';\n\nconst ir = ${irLiteral};\n\nconst result = await runIR(ir, inmem);\nconst summary = (() => {\n  const effects = Array.isArray(result?.effects) ? Array.from(new Set(result.effects)) : [];\n  effects.sort();\n  return { ok: Boolean(result?.ok), ops: result?.ops ?? 0, effects };\n})();\n\nconst here = dirname(fileURLToPath(import.meta.url));\nconst statusSelf = join(here, 'status.json');\nawait writeFile(statusSelf, JSON.stringify(summary, null, 2) + '\\n', 'utf8');\n\nasync function mergeStatus(targetPath) {\n  try {\n    await mkdir(dirname(targetPath), { recursive: true });\n  } catch {}\n  let merged = summary;\n  try {\n    const existingRaw = await readFile(targetPath, 'utf8');\n    const existing = JSON.parse(existingRaw);\n    const effects = new Set([\n      ...(Array.isArray(existing?.effects) ? existing.effects : []),\n      ...summary.effects,\n    ]);\n    merged = {\n      ok: Boolean(existing?.ok) && Boolean(summary.ok),\n      ops: (existing?.ops ?? 0) + (summary.ops ?? 0),\n      effects: Array.from(effects).sort(),\n    };\n  } catch (err) {\n    if (!err || err.code !== 'ENOENT') {\n      console.warn('tf run.mjs: unable to merge status file', err);\n      return;\n    }\n  }\n  await writeFile(targetPath, JSON.stringify(merged, null, 2) + '\\n', 'utf8');\n}\n\nif (process.env.TF_STATUS_PATH) {\n  await mergeStatus(process.env.TF_STATUS_PATH);\n}\n`;
+
+  const canonicalManifest = JSON.parse(canonicalize(manifest));
+  const manifestLiteral = JSON.stringify(canonicalManifest, null, 2);
+
+  const runScript = `import { mkdir, readFile, writeFile } from 'node:fs/promises';\nimport { dirname, join } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport { parseArgs } from 'node:util';\nimport { runIR } from './runtime/run-ir.mjs';\nimport { validateCapabilities } from './runtime/capabilities.mjs';\nimport inmem from './runtime/inmem.mjs';\n\nconst MANIFEST = ${manifestLiteral};\nconst ir = ${irLiteral};\n\nconst { values } = parseArgs({ options: { caps: { type: 'string' } } });\nconst caps = await (async () => {\n  if (values.caps) {\n    const raw = await readFile(values.caps, 'utf8');\n    return JSON.parse(raw);\n  }\n  if (process.env.TF_CAPS) {\n    return JSON.parse(process.env.TF_CAPS);\n  }\n  return { effects: [], allow_writes_prefixes: [] };\n})();\n\nconst verdict = validateCapabilities(MANIFEST, caps);\nlet result;\nif (!verdict.ok) {\n  const failure = { ok: false };\n  if (verdict.missing_effects.length > 0) {\n    failure.missing_effects = verdict.missing_effects;\n  }\n  if (verdict.write_denied.length > 0) {\n    failure.write_denied = verdict.write_denied;\n  }\n  console.error(JSON.stringify(failure));\n  result = { ok: false, ops: 0, effects: [] };\n} else {\n  result = await runIR(ir, inmem);\n}\n\nconst summary = (() => {\n  const effects = Array.isArray(result?.effects) ? Array.from(new Set(result.effects)) : [];\n  effects.sort();\n  return { ok: Boolean(result?.ok), ops: result?.ops ?? 0, effects };\n})();\n\nconsole.log(JSON.stringify(summary));\n\nconst here = dirname(fileURLToPath(import.meta.url));\nconst statusSelf = join(here, 'status.json');\nawait writeFile(statusSelf, JSON.stringify(summary, null, 2) + '\\n', 'utf8');\n\nasync function mergeStatus(targetPath) {\n  try {\n    await mkdir(dirname(targetPath), { recursive: true });\n  } catch {}\n  let merged = summary;\n  try {\n    const existingRaw = await readFile(targetPath, 'utf8');\n    const existing = JSON.parse(existingRaw);\n    const effects = new Set([\n      ...(Array.isArray(existing?.effects) ? existing.effects : []),\n      ...summary.effects,\n    ]);\n    merged = {\n      ok: Boolean(existing?.ok) && Boolean(summary.ok),\n      ops: (existing?.ops ?? 0) + (summary.ops ?? 0),\n      effects: Array.from(effects).sort(),\n    };\n  } catch (err) {\n    if (!err || err.code !== 'ENOENT') {\n      console.warn('tf run.mjs: unable to merge status file', err);\n      return;\n    }\n  }\n  await writeFile(targetPath, JSON.stringify(merged, null, 2) + '\\n', 'utf8');\n}\n\nif (process.env.TF_STATUS_PATH) {\n  await mergeStatus(process.env.TF_STATUS_PATH);\n}\n`;
+
   await writeFile(join(outDir, 'run.mjs'), runScript, 'utf8');
 }

--- a/packages/tf-l0-codegen-ts/src/runtime/capabilities.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/capabilities.mjs
@@ -1,0 +1,39 @@
+export function validateCapabilities(manifest = {}, provided = {}) {
+  const requiredEffects = Array.isArray(manifest?.required_effects)
+    ? manifest.required_effects.slice()
+    : [];
+  const providedEffects = new Set(Array.isArray(provided?.effects) ? provided.effects : []);
+  const missingEffects = requiredEffects
+    .filter((effect) => !providedEffects.has(effect))
+    .sort();
+
+  const writes = Array.isArray(manifest?.footprints_rw?.writes)
+    ? manifest.footprints_rw.writes
+    : [];
+  const prefixes = Array.isArray(provided?.allow_writes_prefixes) ? provided.allow_writes_prefixes : [];
+  const denied = new Set();
+
+  for (const entry of writes) {
+    const uri = typeof entry?.uri === 'string' ? entry.uri : '';
+    if (!uri) continue;
+    if (prefixes.length === 0) {
+      denied.add(uri);
+      continue;
+    }
+    const allowed = prefixes.some((prefix) => typeof prefix === 'string' && uri.startsWith(prefix));
+    if (!allowed) {
+      denied.add(uri);
+    }
+  }
+
+  const writeDenied = Array.from(denied).sort();
+  const ok = missingEffects.length === 0 && writeDenied.length === 0;
+
+  return {
+    ok,
+    missing_effects: missingEffects,
+    write_denied: writeDenied,
+  };
+}
+
+export default validateCapabilities;

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -91,7 +91,7 @@ register('tf:observability/emit-metric@1', ['emit-metric'], 'Observability.EmitM
   return { ok: true };
 });
 
-register('tf:network/publish@1', ['publish'], 'Network.Publish', async (args = {}) => {
+register('tf:network/publish@1', ['publish'], 'Network.Out', async (args = {}) => {
   const topic = args.topic ?? 'default';
   if (!topicQueues.has(topic)) {
     topicQueues.set(topic, []);

--- a/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
@@ -1,3 +1,5 @@
+import { validateCapabilities } from './capabilities.mjs';
+
 let clockWarned = false;
 
 function nowTs() {
@@ -142,6 +144,22 @@ export async function runIR(ir, runtime, options = {}) {
     ops: ctx.ops,
     effects: Array.from(ctx.effects).sort(),
   };
+}
+
+export async function runWithCaps(ir, runtime, caps = {}, manifest = {}) {
+  const verdict = validateCapabilities(manifest, caps);
+  if (!verdict.ok) {
+    const failure = { ok: false };
+    if (verdict.missing_effects.length > 0) {
+      failure.missing_effects = verdict.missing_effects;
+    }
+    if (verdict.write_denied.length > 0) {
+      failure.write_denied = verdict.write_denied;
+    }
+    console.error(JSON.stringify(failure));
+    return { ok: false, ops: 0, effects: [] };
+  }
+  return runIR(ir, runtime);
 }
 
 export default runIR;

--- a/packages/tf-l0-tools/trace-summary.mjs
+++ b/packages/tf-l0-tools/trace-summary.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+
+const {
+  values: { top, pretty = false, quiet = false },
+  positionals,
+} = parseArgs({
+  options: {
+    top: { type: 'string' },
+    pretty: { type: 'boolean', default: false },
+    quiet: { type: 'boolean', default: false },
+  },
+  allowPositionals: true,
+});
+
+if (positionals.length > 0) {
+  console.error('trace-summary: unexpected positional arguments:', positionals.join(' '));
+  process.exit(1);
+}
+
+let limit = null;
+if (top !== undefined) {
+  const parsed = Number.parseInt(top, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    console.error('trace-summary: --top must be a positive integer');
+    process.exit(1);
+  }
+  limit = parsed;
+}
+
+const decoder = new TextDecoder();
+const chunks = [];
+for await (const chunk of process.stdin) {
+  chunks.push(typeof chunk === 'string' ? chunk : decoder.decode(chunk));
+}
+
+const input = chunks.join('');
+const lines = input.split(/\r?\n/);
+
+let warned = false;
+let total = 0;
+const byPrim = new Map();
+const byEffect = new Map();
+
+for (const line of lines) {
+  const trimmed = line.trim();
+  if (!trimmed) continue;
+  let record;
+  try {
+    record = JSON.parse(trimmed);
+  } catch (error) {
+    if (!quiet && !warned) {
+      console.warn('trace-summary: ignoring malformed JSON line');
+      warned = true;
+    }
+    continue;
+  }
+
+  total += 1;
+  const primId = typeof record?.prim_id === 'string' && record.prim_id ? record.prim_id : 'unknown';
+  byPrim.set(primId, (byPrim.get(primId) ?? 0) + 1);
+
+  const effects = collectEffects(record);
+  if (effects.length === 0) {
+    byEffect.set('unknown', (byEffect.get('unknown') ?? 0) + 1);
+  } else {
+    for (const effect of effects) {
+      byEffect.set(effect, (byEffect.get(effect) ?? 0) + 1);
+    }
+  }
+}
+
+const summary = {
+  total,
+  by_prim: toObject(byPrim, limit),
+  by_effect: toObject(byEffect, limit),
+};
+
+const json = JSON.stringify(summary, null, pretty ? 2 : 0);
+process.stdout.write(json + '\n');
+
+function collectEffects(record) {
+  const effects = [];
+  if (typeof record?.effect === 'string' && record.effect) {
+    effects.push(record.effect);
+  }
+  if (Array.isArray(record?.effects)) {
+    for (const entry of record.effects) {
+      if (typeof entry === 'string' && entry) {
+        effects.push(entry);
+      }
+    }
+  }
+  return effects;
+}
+
+function toObject(map, topLimit) {
+  const entries = Array.from(map.entries()).sort((a, b) => {
+    if (b[1] !== a[1]) {
+      return b[1] - a[1];
+    }
+    return a[0].localeCompare(b[0]);
+  });
+  const sliced = topLimit ? entries.slice(0, topLimit) : entries;
+  const out = {};
+  for (const [key, value] of sliced) {
+    out[key] = value;
+  }
+  return out;
+}

--- a/tests/run-ir.test.mjs
+++ b/tests/run-ir.test.mjs
@@ -46,7 +46,7 @@ test('parallel publish and metric capture distinct effects', async () => {
   };
   const out = await runIR(ir, inmem);
   assert.equal(out.ok, true);
-  assert.deepEqual(out.effects, ['Network.Publish', 'Observability.EmitMetric']);
+  assert.deepEqual(out.effects, ['Network.Out', 'Observability.EmitMetric']);
 });
 
 test('hashing is deterministic for equivalent objects', async () => {

--- a/tests/runner-caps.test.mjs
+++ b/tests/runner-caps.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { execFile as execFileCallback } from 'node:child_process';
+
+const execFile = promisify(execFileCallback);
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const tfCli = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+
+const flows = {
+  storage: {
+    file: fileURLToPath(new URL('../examples/flows/run_storage_ok.tf', import.meta.url)),
+    expectEffect: 'Storage.Write',
+    caps: {
+      effects: ['Storage.Write', 'Pure', 'Observability'],
+      allow_writes_prefixes: ['res://kv/'],
+    },
+  },
+  publish: {
+    file: fileURLToPath(new URL('../examples/flows/run_publish.tf', import.meta.url)),
+    expectEffect: 'Network.Out',
+    caps: {
+      effects: ['Network.Out', 'Pure', 'Observability'],
+      allow_writes_prefixes: [],
+    },
+  },
+};
+
+test('generated runner enforces capability manifests', async () => {
+  const baseDir = await mkdtemp(join(tmpdir(), 'tf-runner-'));
+
+  for (const [name, flow] of Object.entries(flows)) {
+    const outDir = join(baseDir, name);
+    await execFile('node', [tfCli, 'emit', flow.file, '--lang', 'ts', '--out', outDir], { cwd: repoRoot });
+
+    const okCapsPath = join(baseDir, `${name}-caps.json`);
+    await writeFile(okCapsPath, JSON.stringify(flow.caps), 'utf8');
+
+    const { stdout: okStdout } = await execFile('node', [join(outDir, 'run.mjs'), '--caps', okCapsPath], { cwd: repoRoot });
+    const okSummary = parseSummary(okStdout);
+    assert.equal(okSummary.ok, true, `${name} flow should succeed with matching caps`);
+    assert.ok(
+      okSummary.effects.includes(flow.expectEffect),
+      `${name} flow should record ${flow.expectEffect}`
+    );
+
+    const denyCapsPath = join(baseDir, `${name}-deny.json`);
+    await writeFile(
+      denyCapsPath,
+      JSON.stringify({ effects: [], allow_writes_prefixes: [] }),
+      'utf8'
+    );
+
+    const { stdout: denyStdout, stderr: denyStderr } = await execFile(
+      'node',
+      [join(outDir, 'run.mjs'), '--caps', denyCapsPath],
+      { cwd: repoRoot }
+    );
+    const denySummary = parseSummary(denyStdout);
+    assert.equal(denySummary.ok, false, `${name} flow should fail without caps`);
+    assert.match(denyStderr, /(missing_effects|write_denied)/, `${name} flow should report missing caps`);
+  }
+});
+
+function parseSummary(output) {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    throw new Error('expected runner output');
+  }
+  const last = lines[lines.length - 1];
+  return JSON.parse(last);
+}


### PR DESCRIPTION
## Summary
- load the spec catalog during TS codegen so manifests are produced alongside IR output and embedded into run.mjs
- add runtime capability validation helpers (including `runWithCaps`) and update the in-memory adapters to report `Network.Out`
- introduce a trace-summary CLI plus docs/tests covering capability-checked runners

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf39655f248320a1040787f590eebd