### PR TITLE
Enforce generated runner capabilities and add trace summary CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,13 @@ npm run tf -- canon examples/flows/signing.tf -o out/0.4/ir/signing.canon.json
 # Generate TS skeleton for the flow
 npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/signing
 
-# Run generated code with capability enforcement + summarize traces
+# Run generated code with capability enforcement (+ env fallback)
 # caps.json: {"effects":["Storage.Write","Pure","Observability"],"allow_writes_prefixes":["res://kv/"]}
 npm run tf -- emit --lang ts examples/flows/run_storage_ok.tf --out out/0.4/codegen-ts/run_storage_ok
 node out/0.4/codegen-ts/run_storage_ok/run.mjs --caps caps.json
-cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --pretty
+TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out/0.4/codegen-ts/run_publish/run.mjs
+# Summarize traces
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
 # Generate capability manifest
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ npm run tf -- canon examples/flows/signing.tf -o out/0.4/ir/signing.canon.json
 # Generate TS skeleton for the flow
 npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/signing
 
+# Run generated code with capability enforcement + summarize traces
+# caps.json: {"effects":["Storage.Write","Pure","Observability"],"allow_writes_prefixes":["res://kv/"]}
+npm run tf -- emit --lang ts examples/flows/run_storage_ok.tf --out out/0.4/codegen-ts/run_storage_ok
+node out/0.4/codegen-ts/run_storage_ok/run.mjs --caps caps.json
+cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --pretty
+
 # Generate capability manifest
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json

--- a/packages/tf-l0-codegen-ts/scripts/generate.mjs
+++ b/packages/tf-l0-codegen-ts/scripts/generate.mjs
@@ -1,34 +1,245 @@
-import { writeFile, mkdir, copyFile } from 'node:fs/promises';
+import { writeFile, mkdir, copyFile, readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+import { checkIR } from '../../tf-l0-check/src/check.mjs';
+import { manifestFromVerdict } from '../../tf-l0-check/src/manifest.mjs';
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const runtimeSrc = join(moduleDir, '..', 'src', 'runtime');
+const catalogPath = join(moduleDir, '..', '..', 'tf-l0-spec', 'spec', 'catalog.json');
+
+let catalogPromise = null;
+async function loadCatalog() {
+  if (!catalogPromise) {
+    catalogPromise = readFile(catalogPath, 'utf8')
+      .then((raw) => JSON.parse(raw))
+      .catch(() => ({ primitives: [] }));
+  }
+  return catalogPromise;
+}
+
 export async function generate(ir, { outDir }) {
   await mkdir(join(outDir, 'src'), { recursive: true });
-  await writeFile(join(outDir, 'package.json'), JSON.stringify({ name:"tf-generated", private:true, type:"module", scripts:{ start:"node ./dist/pipeline.mjs" }, dependencies:{} }, null, 2) + '\n', 'utf8');
-  const adapters = genAdapters(ir); await writeFile(join(outDir,'src','adapters.ts'), adapters, 'utf8');
-  const pipeline = genPipeline(ir); await writeFile(join(outDir,'src','pipeline.ts'), pipeline, 'utf8');
-  await writeFile(join(outDir,'src','trace.ts'), traceUtil(), 'utf8');
-  await writeFile(join(outDir,'src','determinism.ts'), determinismUtil(), 'utf8');
-  await writeFile(join(outDir,'src','redaction.ts'), redactionUtil(), 'utf8');
-  await emitRuntime(ir, outDir);
-}
-function prims(ir, out=new Set()){ if(!ir||typeof ir!=='object') return out; if(ir.node==='Prim') out.add(ir.prim); for(const c of (ir.children||[])) prims(c,out); return out; }
-function genAdapters(ir){ const names=Array.from(prims(ir)); const methods=names.map(n=>`  ${to(n)}(input: any): Promise<any>`).join('\n'); const stubs=names.map(n=>stub(n)).join('\n\n'); return `export interface Adapters {\n${methods}\n}\n\n${stubs}\n`; function to(n){ return 'prim_'+n.replace(/[^a-z0-9]/g,'_'); } function stub(n){ const m=to(n); return `export async function ${m}(input:any):Promise<any>{ throw new Error('Not wired: ${m}'); }`; } }
-function genPipeline(ir){ return `import type { Adapters } from './adapters';\nimport { trace } from './trace';\nimport { XorShift32, FixedClock } from './determinism';\nimport type { RedactionPolicy } from './redaction';\n\nexport async function run(adapters: Adapters, input: any, seed: number = 42, clockEpochMs: number = 1690000000000, redaction?: RedactionPolicy): Promise<any> {\n  (globalThis as any).__tf_rng = new XorShift32(seed);\n  (globalThis as any).__tf_clock = new FixedClock(clockEpochMs);\n  (globalThis as any).__tf_redaction = redaction;\n  return await step_${id(ir)}(adapters, input);\n}\n\n${gen(ir)}\n`; function id(node){ return Math.abs(hashCode(JSON.stringify(node))); } function gen(node){ if(node.node==='Prim'){ const m='prim_'+node.prim.replace(/[^a-z0-9]/g,'_'); return `async function step_${id(node)}(adapters: Adapters, input: any){ const span=trace.start('${node.prim}'); const out = await (adapters as any).${m}(input); trace.end(span, input, out, ['TODO-effects']); return out; }`; } if(node.node==='Seq'){ const kids=node.children.map(c=>`acc = await step_${id(c)}(adapters, acc)`).join('\n  '); return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ let acc=input; ${kids}; return acc; }`; } if(node.node==='Par'){ return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ const parts=await Promise.all([${node.children.map(c=>`step_${id(c)}(adapters, input)`).join(', ')}]); return parts; }`; } return `async function step_${id(node)}(){ return null }`; } }
-function traceUtil(){ return `import { applyRedaction } from './redaction';\nfunction rng(){ const r=(globalThis as any).__tf_rng; if(!r) throw new Error('rng not initialized'); return r.next(); }\nfunction nowNs(){ const c=(globalThis as any).__tf_clock; if(!c) throw new Error('clock not initialized'); return c.nowNs(); }\nexport const trace = { start(prim){ return { prim, ts: nowNs(), in: null }; }, end(span, input, output, effects){ const evt = { ts_ns: String(span.ts), flow_id: 'flow', run_id: 'run', node_id: span.prim, prim_id: span.prim, span_id: String((rng()*1e9)>>>0), parent_span_id: '', in_hash: hash(input), out_hash: hash(output), effects }; const safe = applyRedaction(evt, (globalThis as any).__tf_redaction); if (process.env.TF_TRACE_STDOUT==='1') console.log(JSON.stringify(safe)); }, }; function hash(v){ return 'sha256:' + require('node:crypto').createHash('sha256').update(JSON.stringify(v)).digest('hex'); }`; }
-function determinismUtil(){ return `export { XorShift32, FixedClock } from './determinism';`; }
-function redactionUtil(){ return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`; }
-function hashCode(s){ let h=0; for(let i=0;i<s.length;i++){ h=((h<<5)-h)+s.charCodeAt(i)|0; } return Math.abs(h); }
+  await writeFile(
+    join(outDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'tf-generated',
+        private: true,
+        type: 'module',
+        scripts: { start: 'node ./dist/pipeline.mjs' },
+        dependencies: {},
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf8',
+  );
 
-async function emitRuntime(ir, outDir) {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
-  const runtimeSrc = join(moduleDir, '..', 'src', 'runtime');
+  const adapters = genAdapters(ir);
+  await writeFile(join(outDir, 'src', 'adapters.ts'), adapters, 'utf8');
+
+  const pipeline = genPipeline(ir);
+  await writeFile(join(outDir, 'src', 'pipeline.ts'), pipeline, 'utf8');
+
+  await writeFile(join(outDir, 'src', 'trace.ts'), traceUtil(), 'utf8');
+  await writeFile(join(outDir, 'src', 'determinism.ts'), determinismUtil(), 'utf8');
+  await writeFile(join(outDir, 'src', 'redaction.ts'), redactionUtil(), 'utf8');
+
+  const catalog = await loadCatalog();
+  const verdict = checkIR(ir, catalog);
+  const manifest = manifestFromVerdict(verdict);
+  await emitRuntime(ir, outDir, manifest);
+}
+
+function prims(ir, out = new Set()) {
+  if (!ir || typeof ir !== 'object') return out;
+  if (ir.node === 'Prim') out.add(ir.prim);
+  for (const child of ir.children || []) prims(child, out);
+  return out;
+}
+
+function genAdapters(ir) {
+  const names = Array.from(prims(ir));
+  const methods = names.map((name) => `  ${to(name)}(input: any): Promise<any>`).join('\n');
+  const stubs = names.map((name) => stub(name)).join('\n\n');
+  return `export interface Adapters {\n${methods}\n}\n\n${stubs}\n`;
+
+  function to(name) {
+    return `prim_${name.replace(/[^a-z0-9]/g, '_')}`;
+  }
+
+  function stub(name) {
+    const method = to(name);
+    return `export async function ${method}(input:any):Promise<any>{ throw new Error('Not wired: ${method}'); }`;
+  }
+}
+
+function genPipeline(ir) {
+  return `import type { Adapters } from './adapters';\nimport { trace } from './trace';\nimport { XorShift32, FixedClock } from './determinism';\nimport type { RedactionPolicy } from './redaction';\n\nexport async function run(adapters: Adapters, input: any, seed: number = 42, clockEpochMs: number = 1690000000000, redaction?: RedactionPolicy): Promise<any> {\n  (globalThis as any).__tf_rng = new XorShift32(seed);\n  (globalThis as any).__tf_clock = new FixedClock(clockEpochMs);\n  (globalThis as any).__tf_redaction = redaction;\n  return await step_${id(ir)}(adapters, input);\n}\n\n${gen(ir)}\n`;
+
+  function id(node) {
+    return Math.abs(hashCode(JSON.stringify(node)));
+  }
+
+  function gen(node) {
+    if (node.node === 'Prim') {
+      const method = `prim_${node.prim.replace(/[^a-z0-9]/g, '_')}`;
+      return `async function step_${id(node)}(adapters: Adapters, input: any){ const span=trace.start('${node.prim}'); const out = await (adapters as any).${method}(input); trace.end(span, input, out, ['TODO-effects']); return out; }`;
+    }
+    if (node.node === 'Seq') {
+      const children = node.children.map((child) => `acc = await step_${id(child)}(adapters, acc)`).join('\n  ');
+      return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ let acc=input; ${children}; return acc; }`;
+    }
+    if (node.node === 'Par') {
+      const children = node.children.map((child) => `step_${id(child)}(adapters, input)`).join(', ');
+      return `${node.children.map(gen).join('\n\n')}\nasync function step_${id(node)}(adapters: Adapters, input: any){ const parts=await Promise.all([${children}]); return parts; }`;
+    }
+    return `async function step_${id(node)}(){ return null }`;
+  }
+}
+
+function traceUtil() {
+  return `import { applyRedaction } from './redaction';\nfunction rng(){ const r=(globalThis as any).__tf_rng; if(!r) throw new Error('rng not initialized'); return r.next(); }\nfunction nowNs(){ const c=(globalThis as any).__tf_clock; if(!c) throw new Error('clock not initialized'); return c.nowNs(); }\nexport const trace = { start(prim){ return { prim, ts: nowNs(), in: null }; }, end(span, input, output, effects){ const evt = { ts_ns: String(span.ts), flow_id: 'flow', run_id: 'run', node_id: span.prim, prim_id: span.prim, span_id: String((rng()*1e9)>>>0), parent_span_id: '', in_hash: hash(input), out_hash: hash(output), effects }; const safe = applyRedaction(evt, (globalThis as any).__tf_redaction); if (process.env.TF_TRACE_STDOUT==='1') console.log(JSON.stringify(safe)); }, }; function hash(v){ return 'sha256:' + require('node:crypto').createHash('sha256').update(JSON.stringify(v)).digest('hex'); }`;
+}
+
+function determinismUtil() {
+  return `export { XorShift32, FixedClock } from './determinism';`;
+}
+
+function redactionUtil() {
+  return `export type { RedactionPolicy } from './redaction';\nexport { applyRedaction } from './redaction';`;
+}
+
+function hashCode(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h) + s.charCodeAt(i);
+    h |= 0;
+  }
+  return Math.abs(h);
+}
+
+async function emitRuntime(ir, outDir, manifest) {
   const runtimeOut = join(outDir, 'runtime');
   await mkdir(runtimeOut, { recursive: true });
   await copyFile(join(runtimeSrc, 'inmem.mjs'), join(runtimeOut, 'inmem.mjs'));
   await copyFile(join(runtimeSrc, 'run-ir.mjs'), join(runtimeOut, 'run-ir.mjs'));
+  await copyFile(join(runtimeSrc, 'capabilities.mjs'), join(runtimeOut, 'capabilities.mjs'));
+
   const canonicalIr = JSON.parse(canonicalize(ir));
   const irLiteral = JSON.stringify(canonicalIr, null, 2);
-  const runScript = `import { mkdir, readFile, writeFile } from 'node:fs/promises';\nimport { dirname, join } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport { runIR } from './runtime/run-ir.mjs';\nimport inmem from './runtime/inmem.mjs';\n\nconst ir = ${irLiteral};\n\nconst result = await runIR(ir, inmem);\nconst summary = (() => {\n  const effects = Array.isArray(result?.effects) ? Array.from(new Set(result.effects)) : [];\n  effects.sort();\n  return { ok: Boolean(result?.ok), ops: result?.ops ?? 0, effects };\n})();\n\nconst here = dirname(fileURLToPath(import.meta.url));\nconst statusSelf = join(here, 'status.json');\nawait writeFile(statusSelf, JSON.stringify(summary, null, 2) + '\\n', 'utf8');\n\nasync function mergeStatus(targetPath) {\n  try {\n    await mkdir(dirname(targetPath), { recursive: true });\n  } catch {}\n  let merged = summary;\n  try {\n    const existingRaw = await readFile(targetPath, 'utf8');\n    const existing = JSON.parse(existingRaw);\n    const effects = new Set([\n      ...(Array.isArray(existing?.effects) ? existing.effects : []),\n      ...summary.effects,\n    ]);\n    merged = {\n      ok: Boolean(existing?.ok) && Boolean(summary.ok),\n      ops: (existing?.ops ?? 0) + (summary.ops ?? 0),\n      effects: Array.from(effects).sort(),\n    };\n  } catch (err) {\n    if (!err || err.code !== 'ENOENT') {\n      console.warn('tf run.mjs: unable to merge status file', err);\n      return;\n    }\n  }\n  await writeFile(targetPath, JSON.stringify(merged, null, 2) + '\\n', 'utf8');\n}\n\nif (process.env.TF_STATUS_PATH) {\n  await mergeStatus(process.env.TF_STATUS_PATH);\n}\n`;
+  const manifestLiteral = canonicalize(manifest);
+
+  const runScript = `import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { runIR } from './runtime/run-ir.mjs';
+import { validateCapabilities } from './runtime/capabilities.mjs';
+import inmem from './runtime/inmem.mjs';
+
+const MANIFEST = ${manifestLiteral};
+const ir = ${irLiteral};
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((key) => JSON.stringify(key) + ':' + canonicalJson(value[key])).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeCaps(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { effects: [], allow_writes_prefixes: [] };
+  }
+  const effects = Array.isArray(raw.effects) ? raw.effects.filter((v) => typeof v === 'string') : [];
+  const allow_writes_prefixes = Array.isArray(raw.allow_writes_prefixes)
+    ? raw.allow_writes_prefixes.filter((v) => typeof v === 'string')
+    : [];
+  return { effects, allow_writes_prefixes };
+}
+
+const parsed = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    caps: { type: 'string' },
+  },
+  allowPositionals: true,
+});
+
+let rawCaps = null;
+
+if (parsed.values.caps) {
+  try {
+    rawCaps = JSON.parse(await readFile(parsed.values.caps, 'utf8'));
+  } catch (err) {
+    console.error('tf run.mjs: unable to read capabilities', err?.message ?? err);
+  }
+} else if (process.env.TF_CAPS) {
+  try {
+    rawCaps = JSON.parse(process.env.TF_CAPS);
+  } catch (err) {
+    console.error('tf run.mjs: unable to parse TF_CAPS', err?.message ?? err);
+  }
+}
+
+const caps = normalizeCaps(rawCaps);
+const validation = validateCapabilities(MANIFEST, caps);
+
+let result;
+if (!validation.ok) {
+  console.error('tf run.mjs: capability check failed', JSON.stringify(validation));
+  result = { ok: false, ops: 0, effects: [] };
+} else {
+  result = await runIR(ir, inmem);
+}
+
+const effects = Array.isArray(result?.effects) ? Array.from(new Set(result.effects)) : [];
+effects.sort();
+const summary = { ok: Boolean(result?.ok), ops: result?.ops ?? 0, effects };
+
+console.log(canonicalJson(summary));
+
+const here = dirname(fileURLToPath(import.meta.url));
+const statusSelf = join(here, 'status.json');
+await writeFile(statusSelf, JSON.stringify(summary, null, 2) + '\\n', 'utf8');
+
+async function mergeStatus(targetPath) {
+  try {
+    await mkdir(dirname(targetPath), { recursive: true });
+  } catch {}
+  let merged = summary;
+  try {
+    const existingRaw = await readFile(targetPath, 'utf8');
+    const existing = JSON.parse(existingRaw);
+    const effectsSet = new Set([
+      ...(Array.isArray(existing?.effects) ? existing.effects : []),
+      ...summary.effects,
+    ]);
+    merged = {
+      ok: Boolean(existing?.ok) && Boolean(summary.ok),
+      ops: (existing?.ops ?? 0) + (summary.ops ?? 0),
+      effects: Array.from(effectsSet).sort(),
+    };
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') {
+      console.warn('tf run.mjs: unable to merge status file', err);
+      return;
+    }
+  }
+  await writeFile(targetPath, JSON.stringify(merged, null, 2) + '\\n', 'utf8');
+}
+
+if (process.env.TF_STATUS_PATH) {
+  await mergeStatus(process.env.TF_STATUS_PATH);
+}
+`;
+
   await writeFile(join(outDir, 'run.mjs'), runScript, 'utf8');
 }

--- a/packages/tf-l0-codegen-ts/src/runtime/capabilities.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/capabilities.mjs
@@ -1,0 +1,49 @@
+function toStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry) => typeof entry === 'string');
+}
+
+function uniqueSorted(values) {
+  return Array.from(new Set(values)).sort();
+}
+
+export function validateCapabilities(manifest = {}, provided = {}) {
+  const requiredEffects = toStringArray(manifest?.required_effects);
+  const providedEffects = new Set(toStringArray(provided?.effects));
+  const missingEffects = requiredEffects.filter((effect) => !providedEffects.has(effect));
+
+  const allowPrefixes = toStringArray(provided?.allow_writes_prefixes);
+  const writes = Array.isArray(manifest?.footprints_rw?.writes) ? manifest.footprints_rw.writes : [];
+  const denied = [];
+  for (const entry of writes) {
+    const uri = entry?.uri;
+    if (typeof uri !== 'string' || uri.length === 0) {
+      continue;
+    }
+    if (allowPrefixes.length === 0) {
+      denied.push(uri);
+      continue;
+    }
+    let allowed = false;
+    for (const prefix of allowPrefixes) {
+      if (uri.startsWith(prefix)) {
+        allowed = true;
+        break;
+      }
+    }
+    if (!allowed) {
+      denied.push(uri);
+    }
+  }
+
+  const missing_effects = uniqueSorted(missingEffects);
+  const write_denied = uniqueSorted(denied);
+
+  return {
+    ok: missing_effects.length === 0 && write_denied.length === 0,
+    missing_effects,
+    write_denied,
+  };
+}
+
+export default validateCapabilities;

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -91,7 +91,7 @@ register('tf:observability/emit-metric@1', ['emit-metric'], 'Observability.EmitM
   return { ok: true };
 });
 
-register('tf:network/publish@1', ['publish'], 'Network.Publish', async (args = {}) => {
+register('tf:network/publish@1', ['publish'], 'Network.Out', async (args = {}) => {
   const topic = args.topic ?? 'default';
   if (!topicQueues.has(topic)) {
     topicQueues.set(topic, []);

--- a/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs
@@ -1,3 +1,5 @@
+import { validateCapabilities } from './capabilities.mjs';
+
 let clockWarned = false;
 
 function nowTs() {
@@ -142,6 +144,15 @@ export async function runIR(ir, runtime, options = {}) {
     ops: ctx.ops,
     effects: Array.from(ctx.effects).sort(),
   };
+}
+
+export async function runWithCaps(ir, runtime, caps, manifest) {
+  const verdict = validateCapabilities(manifest, caps);
+  if (!verdict.ok) {
+    console.error('tf run-ir: capability validation failed', JSON.stringify(verdict));
+    return { ok: false, ops: 0, effects: [] };
+  }
+  return runIR(ir, runtime);
 }
 
 export default runIR;

--- a/packages/tf-l0-tools/trace-summary.mjs
+++ b/packages/tf-l0-tools/trace-summary.mjs
@@ -94,8 +94,9 @@ const summary = {
   by_effect: selectTop(effectCounts, topLimit),
 };
 
+const canonical = canonicalJson(summary);
 if (pretty) {
-  process.stdout.write(JSON.stringify(summary, null, 2) + '\n');
+  process.stdout.write(JSON.stringify(JSON.parse(canonical), null, 2) + '\n');
 } else {
-  process.stdout.write(canonicalJson(summary) + '\n');
+  process.stdout.write(canonical + '\n');
 }

--- a/packages/tf-l0-tools/trace-summary.mjs
+++ b/packages/tf-l0-tools/trace-summary.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+function parseTop(value) {
+  if (!value) return Infinity;
+  const num = Number.parseInt(value, 10);
+  if (!Number.isFinite(num) || num <= 0) {
+    return Infinity;
+  }
+  return num;
+}
+
+function selectTop(map, limit) {
+  const entries = Array.from(map.entries());
+  entries.sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+  });
+  const sliced = Number.isFinite(limit) ? entries.slice(0, limit) : entries;
+  sliced.sort((a, b) => a[0].localeCompare(b[0]));
+  const result = {};
+  for (const [key, count] of sliced) {
+    result[key] = count;
+  }
+  return result;
+}
+
+function increment(map, key) {
+  map.set(key, (map.get(key) || 0) + 1);
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return chunks.join('');
+}
+
+const { values } = parseArgs({
+  options: {
+    top: { type: 'string' },
+    pretty: { type: 'boolean' },
+    quiet: { type: 'boolean' },
+  },
+});
+
+const topLimit = parseTop(values.top);
+const pretty = Boolean(values.pretty);
+const quiet = Boolean(values.quiet);
+
+const input = await readStdin();
+const lines = input.split(/\r?\n/);
+
+const primCounts = new Map();
+const effectCounts = new Map();
+let total = 0;
+let warned = false;
+
+for (const raw of lines) {
+  const line = raw.trim();
+  if (!line) continue;
+  try {
+    const parsed = JSON.parse(line);
+    total += 1;
+    if (parsed && typeof parsed.prim_id === 'string') {
+      increment(primCounts, parsed.prim_id);
+    }
+    if (parsed && typeof parsed.effect === 'string') {
+      increment(effectCounts, parsed.effect);
+    }
+  } catch (err) {
+    if (!warned && !quiet) {
+      console.warn('trace-summary: skipping malformed line');
+      warned = true;
+    }
+  }
+}
+
+const summary = {
+  total,
+  by_prim: selectTop(primCounts, topLimit),
+  by_effect: selectTop(effectCounts, topLimit),
+};
+
+if (pretty) {
+  process.stdout.write(JSON.stringify(summary, null, 2) + '\n');
+} else {
+  process.stdout.write(canonicalJson(summary) + '\n');
+}

--- a/tests/run-ir.test.mjs
+++ b/tests/run-ir.test.mjs
@@ -46,7 +46,7 @@ test('parallel publish and metric capture distinct effects', async () => {
   };
   const out = await runIR(ir, inmem);
   assert.equal(out.ok, true);
-  assert.deepEqual(out.effects, ['Network.Publish', 'Observability.EmitMetric']);
+  assert.deepEqual(out.effects, ['Network.Out', 'Observability.EmitMetric']);
 });
 
 test('hashing is deterministic for equivalent objects', async () => {

--- a/tests/runner-caps.test.mjs
+++ b/tests/runner-caps.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const tfCli = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+const storageFlow = fileURLToPath(new URL('../examples/flows/run_storage_ok.tf', import.meta.url));
+const publishFlow = fileURLToPath(new URL('../examples/flows/run_publish.tf', import.meta.url));
+
+async function runProcess(bin, args, { cwd, env, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      cwd,
+      env: env ? { ...process.env, ...env } : process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function parseSummary(output) {
+  const lines = output.trim().split(/\r?\n/).filter(Boolean);
+  const last = lines[lines.length - 1] || '{}';
+  return JSON.parse(last);
+}
+
+async function emitFlow(flowPath) {
+  const tmp = await mkdtemp(join(tmpdir(), 'tf-runner-'));
+  const outDir = join(tmp, 'out');
+  const result = await runProcess(process.execPath, [tfCli, 'emit', flowPath, '--lang', 'ts', '--out', outDir]);
+  assert.equal(result.code, 0, result.stderr);
+  return { outDir, runScript: join(outDir, 'run.mjs') };
+}
+
+test('generated runner embeds manifest constant', async () => {
+  const { runScript } = await emitFlow(storageFlow);
+  const contents = await readFile(runScript, 'utf8');
+  assert.match(contents, /const MANIFEST = \{/);
+  assert.match(contents, /required_effects/);
+});
+
+test('runner enforces capability requirements for storage flow', async () => {
+  const { outDir, runScript } = await emitFlow(storageFlow);
+  const capsPath = join(outDir, 'caps.json');
+  await writeFile(
+    capsPath,
+    JSON.stringify({
+      effects: ['Storage.Write', 'Pure', 'Observability'],
+      allow_writes_prefixes: ['res://kv/'],
+    }),
+    'utf8',
+  );
+
+  const allowed = await runProcess(process.execPath, [runScript, '--caps', capsPath]);
+  assert.equal(allowed.code, 0, allowed.stderr);
+  const okSummary = parseSummary(allowed.stdout);
+  assert.equal(okSummary.ok, true);
+  assert.ok(okSummary.effects.includes('Storage.Write'));
+
+  const denied = await runProcess(process.execPath, [runScript]);
+  assert.equal(denied.code, 0);
+  const deniedSummary = parseSummary(denied.stdout);
+  assert.equal(deniedSummary.ok, false);
+  assert.match(denied.stderr, /(missing_effects|write_denied)/);
+});
+
+test('runner permits publish flow with matching caps', async () => {
+  const { outDir, runScript } = await emitFlow(publishFlow);
+  const capsPath = join(outDir, 'caps.json');
+  await writeFile(
+    capsPath,
+    JSON.stringify({
+      effects: ['Network.Out', 'Pure', 'Observability'],
+      allow_writes_prefixes: [],
+    }),
+    'utf8',
+  );
+
+  const result = await runProcess(process.execPath, [runScript, '--caps', capsPath]);
+  assert.equal(result.code, 0, result.stderr);
+  const summary = parseSummary(result.stdout);
+  assert.equal(summary.ok, true);
+  assert.ok(summary.effects.includes('Network.Out'));
+});

--- a/tests/trace-summary.test.mjs
+++ b/tests/trace-summary.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { promises as fs } from 'node:fs';
+
+const scriptPath = fileURLToPath(new URL('../packages/tf-l0-tools/trace-summary.mjs', import.meta.url));
+const fixturePath = fileURLToPath(new URL('./fixtures/trace-sample.jsonl', import.meta.url));
+
+async function runCli(args, { input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+test('summarizes traces into canonical JSON', async () => {
+  const fixture = await fs.readFile(fixturePath, 'utf8');
+  const { code, stdout, stderr } = await runCli([], { input: fixture });
+  assert.equal(code, 0, stderr);
+  const summary = JSON.parse(stdout.trim());
+  assert.equal(summary.total, 7);
+  assert.equal(summary.by_prim['tf:resource/write-object@1'], 2);
+  assert.equal(summary.by_prim['tf:integration/publish-topic@1'], 2);
+  assert.equal(summary.by_effect['Storage.Write'], 2);
+  assert.equal(summary.by_effect['Network.Out'], 2);
+});
+
+test('top option limits output keys', async () => {
+  const fixture = await fs.readFile(fixturePath, 'utf8');
+  const { code, stdout } = await runCli(['--top=2'], { input: fixture });
+  assert.equal(code, 0);
+  const summary = JSON.parse(stdout.trim());
+  assert.equal(Object.keys(summary.by_prim).length, 2);
+  assert.equal(Object.keys(summary.by_effect).length, 2);
+  assert(summary.by_effect['Network.Out'] >= 2);
+});
+
+test('pretty option produces indented output', async () => {
+  const fixture = await fs.readFile(fixturePath, 'utf8');
+  const { code, stdout } = await runCli(['--pretty'], { input: fixture });
+  assert.equal(code, 0);
+  assert.ok(/\n  "by_prim"/.test(stdout));
+  const summary = JSON.parse(stdout);
+  assert.equal(summary.total, 7);
+});
+
+test('malformed lines warn once unless quiet', async () => {
+  const lines = [
+    '{"prim_id":"one","effect":"Pure"}',
+    'not-json',
+    '{"prim_id":"two","effect":"Pure"}',
+  ];
+  const input = lines.join('\n') + '\n';
+
+  const noisy = await runCli([], { input });
+  assert.equal(noisy.code, 0, noisy.stderr);
+  assert.equal(noisy.stderr, 'trace-summary: skipping malformed line\n');
+  const noisySummary = JSON.parse(noisy.stdout.trim());
+  assert.equal(noisySummary.total, 2);
+
+  const quiet = await runCli(['--quiet'], { input });
+  assert.equal(quiet.code, 0, quiet.stderr);
+  assert.equal(quiet.stderr, '');
+  const quietSummary = JSON.parse(quiet.stdout.trim());
+  assert.deepEqual(quietSummary, noisySummary);
+});


### PR DESCRIPTION
## Summary
- embed checked manifests into generated TS runners and gate execution on capabilities
- add a shared capability validator and ensure the in-memory runtime reports Network.Out for publish
- introduce a trace-summary CLI plus tests and documentation covering capability-aware runs

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf39655f248320a1040787f590eebd