### PR TITLE
Add literal parsing and fmt/show tooling

### DIFF
--- a/docs/l0-dsl.md
+++ b/docs/l0-dsl.md
@@ -2,19 +2,56 @@
 
 **Grammar (subset):**
 ```
-flow  := step ('|>' step)*
-step  := prim | parblock
-prim  := IDENT '(' arglist? ')' | IDENT
+flow    := step ('|>' step)*
+step    := prim | parblock
+prim    := IDENT '(' arglist? ')' | IDENT
 parblock := 'par{' step (';' step)* '}'
 
-arglist := IDENT '=' (NUMBER | STRING | IDENT) (',' IDENT '=' (NUMBER | STRING | IDENT))*
-
-Examples:
-  serialize |> hash |> sign-data(key_ref="k1")
-  par{ a(); b(x=1); c() }
+arglist := IDENT '=' literal (',' IDENT '=' literal)*
+literal := NUMBER | STRING | IDENT | 'true' | 'false' | 'null' | array | object
+array   := '[' (literal (',' literal)* ','?)? ']'
+object  := '{' (objkey ':' literal (',' objkey ':' literal)* ','?)? '}'
+objkey  := STRING | IDENT
 ```
 
-The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws.
-It collapses idempotent primitives, eliminates declared inverse pairs, and swaps commute-with-pure primitives across adjacent pure nodes.
-Normalization never moves steps across `Region{}` or `Par{}` boundaries, so localized effects stay fenced.
-Running the canonicalizer twice yields the same result, keeping canonical hashes deterministic.
+Examples:
+```
+serialize |> hash |> sign-data(key_ref="k1")
+par{ a(); b(x=1); c() }
+seq{
+  write-object(uri="res://kv/bucket", key="x", meta={retry:{count:2}});
+  write-object(uri="res://kv/bucket", key="y", flags=[true, false, null])
+}
+```
+
+Literals accept numbers (with optional leading `-`), booleans, `null`, arrays (with optional trailing commas), and objects with either quoted or bare identifier keys. Nested structures are valid anywhere a literal can appear, so expressions like `write-object(meta={retry:{count:2}})` parse without additional helpers.
+
+The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws. It collapses idempotent primitives, eliminates declared inverse pairs, and swaps commute-with-pure primitives across adjacent pure nodes. Normalization never moves steps across `Region{}` or `Par{}` boundaries, so localized effects stay fenced. Running the canonicalizer twice yields the same result, keeping canonical hashes deterministic.
+
+## Tooling
+
+### Formatter
+
+```
+node packages/tf-compose/bin/tf.mjs fmt flow.tf [--write|-w]
+```
+
+The formatter parses the DSL and reprints it with sorted argument keys, normalized commas/semicolons, and stable literal layouts (object keys sorted, arrays comma-separated). Use `--write`/`-w` to update the file in place. Formatting is idempotent, so running it multiple times yields identical output.
+
+### Tree view
+
+```
+node packages/tf-compose/bin/tf.mjs show flow.tf
+```
+
+`show` renders the parsed IR as a tree with two-space indentation. Each `Prim` displays its identifier and arguments (with sorted keys), which makes it easy to inspect pipelines and block structure without touching the source file.
+
+## Error reporting
+
+Parse failures include a `line:col` suffix and a short caret span pointing at the offending token, e.g.
+```
+Expected value at 2:11
+  write-object(arr=[1,,2])
+           ^^
+```
+This context helps locate issues such as stray commas, unterminated strings, or unbalanced braces quickly.

--- a/packages/tf-compose/bin/tf.mjs
+++ b/packages/tf-compose/bin/tf.mjs
@@ -19,14 +19,26 @@ async function loadCatalog() {
 
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs;
+const cmd = args[0];
+const validCommands = new Set(['parse', 'check', 'canon', 'emit', 'manifest', 'fmt', 'show']);
+
+if (!cmd || !validCommands.has(cmd)) {
+  console.error('Usage: tf <parse|check|canon|emit|manifest|fmt|show> <flow.tf> [--out path] [--lang ts|rs] [--write|-w]');
+  process.exit(2);
+}
+
+if (cmd === 'fmt') {
+  await handleFmt(args.slice(1));
+  process.exit(0);
+}
+
+if (cmd === 'show') {
+  await handleShow(args.slice(1));
+  process.exit(0);
+}
 
 function arg(k) { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : null; }
 
-const cmd = args[0];
-if (!cmd || ['parse', 'check', 'canon', 'emit', 'manifest'].indexOf(cmd) < 0) {
-  console.error('Usage: tf <parse|check|canon|emit|manifest> <flow.tf> [--out path] [--lang ts|rs]');
-  process.exit(2);
-}
 const optionKeys = new Set(['--out', '-o', '--lang']);
 let file = null;
 for (let i = 1; i < args.length; i++) {
@@ -109,4 +121,170 @@ if (cmd === 'emit') {
   }
   console.log('Emitted', lang, 'to', outDir);
   process.exit(0);
+}
+
+async function handleFmt(argv) {
+  const writeFlag = argv.includes('--write') || argv.includes('-w');
+  const file = findFileArg(argv, new Set(['--write', '-w']));
+  if (!file) {
+    console.error('Missing flow path.');
+    process.exit(2);
+  }
+  const src = await readFile(file, 'utf8');
+  const ir = parseDSL(src);
+  const formatted = formatFlow(ir);
+  if (writeFlag) {
+    await writeFile(file, formatted, 'utf8');
+  } else {
+    process.stdout.write(formatted);
+  }
+}
+
+async function handleShow(argv) {
+  const file = findFileArg(argv, new Set());
+  if (!file) {
+    console.error('Missing flow path.');
+    process.exit(2);
+  }
+  const src = await readFile(file, 'utf8');
+  const ir = parseDSL(src);
+  const tree = renderTree(ir);
+  process.stdout.write(tree + '\n');
+}
+
+function findFileArg(argv, optionFlags) {
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === '--') continue;
+    if (optionFlags.has(token)) continue;
+    if (token.startsWith('-')) continue;
+    return token;
+  }
+  return null;
+}
+
+function formatFlow(ir) {
+  const lines = [];
+  renderNode(ir, 0, false, lines);
+  return lines.join('\n') + '\n';
+}
+
+function renderNode(node, indent, needsSemicolon, lines) {
+  if (!node) return;
+  const pad = ' '.repeat(indent);
+  if (node.node === 'Prim') {
+    let line = pad + formatPrim(node);
+    if (needsSemicolon) line += ';';
+    lines.push(line);
+    return;
+  }
+  if (node.node === 'Seq') {
+    renderBlock('seq', node.children || [], indent, needsSemicolon, lines);
+    return;
+  }
+  if (node.node === 'Par') {
+    renderBlock('par', node.children || [], indent, needsSemicolon, lines);
+    return;
+  }
+  if (node.node === 'Region') {
+    renderRegion(node, indent, needsSemicolon, lines);
+    return;
+  }
+  throw new Error(`Unknown node: ${node.node}`);
+}
+
+function renderBlock(name, children, indent, needsSemicolon, lines) {
+  const pad = ' '.repeat(indent);
+  lines.push(`${pad}${name}{`);
+  for (let i = 0; i < children.length; i++) {
+    renderNode(children[i], indent + 2, i < children.length - 1, lines);
+  }
+  lines.push(`${pad}}${needsSemicolon ? ';' : ''}`);
+}
+
+function renderRegion(node, indent, needsSemicolon, lines) {
+  const pad = ' '.repeat(indent);
+  const name = node.kind === 'Transaction' ? 'txn' : 'authorize';
+  const attrs = formatRegionAttrs(node.attrs || {});
+  lines.push(`${pad}${name}${attrs}{`);
+  const children = node.children || [];
+  for (let i = 0; i < children.length; i++) {
+    renderNode(children[i], indent + 2, i < children.length - 1, lines);
+  }
+  lines.push(`${pad}}${needsSemicolon ? ';' : ''}`);
+}
+
+function formatPrim(node) {
+  const name = node.prim;
+  const args = node.args || {};
+  const keys = Object.keys(args).sort((a, b) => a.localeCompare(b));
+  if (keys.length === 0) return name;
+  const parts = keys.map((key) => `${key}=${formatLiteral(args[key])}`);
+  return `${name}(${parts.join(', ')})`;
+}
+
+function formatRegionAttrs(attrs) {
+  const keys = Object.keys(attrs).sort((a, b) => a.localeCompare(b));
+  if (keys.length === 0) return '';
+  const parts = keys.map((key) => `${key}=${formatLiteral(attrs[key])}`);
+  return `(${parts.join(', ')})`;
+}
+
+function formatLiteral(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatLiteral(v)).join(', ')}]`;
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort((a, b) => a.localeCompare(b));
+    const parts = keys.map((key) => `${key}:${formatLiteral(value[key])}`);
+    return `{${parts.join(', ')}}`;
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function renderTree(node) {
+  const lines = [];
+  emitTree(node, 0, lines);
+  return lines.join('\n');
+}
+
+function emitTree(node, indent, lines) {
+  if (!node) return;
+  const pad = ' '.repeat(indent);
+  if (node.node === 'Prim') {
+    const args = node.args || {};
+    const suffix = formatArgsInline(args);
+    lines.push(`${pad}Prim: ${node.prim}${suffix}`);
+    return;
+  }
+  if (node.node === 'Seq') {
+    lines.push(`${pad}Seq`);
+    for (const child of node.children || []) emitTree(child, indent + 2, lines);
+    return;
+  }
+  if (node.node === 'Par') {
+    lines.push(`${pad}Par`);
+    for (const child of node.children || []) emitTree(child, indent + 2, lines);
+    return;
+  }
+  if (node.node === 'Region') {
+    const name = node.kind || 'Region';
+    const attrs = formatArgsInline(node.attrs || {}, '(', ')');
+    const label = name.charAt(0).toUpperCase() + name.slice(1);
+    lines.push(`${pad}Region: ${label}${attrs}`);
+    for (const child of node.children || []) emitTree(child, indent + 2, lines);
+    return;
+  }
+  lines.push(`${pad}${node.node || 'Unknown'}`);
+}
+
+function formatArgsInline(args, open = ' {', close = '}') {
+  const keys = Object.keys(args || {}).sort((a, b) => a.localeCompare(b));
+  if (keys.length === 0) return '';
+  const parts = keys.map((key) => `${key}:${formatLiteral(args[key])}`);
+  return `${open}${parts.join(', ')}${close}`;
 }

--- a/packages/tf-compose/src/parser.mjs
+++ b/packages/tf-compose/src/parser.mjs
@@ -1,106 +1,318 @@
 // DSL parser (extended) supporting regions: authorize{ ... } and txn{ ... }
 export function parseDSL(src) {
   const tokens = tokenize(src);
-  const seq = parseSeq(tokens);
-  expectEOF(tokens);
+  const parser = new Parser(src, tokens);
+  const seq = parseSeq(parser);
+  parser.expectEOF();
   return seq;
 }
 
 function tokenize(s) {
-  const out = []; let i=0;
-  while (i<s.length) {
-    const c=s[i];
-    if (/\s/.test(c)) { i++; continue; }
-    if (s.startsWith('|>', i)) { out.push({t:'PIPE'}); i+=2; continue; }
-    if (s.startsWith('par{', i)) { out.push({t:'PAR_OPEN'}); i+=4; continue; }
-    if (s.startsWith('seq{', i)) { out.push({t:'SEQ_OPEN'}); i+=4; continue; }
-    if (s.startsWith('authorize', i) && ['{','('].includes(s[i+9])) { out.push({t:'REGION_AUTH'}); i+=9; continue; }
-    if (s.startsWith('txn', i) && ['{','('].includes(s[i+3])) { out.push({t:'REGION_TXN'}); i+=3; continue; }
-    if (c==='{' ) { out.push({t:'LBRACE'}); i++; continue; }
-    if (c==='}') { out.push({t:'RBRACE'}); i++; continue; }
-    if (c==='(' ) { out.push({t:'LPAREN'}); i++; continue; }
-    if (c===')' ) { out.push({t:'RPAREN'}); i++; continue; }
-    if (c===';') { out.push({t:'SEMI'}); i++; continue; }
-    if (c===',') { out.push({t:'COMMA'}); i++; continue; }
-    if (c==='=') { out.push({t:'EQ'}); i++; continue; }
-    if (c==='"' || c==="'" ) {
-      const q=c; i++; let buf=''; while (i<s.length && s[i]!==q){ if(s[i]=='\\'){ buf+=s[i+1]; i+=2; } else { buf+=s[i++]; } }
-      i++; out.push({t:'STRING', v:buf}); continue;
+  const tokens = [];
+  let i = 0;
+  let line = 1;
+  let col = 1;
+
+  const push = (t, v, start, end, lineStart, colStart) => {
+    tokens.push({ t, v, start, end, line: lineStart, col: colStart });
+  };
+
+  const advanceChar = () => {
+    const ch = s[i];
+    i++;
+    if (ch === '\n') { line++; col = 1; }
+    else { col++; }
+    return ch;
+  };
+
+  while (i < s.length) {
+    const start = i;
+    const lineStart = line;
+    const colStart = col;
+    const c = s[i];
+
+    if (/\s/.test(c)) { advanceChar(); continue; }
+
+    if (s.startsWith('|>', i)) {
+      advanceChar(); advanceChar();
+      push('PIPE', '|>', start, i, lineStart, colStart);
+      continue;
     }
-    if (/[0-9]/.test(c)) { let j=i; while (j<s.length && /[0-9]/.test(s[j])) j++; out.push({t:'NUMBER', v:Number(s.slice(i,j))}); i=j; continue; }
-    let j=i; while (j<s.length && /[A-Za-z0-9_\-\.]/.test(s[j])) j++;
-    out.push({t:'IDENT', v:s.slice(i,j)}); i=j;
+
+    if (s.startsWith('par{', i)) {
+      advanceChar(); advanceChar(); advanceChar(); advanceChar();
+      push('PAR_OPEN', 'par{', start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (s.startsWith('seq{', i)) {
+      advanceChar(); advanceChar(); advanceChar(); advanceChar();
+      push('SEQ_OPEN', 'seq{', start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (s.startsWith('authorize', i) && (s[i + 9] === '{' || s[i + 9] === '(')) {
+      for (let k = 0; k < 9; k++) advanceChar();
+      push('REGION_AUTH', 'authorize', start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (s.startsWith('txn', i) && (s[i + 3] === '{' || s[i + 3] === '(')) {
+      for (let k = 0; k < 3; k++) advanceChar();
+      push('REGION_TXN', 'txn', start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (c === '{') { advanceChar(); push('LBRACE', '{', start, i, lineStart, colStart); continue; }
+    if (c === '}') { advanceChar(); push('RBRACE', '}', start, i, lineStart, colStart); continue; }
+    if (c === '(') { advanceChar(); push('LPAREN', '(', start, i, lineStart, colStart); continue; }
+    if (c === ')') { advanceChar(); push('RPAREN', ')', start, i, lineStart, colStart); continue; }
+    if (c === '[') { advanceChar(); push('LBRACKET', '[', start, i, lineStart, colStart); continue; }
+    if (c === ']') { advanceChar(); push('RBRACKET', ']', start, i, lineStart, colStart); continue; }
+    if (c === ';') { advanceChar(); push('SEMI', ';', start, i, lineStart, colStart); continue; }
+    if (c === ',') { advanceChar(); push('COMMA', ',', start, i, lineStart, colStart); continue; }
+    if (c === '=') { advanceChar(); push('EQ', '=', start, i, lineStart, colStart); continue; }
+    if (c === ':') { advanceChar(); push('COLON', ':', start, i, lineStart, colStart); continue; }
+
+    if (c === '"' || c === '\'') {
+      const quote = c;
+      advanceChar();
+      let buf = '';
+      let closed = false;
+      while (i < s.length) {
+        const ch = s[i];
+        if (ch === quote) { advanceChar(); closed = true; break; }
+        if (ch === '\\') {
+          advanceChar();
+          if (i >= s.length) throw formatError(s, start, i, 'Unterminated string');
+          buf += advanceChar();
+          continue;
+        }
+        buf += ch;
+        advanceChar();
+      }
+      if (!closed) throw formatError(s, start, i, 'Unterminated string');
+      push('STRING', buf, start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (/[0-9]/.test(c) || (c === '-' && /[0-9]/.test(s[i + 1] || ''))) {
+      let hasDigits = false;
+      let text = '';
+      if (s[i] === '-') { text += advanceChar(); }
+      while (i < s.length && /[0-9]/.test(s[i])) { hasDigits = true; text += advanceChar(); }
+      let fracDigits = 0;
+      if (s[i] === '.') {
+        text += advanceChar();
+        while (i < s.length && /[0-9]/.test(s[i])) { fracDigits++; text += advanceChar(); }
+      }
+      if (!hasDigits && fracDigits === 0) throw formatError(s, start, i, 'Invalid number');
+      push('NUMBER', Number(text), start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(c)) {
+      let text = '';
+      while (i < s.length && /[A-Za-z0-9_\-\.]/.test(s[i])) text += advanceChar();
+      push('IDENT', text, start, i, lineStart, colStart);
+      continue;
+    }
+
+    if (c === '-' || c === '.') {
+      let text = '';
+      while (i < s.length && /[A-Za-z0-9_\-\.]/.test(s[i])) text += advanceChar();
+      push('IDENT', text, start, i, lineStart, colStart);
+      continue;
+    }
+
+    throw formatError(s, start, start + 1, `Unexpected character '${c}'`);
   }
-  return {i:0, list:out};
+
+  tokens.push({ t: 'EOF', v: null, start: s.length, end: s.length, line, col });
+  return tokens;
 }
 
-function peek(t){ return t.list[t.i]||{t:'EOF'}; }
-function take(t, kind){ const p=peek(t); if (p.t!==kind) throw new Error(`Expected ${kind}, got ${p.t}`); t.i++; return p; }
-function maybe(t, kind){ const p=peek(t); if (p.t===kind){ t.i++; return true; } return false; }
-function expectEOF(t){ if (peek(t).t!=='EOF') throw new Error('Trailing tokens'); }
-
-function parseSeq(t){
-  const parts=[parseStep(t)];
-  while (maybe(t,'PIPE')) parts.push(parseStep(t));
-  return parts.length===1 ? parts[0] : { node:'Seq', children: parts };
+class Parser {
+  constructor(src, tokens) {
+    this.src = src;
+    this.tokens = tokens;
+    this.i = 0;
+  }
+  peek() { return this.tokens[this.i] || this.tokens[this.tokens.length - 1]; }
+  take(kind) {
+    const tok = this.peek();
+    if (tok.t !== kind) this.fail(tok, `Expected ${kind}, got ${tok.t}`);
+    this.i++;
+    return tok;
+  }
+  maybe(kind) {
+    const tok = this.peek();
+    if (tok.t === kind) { this.i++; return tok; }
+    return null;
+  }
+  expectEOF() {
+    const tok = this.peek();
+    if (tok.t !== 'EOF') this.fail(tok, 'Trailing tokens');
+  }
+  fail(tok, message) {
+    throw formatError(this.src, tok.start, Math.max(tok.end, tok.start + 1), message);
+  }
+  errorAt(tok, message) {
+    throw formatError(this.src, tok.start, Math.max(tok.end, tok.start + 1), message);
+  }
 }
 
-function parseBlock(t, node){
-  const kids=[];
-  while (true){
-    kids.push(parseStep(t));
-    if (maybe(t,'SEMI')) continue;
-    take(t,'RBRACE'); break;
+function parseSeq(parser) {
+  const parts = [parseStep(parser)];
+  while (parser.maybe('PIPE')) parts.push(parseStep(parser));
+  return parts.length === 1 ? parts[0] : { node: 'Seq', children: parts };
+}
+
+function parseBlock(parser, node) {
+  const kids = [];
+  if (parser.maybe('RBRACE')) { node.children = kids; return node; }
+  while (true) {
+    kids.push(parseStep(parser));
+    if (parser.maybe('SEMI')) {
+      if (parser.maybe('RBRACE')) break;
+      continue;
+    }
+    parser.take('RBRACE');
+    break;
   }
   node.children = kids;
   return node;
 }
 
-function parseRegion(t, kind){
-  // optional attrs: e.g., authorize(region="us", scope="kms.sign"){ ... }
-  let attrs={};
-  if (maybe(t,'LPAREN')) {
-    if (!maybe(t,'RPAREN')) {
-      while (true){
-        const key = take(t,'IDENT').v;
-        take(t,'EQ');
-        const vTok=peek(t);
-        let val;
-        if (vTok.t==='STRING' || vTok.t==='NUMBER'){ take(t,vTok.t); val=vTok.v; }
-        else if (vTok.t==='IDENT'){ take(t,'IDENT'); val=vTok.v; }
-        else throw new Error('Bad region attr value');
-        attrs[key]=val;
-        if (maybe(t,'COMMA')) continue;
-        take(t,'RPAREN'); break;
-      }
+function parseRegion(parser, kind) {
+  let attrs = {};
+  if (parser.maybe('LPAREN')) {
+    if (!parser.maybe('RPAREN')) {
+      attrs = parseAssignments(parser, 'RPAREN');
     }
   }
-  take(t,'LBRACE');
-  return parseBlock(t, { node:'Region', kind, attrs, children: [] });
+  parser.take('LBRACE');
+  return parseBlock(parser, { node: 'Region', kind, attrs, children: [] });
 }
 
-function parseStep(t){
-  if (maybe(t,'PAR_OPEN')) return parseBlock(t, { node:'Par', children: [] });
-  if (maybe(t,'SEQ_OPEN')) return parseBlock(t, { node:'Seq', children: [] });
-  if (maybe(t,'REGION_AUTH')) return parseRegion(t, 'Authorize');
-  if (maybe(t,'REGION_TXN')) return parseRegion(t, 'Transaction');
-  const id = take(t,'IDENT').v;
-  let args={};
-  if (maybe(t,'LPAREN')) {
-    if (!maybe(t,'RPAREN')) {
-      while (true){
-        const key = take(t,'IDENT').v;
-        take(t,'EQ');
-        const vTok=peek(t);
-        let val;
-        if (vTok.t==='STRING' || vTok.t==='NUMBER'){ take(t,vTok.t); val=vTok.v; }
-        else if (vTok.t==='IDENT'){ take(t,'IDENT'); val=vTok.v; }
-        else throw new Error('Bad arg value');
-        args[key]=val;
-        if (maybe(t,'COMMA')) continue;
-        take(t,'RPAREN'); break;
-      }
+function parseAssignments(parser, closing) {
+  const out = {};
+  while (true) {
+    const keyTok = parser.take('IDENT');
+    parser.take('EQ');
+    out[keyTok.v] = parseValue(parser);
+    if (parser.maybe('COMMA')) {
+      if (parser.maybe(closing)) break;
+      continue;
+    }
+    parser.take(closing);
+    break;
+  }
+  return out;
+}
+
+function parseStep(parser) {
+  if (parser.maybe('PAR_OPEN')) return parseBlock(parser, { node: 'Par', children: [] });
+  if (parser.maybe('SEQ_OPEN')) return parseBlock(parser, { node: 'Seq', children: [] });
+  if (parser.maybe('REGION_AUTH')) return parseRegion(parser, 'Authorize');
+  if (parser.maybe('REGION_TXN')) return parseRegion(parser, 'Transaction');
+  const id = parser.take('IDENT').v;
+  const args = {};
+  if (parser.maybe('LPAREN')) {
+    if (!parser.maybe('RPAREN')) {
+      Object.assign(args, parseAssignments(parser, 'RPAREN'));
     }
   }
-  return { node:'Prim', prim: id.toLowerCase(), args };
+  return { node: 'Prim', prim: id.toLowerCase(), args };
+}
+
+function parseValue(parser) {
+  const tok = parser.peek();
+  switch (tok.t) {
+    case 'STRING': parser.take('STRING'); return tok.v;
+    case 'NUMBER': parser.take('NUMBER'); return tok.v;
+    case 'IDENT': {
+      parser.take('IDENT');
+      if (tok.v === 'true') return true;
+      if (tok.v === 'false') return false;
+      if (tok.v === 'null') return null;
+      return tok.v;
+    }
+    case 'LBRACE':
+      return parseObject(parser);
+    case 'LBRACKET':
+      return parseArray(parser);
+    default:
+      parser.errorAt(tok, 'Expected value');
+  }
+}
+
+function parseObject(parser) {
+  parser.take('LBRACE');
+  const obj = {};
+  if (parser.maybe('RBRACE')) return obj;
+  while (true) {
+    const keyTok = parser.peek();
+    let key;
+    if (keyTok.t === 'STRING') { parser.take('STRING'); key = keyTok.v; }
+    else if (keyTok.t === 'IDENT') { parser.take('IDENT'); key = keyTok.v; }
+    else parser.errorAt(keyTok, 'Expected object key');
+    parser.take('COLON');
+    obj[key] = parseValue(parser);
+    if (parser.maybe('COMMA')) {
+      if (parser.maybe('RBRACE')) break;
+      continue;
+    }
+    parser.take('RBRACE');
+    break;
+  }
+  return obj;
+}
+
+function parseArray(parser) {
+  parser.take('LBRACKET');
+  const items = [];
+  if (parser.maybe('RBRACKET')) return items;
+  while (true) {
+    items.push(parseValue(parser));
+    if (parser.maybe('COMMA')) {
+      if (parser.maybe('RBRACKET')) break;
+      continue;
+    }
+    parser.take('RBRACKET');
+    break;
+  }
+  return items;
+}
+
+function formatError(src, start, end, message) {
+  const { line, column, lineText } = locate(src, start);
+  const spanBase = Math.max(1, end - start);
+  const span = Math.max(2, Math.min(12, spanBase));
+  const caret = ' '.repeat(Math.max(0, column - 1)) + '^'.repeat(span);
+  const err = new Error(`${message} at ${line}:${column}\n${lineText}\n${caret}`);
+  err.line = line;
+  err.column = column;
+  return err;
+}
+
+function locate(src, index) {
+  const len = src.length;
+  const clamped = Math.max(0, Math.min(index, len));
+  let line = 1;
+  let lineStart = 0;
+  for (let i = 0; i < clamped; i++) {
+    if (src[i] === '\n') {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  const column = clamped - lineStart + 1;
+  const lineEndIdx = src.indexOf('\n', lineStart);
+  const lineEnd = lineEndIdx === -1 ? len : lineEndIdx;
+  const lineText = src.slice(lineStart, lineEnd);
+  if (index > len && src.length > 0 && src[len - 1] === '\n') {
+    return { line: line + 1, column: 1, lineText: '' };
+  }
+  return { line, column, lineText };
 }

--- a/tests/dsl-fmt.test.mjs
+++ b/tests/dsl-fmt.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const run = promisify(execFile);
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+function cli(...args) {
+  return run(process.execPath, ['packages/tf-compose/bin/tf.mjs', ...args], { cwd: repoRoot });
+}
+
+test('fmt normalizes and sorts arguments', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'dsl-fmt-'));
+  const file = join(dir, 'flow.tf');
+  const messy = 'seq{write-object(flag=true ,uri="res://kv/a", key="x", arr=[1,2,], meta={retry:{count:2,}}, note=fast);write-object(key="y",uri="res://kv/a") }';
+  await writeFile(file, messy, 'utf8');
+  const { stdout } = await cli('fmt', file);
+  const expected = `seq{\n  write-object(arr=[1, 2], flag=true, key="x", meta={retry:{count:2}}, note="fast", uri="res://kv/a");\n  write-object(key="y", uri="res://kv/a")\n}\n`;
+  assert.equal(stdout, expected);
+});
+
+test('fmt is idempotent with --write', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'dsl-fmt-idem-'));
+  const file = join(dir, 'flow.tf');
+  const messy = 'seq{write-object(key="x", uri="res://kv/a" )}';
+  await writeFile(file, messy, 'utf8');
+  await cli('fmt', file, '--write');
+  const once = await readFile(file, 'utf8');
+  await cli('fmt', file, '-w');
+  const twice = await readFile(file, 'utf8');
+  assert.equal(once, twice);
+});

--- a/tests/dsl-literals.test.mjs
+++ b/tests/dsl-literals.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+
+test('parses numbers, booleans, null, arrays, and objects', () => {
+  const src = `seq{
+    write-object(
+      arr=[1, 2.5, -0.25, true, false, null, {inner:true}],
+      flag=true,
+      meta={retry:{count:2}, "retry-mode": "fast"},
+      name="alpha",
+      nested={child:{count:2}},
+      note=fast,
+      value=-42
+    )
+  }`;
+  const ir = parseDSL(src);
+  assert.equal(ir.node, 'Seq');
+  assert.equal(ir.children.length, 1);
+  const prim = ir.children[0];
+  assert.equal(prim.node, 'Prim');
+  assert.equal(prim.args.flag, true);
+  assert.equal(prim.args.value, -42);
+  assert.deepEqual(prim.args.arr, [1, 2.5, -0.25, true, false, null, { inner: true }]);
+  assert.deepEqual(prim.args.meta, { retry: { count: 2 }, 'retry-mode': 'fast' });
+  assert.deepEqual(prim.args.nested, { child: { count: 2 } });
+  assert.equal(prim.args.note, 'fast');
+  assert.equal(prim.args.name, 'alpha');
+});
+
+const failureCases = [
+  {
+    name: 'extra comma in array',
+    src: 'seq{ write-object(arr=[1,,2]) }',
+  },
+  {
+    name: 'unterminated string',
+    src: 'seq{ write-object(name="alpha) }',
+  },
+  {
+    name: 'unclosed object',
+    src: 'seq{ write-object(meta={retry:{count:2}) }',
+  },
+];
+
+for (const { name, src } of failureCases) {
+  test(`parse failure emits location for ${name}`, () => {
+    assert.throws(() => parseDSL(src), (err) => {
+      assert.match(err.message, /at \d+:\d+/);
+      assert.match(err.message, /\n.*\n\s*\^{2,}/);
+      return true;
+    });
+  });
+}

--- a/tests/dsl-show.test.mjs
+++ b/tests/dsl-show.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const run = promisify(execFile);
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+function cli(...args) {
+  return run(process.execPath, ['packages/tf-compose/bin/tf.mjs', ...args], { cwd: repoRoot });
+}
+
+test('show prints a readable tree', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'dsl-show-'));
+  const file = join(dir, 'flow.tf');
+  const src = 'seq{ write-object(uri="res://kv/x", key="a"); write-object(uri="res://kv/x", key="b") }';
+  await writeFile(file, src, 'utf8');
+  const { stdout } = await cli('show', file);
+  const lines = stdout.trim().split('\n');
+  assert.ok(lines[0].startsWith('Seq'));
+  assert.ok(lines[1].startsWith('  Prim: write-object {key:"a", uri:"res://kv/x"}'));
+  assert.ok(lines[2].startsWith('  Prim: write-object {key:"b", uri:"res://kv/x"}'));
+});


### PR DESCRIPTION
## Summary
- extend the DSL tokenizer/parser to handle numbers, booleans, null, arrays, and objects while reporting errors with line:col carets
- add `fmt` and `show` subcommands that format flows deterministically and print IR trees without mutating files by default
- cover the new behavior with parser/CLI tests and refresh the DSL docs with literal, fmt, show, and error guidance

## Testing
- `node --test tests/dsl-literals.test.mjs`
- `node --test tests/dsl-fmt.test.mjs`
- `node --test tests/dsl-show.test.mjs`
- `pnpm -w -r test` *(fails: existing workspace packages currently report failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3977ecc48320a7aae27ca5ad0a12