### PR TITLE
feat: extend DSL literals and add fmt/show tooling

### DIFF
--- a/docs/l0-dsl.md
+++ b/docs/l0-dsl.md
@@ -14,6 +14,31 @@ Examples:
   par{ a(); b(x=1); c() }
 ```
 
+## Literals
+
+Arguments accept rich literal forms in addition to bare identifiers:
+
+* Numbers with optional leading `-`: `-42`, `3.14`
+* Booleans: `true`, `false`
+* `null`
+* Arrays with trailing commas allowed on input: `[1, "two", true, null, -0.5]`
+* Objects with string or identifier keys: `{name:"alice", retry:{count:2}}`
+
+Nested combinations are supported, e.g.:
+
+```
+write-object(meta={retry:{count:2, windows:[1,2,3]}}, tags=[true,false])
+```
+
+## Tooling
+
+The CLI includes helpers for working with DSL flows:
+
+* `tf fmt flow.tf` reprints the flow using a canonical layout. Add `--write`/`-w` to update the file in-place. The formatter is idempotent and sorts argument keys, object members, and normalizes commas/semicolons.
+* `tf show flow.tf` prints a tree representation of the parsed IR for quick inspection.
+
+Parse errors report a `line:col` location with a short caret span to highlight the offending range, making it easier to pinpoint syntax issues.
+
 The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws.
 It collapses idempotent primitives, eliminates declared inverse pairs, and swaps commute-with-pure primitives across adjacent pure nodes.
 Normalization never moves steps across `Region{}` or `Par{}` boundaries, so localized effects stay fenced.

--- a/docs/l0-dsl.md
+++ b/docs/l0-dsl.md
@@ -37,6 +37,8 @@ The CLI includes helpers for working with DSL flows:
 * `tf fmt flow.tf` reprints the flow using a canonical layout. Add `--write`/`-w` to update the file in-place. The formatter is idempotent and sorts argument keys, object members, and normalizes commas/semicolons.
 * `tf show flow.tf` prints a tree representation of the parsed IR for quick inspection.
 
+The formatter quotes object keys that aren’t identifiers (such as keys with spaces or numeric names) and always produces a stable, idempotent layout.
+
 Parse errors report a `line:col` location with a short caret span to highlight the offending range, making it easier to pinpoint syntax issues.
 
 The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws.

--- a/packages/tf-compose/bin/tf.mjs
+++ b/packages/tf-compose/bin/tf.mjs
@@ -18,116 +18,130 @@ async function loadCatalog() {
   }
 }
 
-const rawArgs = process.argv.slice(2);
-const args = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs;
+async function run() {
+  const rawArgs = process.argv.slice(2);
+  const args = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs;
 
-function arg(k) { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : null; }
+  function arg(k) { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : null; }
 
-const cmd = args[0];
-if (!cmd || ['parse', 'check', 'canon', 'emit', 'manifest', 'fmt', 'show'].indexOf(cmd) < 0) {
+  const cmd = args[0];
+  if (!cmd || ['parse', 'check', 'canon', 'emit', 'manifest', 'fmt', 'show'].indexOf(cmd) < 0) {
+    console.error('Usage: tf <parse|check|canon|emit|manifest|fmt|show> <flow.tf> [--out path] [--lang ts|rs] [--write|-w]');
+    process.exit(2);
+  }
+  const optionKeys = new Set(['--out', '-o', '--lang']);
+  let file = null;
+  for (let i = 1; i < args.length; i++) {
+    const token = args[i];
+    if (optionKeys.has(token)) { i++; continue; }
+    if (token === '--') continue;
+    if (token.startsWith('-')) continue;
+    file = token;
+    break;
+  }
+  if (!file) {
+    console.error('Missing flow path.');
+    process.exit(2);
+  }
+  const out = arg('-o') || arg('--out');
+
+  const src = await readFile(file, 'utf8');
+  const ir = parseDSL(src);
+
+  if (cmd === 'fmt') {
+    const write = args.includes('-w') || args.includes('--write');
+    const formatted = formatDSL(ir);
+    const payload = formatted.endsWith('\n') ? formatted : `${formatted}\n`;
+    if (write) {
+      await writeFile(file, payload, 'utf8');
+    } else {
+      process.stdout.write(payload);
+    }
+    process.exit(0);
+  }
+
+  if (cmd === 'show') {
+    const tree = renderIRTree(ir);
+    const payload = tree.length > 0 ? `${tree}\n` : '\n';
+    process.stdout.write(payload);
+    process.exit(0);
+  }
+
+  const cat = await loadCatalog();
+
+  if (cmd === 'parse') {
+    const s = canonicalize(ir) + '\n';
+    if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, s, 'utf8'); }
+    else process.stdout.write(s);
+    process.exit(0);
+  }
+
+  if (cmd === 'check') {
+    const verdict = checkIR(ir, cat);
+
+    let protectedList = [];
+    try {
+      const p = JSON.parse(await readFile('packages/tf-l0-spec/spec/protected.json', 'utf8'));
+      protectedList = p.protected_keywords || [];
+    } catch { }
+    const regionVerdict = checkRegions(ir, cat, protectedList);
+
+    const ok = Boolean(verdict.ok && regionVerdict.ok);
+    const reasons = []
+      .concat(verdict.reasons || [])
+      .concat(regionVerdict.reasons || []);
+
+    const payload = JSON.stringify({ ok, effects: verdict.effects || [], reasons }, null, 2) + '\n';
+    if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, payload, 'utf8'); }
+    else process.stdout.write(payload);
+    process.exit(ok ? 0 : 1);
+  }
+
+  if (cmd === 'canon') {
+    const laws = await readFile('packages/tf-l0-spec/spec/laws.json', 'utf8').then(JSON.parse).catch(() => ({ laws: [] }));
+    const norm = canon(ir, laws);
+    const payload = canonicalize(norm) + '\n';
+    if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, payload, 'utf8'); }
+    else process.stdout.write(payload);
+    process.exit(0);
+  }
+
+  if (cmd === 'manifest') {
+    const verdict = checkIR(ir, cat);
+    const mani = manifestFromVerdict(verdict);
+    const payload = JSON.stringify(mani, null, 2) + '\n';
+    if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, payload, 'utf8'); }
+    else process.stdout.write(payload);
+    process.exit(0);
+  }
+
+  if (cmd === 'emit') {
+    const lang = arg('--lang') || 'ts';
+    const outDir = out || `out/0.4/codegen-${lang}/${basename(file, '.tf')}`;
+    await mkdir(outDir, { recursive: true });
+    if (lang === 'ts') {
+      const gen = await import('../../tf-l0-codegen-ts/scripts/generate.mjs');
+      await gen.generate(ir, { outDir });
+    } else if (lang === 'rs') {
+      const gen = await import('../../tf-l0-codegen-rs/scripts/generate.mjs');
+      await gen.generate(ir, { outDir });
+    } else {
+      console.error('Unknown language:', lang);
+      process.exit(2);
+    }
+    console.log('Emitted', lang, 'to', outDir);
+    process.exit(0);
+  }
+
   console.error('Usage: tf <parse|check|canon|emit|manifest|fmt|show> <flow.tf> [--out path] [--lang ts|rs] [--write|-w]');
   process.exit(2);
 }
-const optionKeys = new Set(['--out', '-o', '--lang']);
-let file = null;
-for (let i = 1; i < args.length; i++) {
-  const token = args[i];
-  if (optionKeys.has(token)) { i++; continue; }
-  if (token === '--') continue;
-  if (token.startsWith('-')) continue;
-  file = token;
-  break;
-}
-if (!file) {
-  console.error('Missing flow path.');
-  process.exit(2);
-}
-const out = arg('-o') || arg('--out');
 
-const src = await readFile(file, 'utf8');
-const ir = parseDSL(src);
-
-if (cmd === 'fmt') {
-  const write = args.includes('-w') || args.includes('--write');
-  const formatted = formatDSL(ir);
-  const payload = formatted.endsWith('\n') ? formatted : `${formatted}\n`;
-  if (write) {
-    await writeFile(file, payload, 'utf8');
+run().catch((err) => {
+  if (err && typeof err.message === 'string') {
+    console.error(err.message);
   } else {
-    process.stdout.write(payload);
+    console.error(err);
   }
-  process.exit(0);
-}
-
-if (cmd === 'show') {
-  const tree = renderIRTree(ir);
-  const payload = tree.length > 0 ? `${tree}\n` : '\n';
-  process.stdout.write(payload);
-  process.exit(0);
-}
-
-const cat = await loadCatalog();
-
-if (cmd === 'parse') {
-  const s = canonicalize(ir) + '\n';
-  if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, s, 'utf8'); }
-  else process.stdout.write(s);
-  process.exit(0);
-}
-
-if (cmd === 'check') {
-  const verdict = checkIR(ir, cat);
-
-  let protectedList = [];
-  try {
-    const p = JSON.parse(await readFile('packages/tf-l0-spec/spec/protected.json', 'utf8'));
-    protectedList = p.protected_keywords || [];
-  } catch { }
-  const regionVerdict = checkRegions(ir, cat, protectedList);
-
-  const ok = Boolean(verdict.ok && regionVerdict.ok);
-  const reasons = []
-    .concat(verdict.reasons || [])
-    .concat(regionVerdict.reasons || []);
-
-  const payload = JSON.stringify({ ok, effects: verdict.effects || [], reasons }, null, 2) + '\n';
-  if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, payload, 'utf8'); }
-  else process.stdout.write(payload);
-  process.exit(ok ? 0 : 1);
-}
-
-if (cmd === 'canon') {
-  const laws = await readFile('packages/tf-l0-spec/spec/laws.json', 'utf8').then(JSON.parse).catch(() => ({ laws: [] }));
-  const norm = canon(ir, laws);
-  const payload = canonicalize(norm) + '\n';
-  if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, payload, 'utf8'); }
-  else process.stdout.write(payload);
-  process.exit(0);
-}
-
-if (cmd === 'manifest') {
-  const verdict = checkIR(ir, cat);
-  const mani = manifestFromVerdict(verdict);
-  const payload = JSON.stringify(mani, null, 2) + '\n';
-  if (out) { await mkdir(dirname(out), { recursive: true }); await writeFile(out, payload, 'utf8'); }
-  else process.stdout.write(payload);
-  process.exit(0);
-}
-
-if (cmd === 'emit') {
-  const lang = arg('--lang') || 'ts';
-  const outDir = out || `out/0.4/codegen-${lang}/${basename(file, '.tf')}`;
-  await mkdir(outDir, { recursive: true });
-  if (lang === 'ts') {
-    const gen = await import('../../tf-l0-codegen-ts/scripts/generate.mjs');
-    await gen.generate(ir, { outDir });
-  } else if (lang === 'rs') {
-    const gen = await import('../../tf-l0-codegen-rs/scripts/generate.mjs');
-    await gen.generate(ir, { outDir });
-  } else {
-    console.error('Unknown language:', lang);
-    process.exit(2);
-  }
-  console.log('Emitted', lang, 'to', outDir);
-  process.exit(0);
-}
+  process.exit(1);
+});

--- a/packages/tf-compose/src/format.mjs
+++ b/packages/tf-compose/src/format.mjs
@@ -1,0 +1,198 @@
+const INDENT = '  ';
+const IDENT_KEY_RE = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
+
+export function formatDSL(ir) {
+  const lines = formatNode(ir, 0);
+  return lines.join('\n');
+}
+
+export function renderIRTree(ir) {
+  return renderTreeLines(ir, 0).join('\n');
+}
+
+function formatNode(node, level) {
+  if (!node || typeof node !== 'object') {
+    return [`${indent(level)}${String(node)}`];
+  }
+
+  if (node.node === 'Prim') {
+    return [`${indent(level)}${formatPrim(node)}`];
+  }
+
+  if (node.node === 'Seq' && node.syntax === 'block') {
+    return formatBlock('seq', node.children ?? [], level);
+  }
+
+  if (node.node === 'Par') {
+    return formatBlock('par', node.children ?? [], level);
+  }
+
+  if (node.node === 'Region') {
+    return formatRegion(node, level);
+  }
+
+  if (node.node === 'Seq') {
+    return formatPipeline(node, level);
+  }
+
+  if (Array.isArray(node)) {
+    return [`${indent(level)}${formatLiteral(node)}`];
+  }
+
+  return [`${indent(level)}${String(node)}`];
+}
+
+function formatPrim(node) {
+  const name = typeof node.prim === 'string' ? node.prim : '';
+  const args = node.args && typeof node.args === 'object' ? node.args : {};
+  const keys = Object.keys(args);
+  if (keys.length === 0) return name;
+  const parts = keys.sort().map((key) => `${key}=${formatLiteral(args[key])}`);
+  return `${name}(${parts.join(', ')})`;
+}
+
+function formatBlock(name, children, level) {
+  const lines = [`${indent(level)}${name}{`];
+  const count = children.length;
+  children.forEach((child, index) => {
+    const childLines = formatNode(child, level + 1);
+    if (index < count - 1) {
+      childLines[childLines.length - 1] = `${childLines[childLines.length - 1]};`;
+    }
+    lines.push(...childLines);
+  });
+  lines.push(`${indent(level)}}`);
+  return lines;
+}
+
+function formatRegion(node, level) {
+  const name = typeof node.kind === 'string' ? node.kind.toLowerCase() : 'region';
+  const attrs = node.attrs && typeof node.attrs === 'object' ? node.attrs : {};
+  const keys = Object.keys(attrs).sort();
+  const attrParts = keys.map((key) => `${key}=${formatLiteral(attrs[key])}`);
+  const header = attrParts.length > 0
+    ? `${indent(level)}${name}(${attrParts.join(', ')}){`
+    : `${indent(level)}${name}{`;
+  const lines = [header];
+  const children = node.children ?? [];
+  children.forEach((child, index) => {
+    const childLines = formatNode(child, level + 1);
+    if (index < children.length - 1) {
+      childLines[childLines.length - 1] = `${childLines[childLines.length - 1]};`;
+    }
+    lines.push(...childLines);
+  });
+  lines.push(`${indent(level)}}`);
+  return lines;
+}
+
+function formatPipeline(node, level) {
+  const children = node.children ?? [];
+  if (children.length === 0) {
+    return [`${indent(level)}`];
+  }
+  const parts = children.map((child) => renderInline(child));
+  const joined = parts.join(' |> ');
+  return indentMultiline(joined, level);
+}
+
+function renderInline(node) {
+  if (!node || typeof node !== 'object') {
+    return String(node);
+  }
+  if (node.node === 'Prim') {
+    return formatPrim(node);
+  }
+  return formatNode(node, 0).join('\n');
+}
+
+function indentMultiline(text, level) {
+  const pad = indent(level);
+  return text.split('\n').map((line) => `${pad}${line}`);
+}
+
+function indent(level) {
+  return INDENT.repeat(level);
+}
+
+function renderTreeLines(node, level) {
+  if (!node || typeof node !== 'object') {
+    return [`${indent(level)}${String(node)}`];
+  }
+
+  if (node.node === 'Prim') {
+    const args = formatArgsForShow(node.args);
+    const suffix = args ? ` ${args}` : '';
+    return [`${indent(level)}Prim: ${node.prim}${suffix}`];
+  }
+
+  if (node.node === 'Seq') {
+    const lines = [`${indent(level)}Seq`];
+    for (const child of node.children ?? []) {
+      lines.push(...renderTreeLines(child, level + 1));
+    }
+    return lines;
+  }
+
+  if (node.node === 'Par') {
+    const lines = [`${indent(level)}Par`];
+    for (const child of node.children ?? []) {
+      lines.push(...renderTreeLines(child, level + 1));
+    }
+    return lines;
+  }
+
+  if (node.node === 'Region') {
+    const attrs = formatArgsForShow(node.attrs);
+    const suffix = attrs ? ` ${attrs}` : '';
+    const lines = [`${indent(level)}Region: ${node.kind}${suffix}`];
+    for (const child of node.children ?? []) {
+      lines.push(...renderTreeLines(child, level + 1));
+    }
+    return lines;
+  }
+
+  return [`${indent(level)}${String(node.node ?? node)}`];
+}
+
+function formatArgsForShow(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return '';
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return '';
+  const parts = keys.sort().map((key) => `${key}:${formatLiteral(obj[key])}`);
+  return `{${parts.join(', ')}}`;
+}
+
+function formatLiteral(value) {
+  if (value === null) return 'null';
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : 'null';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'string') {
+    return `"${escapeString(value)}"`;
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => formatLiteral(item)).join(', ')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    const parts = keys.map((key) => {
+      const keyText = IDENT_KEY_RE.test(key) ? key : formatLiteral(String(key));
+      return `${keyText}:${formatLiteral(value[key])}`;
+    });
+    return `{${parts.join(', ')}}`;
+  }
+  return `"${escapeString(String(value))}"`;
+}
+
+function escapeString(value) {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}

--- a/packages/tf-compose/src/parser.mjs
+++ b/packages/tf-compose/src/parser.mjs
@@ -414,7 +414,7 @@ function parseArray(tokens) {
 
 function parseObject(tokens) {
   take(tokens, 'LBRACE');
-  const obj = {};
+  const obj = Object.create(null);
   if (maybe(tokens, 'RBRACE')) return obj;
   while (true) {
     const keyTok = peek(tokens);
@@ -423,8 +423,10 @@ function parseObject(tokens) {
       key = take(tokens, 'STRING').v;
     } else if (keyTok.t === 'IDENT') {
       key = take(tokens, 'IDENT').v;
+    } else if (keyTok.t === 'NUMBER') {
+      key = String(take(tokens, 'NUMBER').v);
     } else {
-      throw syntaxError(tokens, keyTok, 'Expected string or identifier key');
+      throw syntaxError(tokens, keyTok, 'Expected string, identifier, or number key');
     }
     take(tokens, 'COLON');
     obj[key] = parseValue(tokens);

--- a/packages/tf-compose/src/parser.mjs
+++ b/packages/tf-compose/src/parser.mjs
@@ -6,101 +6,434 @@ export function parseDSL(src) {
   return seq;
 }
 
-function tokenize(s) {
-  const out = []; let i=0;
-  while (i<s.length) {
-    const c=s[i];
-    if (/\s/.test(c)) { i++; continue; }
-    if (s.startsWith('|>', i)) { out.push({t:'PIPE'}); i+=2; continue; }
-    if (s.startsWith('par{', i)) { out.push({t:'PAR_OPEN'}); i+=4; continue; }
-    if (s.startsWith('seq{', i)) { out.push({t:'SEQ_OPEN'}); i+=4; continue; }
-    if (s.startsWith('authorize', i) && ['{','('].includes(s[i+9])) { out.push({t:'REGION_AUTH'}); i+=9; continue; }
-    if (s.startsWith('txn', i) && ['{','('].includes(s[i+3])) { out.push({t:'REGION_TXN'}); i+=3; continue; }
-    if (c==='{' ) { out.push({t:'LBRACE'}); i++; continue; }
-    if (c==='}') { out.push({t:'RBRACE'}); i++; continue; }
-    if (c==='(' ) { out.push({t:'LPAREN'}); i++; continue; }
-    if (c===')' ) { out.push({t:'RPAREN'}); i++; continue; }
-    if (c===';') { out.push({t:'SEMI'}); i++; continue; }
-    if (c===',') { out.push({t:'COMMA'}); i++; continue; }
-    if (c==='=') { out.push({t:'EQ'}); i++; continue; }
-    if (c==='"' || c==="'" ) {
-      const q=c; i++; let buf=''; while (i<s.length && s[i]!==q){ if(s[i]=='\\'){ buf+=s[i+1]; i+=2; } else { buf+=s[i++]; } }
-      i++; out.push({t:'STRING', v:buf}); continue;
-    }
-    if (/[0-9]/.test(c)) { let j=i; while (j<s.length && /[0-9]/.test(s[j])) j++; out.push({t:'NUMBER', v:Number(s.slice(i,j))}); i=j; continue; }
-    let j=i; while (j<s.length && /[A-Za-z0-9_\-\.]/.test(s[j])) j++;
-    out.push({t:'IDENT', v:s.slice(i,j)}); i=j;
+function tokenize(src) {
+  const tokens = [];
+  let i = 0;
+  let line = 1;
+  let col = 1;
+
+  function currentPos() {
+    return { index: i, line, col };
   }
-  return {i:0, list:out};
+
+  function advanceChar() {
+    const ch = src[i++];
+    if (ch === '\n') {
+      line += 1;
+      col = 1;
+    } else if (ch === '\r') {
+      if (src[i] === '\n') {
+        i += 1;
+      }
+      line += 1;
+      col = 1;
+    } else {
+      col += 1;
+    }
+    return ch;
+  }
+
+  function makeToken(t, v, start) {
+    return { t, v, start, end: currentPos() };
+  }
+
+  function throwError(start, message, span = 2) {
+    throw syntaxErrorFromPositions(src, start, currentPos(), message, span);
+  }
+
+  function consumeWord(word) {
+    for (const ch of word) {
+      if (src[i] !== ch) return false;
+      advanceChar();
+    }
+    return true;
+  }
+
+  function consumeWhile(regex) {
+    let consumed = '';
+    while (i < src.length && regex.test(src[i])) {
+      consumed += advanceChar();
+    }
+    return consumed;
+  }
+
+  while (i < src.length) {
+    const ch = src[i];
+    if (/\s/.test(ch)) {
+      advanceChar();
+      continue;
+    }
+
+    const start = currentPos();
+
+    if (src.startsWith('|>', i)) {
+      advanceChar();
+      advanceChar();
+      tokens.push(makeToken('PIPE', null, start));
+      continue;
+    }
+
+    if (src.startsWith('par{', i)) {
+      consumeWord('par{');
+      tokens.push(makeToken('PAR_OPEN', null, start));
+      continue;
+    }
+
+    if (src.startsWith('seq{', i)) {
+      consumeWord('seq{');
+      tokens.push(makeToken('SEQ_OPEN', null, start));
+      continue;
+    }
+
+    if (src.startsWith('authorize', i)) {
+      const next = src[i + 9] ?? '';
+      if (next === '{' || next === '(') {
+        consumeWord('authorize');
+        tokens.push(makeToken('REGION_AUTH', null, start));
+        continue;
+      }
+    }
+
+    if (src.startsWith('txn', i)) {
+      const next = src[i + 3] ?? '';
+      if (next === '{' || next === '(') {
+        consumeWord('txn');
+        tokens.push(makeToken('REGION_TXN', null, start));
+        continue;
+      }
+    }
+
+    if (ch === '{') {
+      advanceChar();
+      tokens.push(makeToken('LBRACE', null, start));
+      continue;
+    }
+
+    if (ch === '}') {
+      advanceChar();
+      tokens.push(makeToken('RBRACE', null, start));
+      continue;
+    }
+
+    if (ch === '[') {
+      advanceChar();
+      tokens.push(makeToken('LBRACKET', null, start));
+      continue;
+    }
+
+    if (ch === ']') {
+      advanceChar();
+      tokens.push(makeToken('RBRACKET', null, start));
+      continue;
+    }
+
+    if (ch === '(') {
+      advanceChar();
+      tokens.push(makeToken('LPAREN', null, start));
+      continue;
+    }
+
+    if (ch === ')') {
+      advanceChar();
+      tokens.push(makeToken('RPAREN', null, start));
+      continue;
+    }
+
+    if (ch === ';') {
+      advanceChar();
+      tokens.push(makeToken('SEMI', null, start));
+      continue;
+    }
+
+    if (ch === ',') {
+      advanceChar();
+      tokens.push(makeToken('COMMA', null, start));
+      continue;
+    }
+
+    if (ch === '=') {
+      advanceChar();
+      tokens.push(makeToken('EQ', null, start));
+      continue;
+    }
+
+    if (ch === ':') {
+      advanceChar();
+      tokens.push(makeToken('COLON', null, start));
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const quote = advanceChar();
+      let buf = '';
+      let closed = false;
+      while (i < src.length) {
+        const nextCh = advanceChar();
+        if (nextCh === quote) {
+          closed = true;
+          break;
+        }
+        if (nextCh === '\\') {
+          if (i >= src.length) {
+            throwError(start, 'Unterminated string literal');
+          }
+          const escaped = advanceChar();
+          buf += escaped;
+          continue;
+        }
+        buf += nextCh;
+      }
+      if (!closed) {
+        throwError(start, 'Unterminated string literal');
+      }
+      tokens.push(makeToken('STRING', buf, start));
+      continue;
+    }
+
+    const isNumberStart = (ch === '-' && /[0-9]/.test(src[i + 1] ?? '')) || /[0-9]/.test(ch);
+    if (isNumberStart) {
+      let raw = '';
+      if (ch === '-') {
+        raw += advanceChar();
+      }
+      const digits = consumeWhile(/[0-9]/);
+      raw += digits;
+      if (!digits) {
+        throwError(start, 'Invalid number literal');
+      }
+      if (src[i] === '.') {
+        raw += advanceChar();
+        const frac = consumeWhile(/[0-9]/);
+        if (!frac) {
+          throwError(start, 'Invalid number literal');
+        }
+        raw += frac;
+      }
+      const value = Number(raw);
+      if (!Number.isFinite(value)) {
+        throwError(start, 'Invalid number literal');
+      }
+      tokens.push(makeToken('NUMBER', value, start));
+      continue;
+    }
+
+    let ident = '';
+    while (i < src.length && /[A-Za-z0-9_\-\.]/.test(src[i])) {
+      ident += advanceChar();
+    }
+    if (ident) {
+      tokens.push(makeToken('IDENT', ident, start));
+      continue;
+    }
+
+    throwError(start, `Unexpected character '${ch}'`);
+  }
+
+  return { i: 0, list: tokens, src, endPos: { index: i, line, col } };
 }
 
-function peek(t){ return t.list[t.i]||{t:'EOF'}; }
-function take(t, kind){ const p=peek(t); if (p.t!==kind) throw new Error(`Expected ${kind}, got ${p.t}`); t.i++; return p; }
-function maybe(t, kind){ const p=peek(t); if (p.t===kind){ t.i++; return true; } return false; }
-function expectEOF(t){ if (peek(t).t!=='EOF') throw new Error('Trailing tokens'); }
-
-function parseSeq(t){
-  const parts=[parseStep(t)];
-  while (maybe(t,'PIPE')) parts.push(parseStep(t));
-  return parts.length===1 ? parts[0] : { node:'Seq', children: parts };
+function peek(tokens) {
+  return tokens.list[tokens.i] || { t: 'EOF', start: tokens.endPos, end: tokens.endPos };
 }
 
-function parseBlock(t, node){
-  const kids=[];
-  while (true){
-    kids.push(parseStep(t));
-    if (maybe(t,'SEMI')) continue;
-    take(t,'RBRACE'); break;
+function take(tokens, kind) {
+  const token = peek(tokens);
+  if (token.t !== kind) {
+    throw syntaxError(tokens, token, `Expected ${kind}, got ${token.t}`);
+  }
+  tokens.i += 1;
+  return token;
+}
+
+function maybe(tokens, kind) {
+  const token = peek(tokens);
+  if (token.t === kind) {
+    tokens.i += 1;
+    return true;
+  }
+  return false;
+}
+
+function expectEOF(tokens) {
+  if (peek(tokens).t !== 'EOF') {
+    throw syntaxError(tokens, peek(tokens), 'Trailing tokens');
+  }
+}
+
+function syntaxError(tokens, token, message, span) {
+  const start = token.start || tokens.endPos;
+  const end = token.end || start;
+  const err = new Error(formatErrorMessage(tokens.src, start, end, message, span));
+  err.loc = { line: start.line, col: start.col };
+  return err;
+}
+
+function syntaxErrorFromPositions(src, start, end, message, span) {
+  return new Error(formatErrorMessage(src, start, end, message, span));
+}
+
+function formatErrorMessage(src, start, end, message, spanOverride) {
+  const line = start.line ?? 1;
+  const col = start.col ?? 1;
+  const index = start.index ?? 0;
+  const span = spanOverride ?? Math.max(1, (end?.index ?? index + 1) - index);
+  const caretCount = Math.min(12, Math.max(2, span));
+
+  let lineStart = index;
+  while (lineStart > 0 && src[lineStart - 1] !== '\n') {
+    lineStart -= 1;
+  }
+  let lineEnd = index;
+  while (lineEnd < src.length && src[lineEnd] !== '\n') {
+    lineEnd += 1;
+  }
+  const lineText = src.slice(lineStart, lineEnd);
+  const caretOffset = Math.max(0, index - lineStart);
+  const caretLine = `${' '.repeat(caretOffset)}${'^'.repeat(caretCount)}`;
+
+  return `Parse error at ${line}:${col}: ${message}\n${lineText}\n${caretLine}`;
+}
+
+function parseSeq(tokens) {
+  const parts = [parseStep(tokens)];
+  while (maybe(tokens, 'PIPE')) {
+    parts.push(parseStep(tokens));
+  }
+  return parts.length === 1 ? parts[0] : { node: 'Seq', children: parts };
+}
+
+function parseBlock(tokens, node) {
+  const kids = [];
+  if (maybe(tokens, 'RBRACE')) {
+    node.children = kids;
+    return node;
+  }
+  while (true) {
+    kids.push(parseStep(tokens));
+    if (maybe(tokens, 'SEMI')) {
+      if (maybe(tokens, 'RBRACE')) break;
+      continue;
+    }
+    take(tokens, 'RBRACE');
+    break;
   }
   node.children = kids;
   return node;
 }
 
-function parseRegion(t, kind){
-  // optional attrs: e.g., authorize(region="us", scope="kms.sign"){ ... }
-  let attrs={};
-  if (maybe(t,'LPAREN')) {
-    if (!maybe(t,'RPAREN')) {
-      while (true){
-        const key = take(t,'IDENT').v;
-        take(t,'EQ');
-        const vTok=peek(t);
-        let val;
-        if (vTok.t==='STRING' || vTok.t==='NUMBER'){ take(t,vTok.t); val=vTok.v; }
-        else if (vTok.t==='IDENT'){ take(t,'IDENT'); val=vTok.v; }
-        else throw new Error('Bad region attr value');
-        attrs[key]=val;
-        if (maybe(t,'COMMA')) continue;
-        take(t,'RPAREN'); break;
+function parseRegion(tokens, kind) {
+  const attrs = {};
+  if (maybe(tokens, 'LPAREN')) {
+    if (!maybe(tokens, 'RPAREN')) {
+      while (true) {
+        const key = take(tokens, 'IDENT').v;
+        take(tokens, 'EQ');
+        attrs[key] = parseValue(tokens);
+        if (maybe(tokens, 'COMMA')) {
+          if (maybe(tokens, 'RPAREN')) break;
+          continue;
+        }
+        take(tokens, 'RPAREN');
+        break;
       }
     }
   }
-  take(t,'LBRACE');
-  return parseBlock(t, { node:'Region', kind, attrs, children: [] });
+  take(tokens, 'LBRACE');
+  return parseBlock(tokens, { node: 'Region', kind, attrs, children: [] });
 }
 
-function parseStep(t){
-  if (maybe(t,'PAR_OPEN')) return parseBlock(t, { node:'Par', children: [] });
-  if (maybe(t,'SEQ_OPEN')) return parseBlock(t, { node:'Seq', children: [] });
-  if (maybe(t,'REGION_AUTH')) return parseRegion(t, 'Authorize');
-  if (maybe(t,'REGION_TXN')) return parseRegion(t, 'Transaction');
-  const id = take(t,'IDENT').v;
-  let args={};
-  if (maybe(t,'LPAREN')) {
-    if (!maybe(t,'RPAREN')) {
-      while (true){
-        const key = take(t,'IDENT').v;
-        take(t,'EQ');
-        const vTok=peek(t);
-        let val;
-        if (vTok.t==='STRING' || vTok.t==='NUMBER'){ take(t,vTok.t); val=vTok.v; }
-        else if (vTok.t==='IDENT'){ take(t,'IDENT'); val=vTok.v; }
-        else throw new Error('Bad arg value');
-        args[key]=val;
-        if (maybe(t,'COMMA')) continue;
-        take(t,'RPAREN'); break;
-      }
+function parseArgs(tokens) {
+  const args = {};
+  if (!maybe(tokens, 'LPAREN')) return args;
+  if (maybe(tokens, 'RPAREN')) return args;
+  while (true) {
+    const key = take(tokens, 'IDENT').v;
+    take(tokens, 'EQ');
+    args[key] = parseValue(tokens);
+    if (maybe(tokens, 'COMMA')) {
+      if (maybe(tokens, 'RPAREN')) break;
+      continue;
     }
+    take(tokens, 'RPAREN');
+    break;
   }
-  return { node:'Prim', prim: id.toLowerCase(), args };
+  return args;
+}
+
+function parseStep(tokens) {
+  if (maybe(tokens, 'PAR_OPEN')) return parseBlock(tokens, { node: 'Par', children: [] });
+  if (maybe(tokens, 'SEQ_OPEN')) return parseBlock(tokens, { node: 'Seq', syntax: 'block', children: [] });
+  if (maybe(tokens, 'REGION_AUTH')) return parseRegion(tokens, 'Authorize');
+  if (maybe(tokens, 'REGION_TXN')) return parseRegion(tokens, 'Transaction');
+  const id = take(tokens, 'IDENT');
+  const args = parseArgs(tokens);
+  return { node: 'Prim', prim: id.v.toLowerCase(), args };
+}
+
+function parseValue(tokens) {
+  const token = peek(tokens);
+  if (token.t === 'STRING') {
+    tokens.i += 1;
+    return token.v;
+  }
+  if (token.t === 'NUMBER') {
+    tokens.i += 1;
+    return token.v;
+  }
+  if (token.t === 'IDENT') {
+    tokens.i += 1;
+    if (token.v === 'true') return true;
+    if (token.v === 'false') return false;
+    if (token.v === 'null') return null;
+    return token.v;
+  }
+  if (token.t === 'LBRACKET') {
+    return parseArray(tokens);
+  }
+  if (token.t === 'LBRACE') {
+    return parseObject(tokens);
+  }
+  throw syntaxError(tokens, token, 'Unexpected value');
+}
+
+function parseArray(tokens) {
+  take(tokens, 'LBRACKET');
+  const values = [];
+  if (maybe(tokens, 'RBRACKET')) return values;
+  while (true) {
+    values.push(parseValue(tokens));
+    if (maybe(tokens, 'COMMA')) {
+      if (maybe(tokens, 'RBRACKET')) break;
+      continue;
+    }
+    take(tokens, 'RBRACKET');
+    break;
+  }
+  return values;
+}
+
+function parseObject(tokens) {
+  take(tokens, 'LBRACE');
+  const obj = {};
+  if (maybe(tokens, 'RBRACE')) return obj;
+  while (true) {
+    const keyTok = peek(tokens);
+    let key;
+    if (keyTok.t === 'STRING') {
+      key = take(tokens, 'STRING').v;
+    } else if (keyTok.t === 'IDENT') {
+      key = take(tokens, 'IDENT').v;
+    } else {
+      throw syntaxError(tokens, keyTok, 'Expected string or identifier key');
+    }
+    take(tokens, 'COLON');
+    obj[key] = parseValue(tokens);
+    if (maybe(tokens, 'COMMA')) {
+      if (maybe(tokens, 'RBRACE')) break;
+      continue;
+    }
+    take(tokens, 'RBRACE');
+    break;
+  }
+  return obj;
 }

--- a/tests/dsl-fmt.test.mjs
+++ b/tests/dsl-fmt.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const parser = await import('../packages/tf-compose/src/parser.mjs');
+const formatter = await import('../packages/tf-compose/src/format.mjs');
+
+test('fmt produces canonical layout', () => {
+  const messy = 'seq{ write-object(uri="res://kv/x", key="a", meta={retry:{count:2}, mode:"safe"}, tags=[true,false,null]);write-object(uri="res://kv/x", key="b",); authorize(region="us"){ seq{write-object(key="c", value="3");write-object(key="d", value="4",)} }}';
+  const ir = parser.parseDSL(messy);
+  const formatted = formatter.formatDSL(ir);
+  const expected = [
+    'seq{',
+    '  write-object(key="a", meta={mode:"safe", retry:{count:2}}, tags=[true, false, null], uri="res://kv/x");',
+    '  write-object(key="b", uri="res://kv/x");',
+    '  authorize(region="us"){',
+    '    seq{',
+    '      write-object(key="c", value="3");',
+    '      write-object(key="d", value="4")',
+    '    }',
+    '  }',
+    '}'
+  ].join('\n');
+  assert.equal(formatted, expected);
+});
+
+test('fmt is idempotent', () => {
+  const src = 'write-object(key="x", value="1") |> write-object(key="y", value="2")';
+  const ir = parser.parseDSL(src);
+  const once = formatter.formatDSL(ir);
+  const twice = formatter.formatDSL(parser.parseDSL(once));
+  assert.equal(once, twice);
+});

--- a/tests/dsl-fmt.test.mjs
+++ b/tests/dsl-fmt.test.mjs
@@ -5,28 +5,32 @@ const parser = await import('../packages/tf-compose/src/parser.mjs');
 const formatter = await import('../packages/tf-compose/src/format.mjs');
 
 test('fmt produces canonical layout', () => {
-  const messy = 'seq{ write-object(uri="res://kv/x", key="a", meta={retry:{count:2}, mode:"safe"}, tags=[true,false,null]);write-object(uri="res://kv/x", key="b",); authorize(region="us"){ seq{write-object(key="c", value="3");write-object(key="d", value="4",)} }}';
+  const messy = 'seq{ write-object(uri="res://kv/x", key="a", meta={"retry mode":"fast","-x":true,plain:1,"404":"err"}, tags=[true,false,null]);write-object(uri="res://kv/x", key="b",); authorize(region="us"){ seq{write-object(key="c", value="3");write-object(key="d", value="4",)} }}';
   const ir = parser.parseDSL(messy);
   const formatted = formatter.formatDSL(ir);
   const expected = [
     'seq{',
-    '  write-object(key="a", meta={mode:"safe", retry:{count:2}}, tags=[true, false, null], uri="res://kv/x");',
+    '  write-object(key="a", meta={"-x":true, "404":"err", plain:1, "retry mode":"fast"}, tags=[true, false, null], uri="res://kv/x");',
     '  write-object(key="b", uri="res://kv/x");',
     '  authorize(region="us"){',
-    '    seq{',
-    '      write-object(key="c", value="3");',
-    '      write-object(key="d", value="4")',
-    '    }',
-    '  }',
-    '}'
+      '    seq{',
+        '      write-object(key="c", value="3");',
+        '      write-object(key="d", value="4")',
+      '    }',
+      '  }',
+      '}'
   ].join('\n');
   assert.equal(formatted, expected);
+  assert.match(formatted, /"-x":true/);
+  assert.match(formatted, /"404":"err"/);
+  assert.match(formatted, /"retry mode":"fast"/);
 });
 
 test('fmt is idempotent', () => {
-  const src = 'write-object(key="x", value="1") |> write-object(key="y", value="2")';
+  const src = 'seq{write-object(meta={ "retry mode": "fast", "-x":true, plain:1, }, tags=[true,false,null,], uri="res://kv/x", key="a");write-object(key="b", uri="res://kv/x") }';
   const ir = parser.parseDSL(src);
   const once = formatter.formatDSL(ir);
   const twice = formatter.formatDSL(parser.parseDSL(once));
   assert.equal(once, twice);
+  assert.ok(!once.endsWith('\n\n'));
 });

--- a/tests/dsl-literals.test.mjs
+++ b/tests/dsl-literals.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const parser = await import('../packages/tf-compose/src/parser.mjs');
+
+test('parses extended literals', () => {
+  const src = 'write-object(meta={retry:{count:2}, mode:"safe"}, tags=[true,false,null,-3.5], name=foo)';
+  const ir = parser.parseDSL(src);
+  assert.equal(ir.node, 'Prim');
+  assert.equal(ir.prim, 'write-object');
+  assert.deepEqual(ir.args.tags, [true, false, null, -3.5]);
+  assert.deepEqual(ir.args.meta, { mode: 'safe', retry: { count: 2 } });
+  assert.equal(ir.args.name, 'foo');
+});
+
+test('parses nested structures inside args', () => {
+  const src = 'write-object(meta={retry:{count:2, windows:[1,2]}, extra:{enabled:true}})';
+  const ir = parser.parseDSL(src);
+  assert.deepEqual(ir.args.meta.retry, { count: 2, windows: [1, 2] });
+  assert.deepEqual(ir.args.meta.extra, { enabled: true });
+});
+
+test('parse failures include location and caret', () => {
+  const cases = [
+    'write-object(tags=[1,,2])',
+    'write-object(name="unterminated)',
+    'write-object(meta={retry:{count:2})'
+  ];
+
+  for (const src of cases) {
+    assert.throws(() => parser.parseDSL(src), (err) => {
+      assert.match(err.message, /Parse error at \d+:\d+:/);
+      const lines = err.message.split('\n');
+      assert.ok(lines.length >= 3, 'error should include snippet');
+      assert.match(lines[2], /\^{2,12}/);
+      return true;
+    });
+  }
+});

--- a/tests/dsl-literals.test.mjs
+++ b/tests/dsl-literals.test.mjs
@@ -2,29 +2,60 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 const parser = await import('../packages/tf-compose/src/parser.mjs');
+const formatter = await import('../packages/tf-compose/src/format.mjs');
 
 test('parses extended literals', () => {
-  const src = 'write-object(meta={retry:{count:2}, mode:"safe"}, tags=[true,false,null,-3.5], name=foo)';
+  const src = 'write-object(meta={retry:{count:2}, mode:"safe", window:[1,2,], 404:"err"}, tags=[true,false,null,-3.5,], name=foo)';
   const ir = parser.parseDSL(src);
   assert.equal(ir.node, 'Prim');
   assert.equal(ir.prim, 'write-object');
   assert.deepEqual(ir.args.tags, [true, false, null, -3.5]);
-  assert.deepEqual(ir.args.meta, { mode: 'safe', retry: { count: 2 } });
+  assert.equal(Object.getPrototypeOf(ir.args.meta), null);
+  const metaSnapshot = JSON.parse(JSON.stringify(ir.args.meta));
+  assert.deepEqual(metaSnapshot, { '404': 'err', mode: 'safe', retry: { count: 2 }, window: [1, 2] });
   assert.equal(ir.args.name, 'foo');
 });
 
 test('parses nested structures inside args', () => {
   const src = 'write-object(meta={retry:{count:2, windows:[1,2]}, extra:{enabled:true}})';
   const ir = parser.parseDSL(src);
-  assert.deepEqual(ir.args.meta.retry, { count: 2, windows: [1, 2] });
-  assert.deepEqual(ir.args.meta.extra, { enabled: true });
+  const retrySnapshot = JSON.parse(JSON.stringify(ir.args.meta.retry));
+  const extraSnapshot = JSON.parse(JSON.stringify(ir.args.meta.extra));
+  assert.deepEqual(retrySnapshot, { count: 2, windows: [1, 2] });
+  assert.deepEqual(extraSnapshot, { enabled: true });
+});
+
+test('object literals keep null prototypes and quote-sensitive keys', () => {
+  const src = 'write-object(meta={__proto__:{polluted:true}, constructor:{x:1}, ok:2})';
+  const ir = parser.parseDSL(src);
+  const meta = ir.args.meta;
+  assert.equal(Object.getPrototypeOf(meta), null);
+  const snapshot = Object.entries(meta).map(([key, value]) => [key, JSON.parse(JSON.stringify(value))]);
+  assert.deepEqual(snapshot, [
+    ['__proto__', { polluted: true }],
+    ['constructor', { x: 1 }],
+    ['ok', 2],
+  ]);
+
+  const formatted = formatter.formatDSL(ir);
+  const roundTrip = parser.parseDSL(formatted);
+  const meta2 = roundTrip.args.meta;
+  assert.equal(Object.getPrototypeOf(meta2), null);
+  const expected = [
+    ['__proto__', { polluted: true }],
+    ['constructor', { x: 1 }],
+    ['ok', 2],
+  ].sort((a, b) => a[0].localeCompare(b[0]));
+  const snapshot2 = Object.entries(meta2).map(([key, value]) => [key, JSON.parse(JSON.stringify(value))]);
+  assert.deepEqual(snapshot2, expected);
 });
 
 test('parse failures include location and caret', () => {
   const cases = [
     'write-object(tags=[1,,2])',
     'write-object(name="unterminated)',
-    'write-object(meta={retry:{count:2})'
+    'write-object(meta={retry:{count:2})',
+    'write-object(meta={a:1,,b:2})',
   ];
 
   for (const src of cases) {
@@ -32,7 +63,8 @@ test('parse failures include location and caret', () => {
       assert.match(err.message, /Parse error at \d+:\d+:/);
       const lines = err.message.split('\n');
       assert.ok(lines.length >= 3, 'error should include snippet');
-      assert.match(lines[2], /\^{2,12}/);
+      const caret = lines[2].trim();
+      assert.match(caret, /^\^{2,12}$/);
       return true;
     });
   }

--- a/tests/dsl-show.test.mjs
+++ b/tests/dsl-show.test.mjs
@@ -12,6 +12,6 @@ test('show renders tree structure', () => {
   assert.equal(lines[0], 'Seq');
   const primLines = lines.filter((line) => line.trimStart().startsWith('Prim:'));
   assert.equal(primLines.length, 2);
-  assert.match(primLines[0], /Prim: write-object .*key:"a"/);
-  assert.match(primLines[1], /Prim: write-object .*key:"b"/);
+  assert.equal(primLines[0].trim(), 'Prim: write-object {key:"a", uri:"res://kv/x"}');
+  assert.equal(primLines[1].trim(), 'Prim: write-object {key:"b", uri:"res://kv/x"}');
 });

--- a/tests/dsl-show.test.mjs
+++ b/tests/dsl-show.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const parser = await import('../packages/tf-compose/src/parser.mjs');
+const formatter = await import('../packages/tf-compose/src/format.mjs');
+
+test('show renders tree structure', () => {
+  const src = 'write-object(uri="res://kv/x", key="a") |> write-object(uri="res://kv/x", key="b")';
+  const ir = parser.parseDSL(src);
+  const tree = formatter.renderIRTree(ir);
+  const lines = tree.split('\n');
+  assert.equal(lines[0], 'Seq');
+  const primLines = lines.filter((line) => line.trimStart().startsWith('Prim:'));
+  assert.equal(primLines.length, 2);
+  assert.match(primLines[0], /Prim: write-object .*key:"a"/);
+  assert.match(primLines[1], /Prim: write-object .*key:"b"/);
+});


### PR DESCRIPTION
## Summary
- extend the DSL tokenizer and parser to support numbers, booleans, null, arrays, and objects while emitting precise caret-based errors
- add a formatter/rendering module used by the CLI fmt and show commands for canonical printing and IR inspection
- cover the new behavior with parser/formatter/show tests and document literal support plus the new CLI helpers

## Testing
- pnpm run a0
- pnpm run a1
- pnpm -w -r test *(fails: packages/mapper/trace2tags vitest run)*
- node --test tests/dsl-literals.test.mjs tests/dsl-fmt.test.mjs tests/dsl-show.test.mjs
- node packages/tf-compose/bin/tf.mjs fmt examples/flows/storage_ok.tf
- node packages/tf-compose/bin/tf.mjs show examples/flows/storage_ok.tf

------
https://chatgpt.com/codex/tasks/task_e_68cf3977ecc48320a7aae27ca5ad0a12