### PR TITLE
Add extended DSL literals, formatting, and CLI tooling

### DIFF
--- a/docs/l0-dsl.md
+++ b/docs/l0-dsl.md
@@ -14,6 +14,42 @@ Examples:
   par{ a(); b(x=1); c() }
 ```
 
+## Literals
+
+Arguments accept rich literal values in addition to bare identifiers. You can mix
+numbers (including negatives and floats), booleans, `null`, arrays, and nested
+objects with either quoted or bare keys:
+
+```
+write-object(
+  key="alpha",
+  count=2,
+  flags=[true, false, null],
+  meta={retry:{count:2, strategy:"linear"}}
+)
+```
+
+Arrays may include trailing commas and object keys are normalized to strings.
+
+## Formatting and inspection
+
+Use the compose CLI to keep flows tidy and to inspect the parsed tree:
+
+* `tf fmt flow.tf` prints the canonical layout (pass `-w`/`--write` to update the file).
+  Running `fmt` multiple times is idempotent.
+* `tf show flow.tf` renders a tree view of the IR with two-space indentation.
+
+## Error reporting
+
+Parse failures include a `line:col` location and a short caret span to highlight
+the offending token, e.g.:
+
+```
+Expected literal at 3:5
+  write-object(value=[1,,2])
+    ^^
+```
+
 The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws.
 It collapses idempotent primitives, eliminates declared inverse pairs, and swaps commute-with-pure primitives across adjacent pure nodes.
 Normalization never moves steps across `Region{}` or `Par{}` boundaries, so localized effects stay fenced.

--- a/packages/tf-compose/src/formatter.mjs
+++ b/packages/tf-compose/src/formatter.mjs
@@ -1,0 +1,146 @@
+const INDENT = '  ';
+
+export function formatDSL(ir) {
+  const lines = formatNode(ir, 0);
+  return lines.join('\n');
+}
+
+export function formatTree(ir) {
+  const lines = treeLines(ir, 0);
+  return lines.join('\n');
+}
+
+function formatNode(node, depth) {
+  if (!node) return [];
+  switch (node.node) {
+    case 'Prim':
+      return [formatPrim(node, depth)];
+    case 'Seq':
+      return formatBlock('seq', node.children, depth);
+    case 'Par':
+      return formatBlock('par', node.children, depth);
+    case 'Region':
+      return formatRegion(node, depth);
+    default:
+      if (node.prim) return [formatPrim(node, depth)];
+      return [indent(depth) + String(node)];
+  }
+}
+
+function formatPrim(node, depth) {
+  const pad = indent(depth);
+  const args = formatAssignments(node.args);
+  if (!args) return pad + node.prim;
+  return pad + node.prim + '(' + args + ')';
+}
+
+function formatBlock(keyword, children, depth) {
+  const lines = [];
+  lines.push(indent(depth) + keyword + '{');
+  const childLines = formatChildren(children, depth + 1);
+  lines.push(...childLines);
+  lines.push(indent(depth) + '}');
+  return lines;
+}
+
+function formatRegion(node, depth) {
+  const keyword = regionKeyword(node.kind);
+  const attrs = formatAssignments(node.attrs);
+  const header = keyword + (attrs ? '(' + attrs + ')' : '');
+  return formatBlock(header, node.children, depth);
+}
+
+function formatChildren(children = [], depth) {
+  const lines = [];
+  const list = children || [];
+  for (let i = 0; i < list.length; i++) {
+    const childLines = formatNode(list[i], depth);
+    if (i < list.length - 1 && childLines.length > 0) {
+      childLines[childLines.length - 1] += ';';
+    }
+    lines.push(...childLines);
+  }
+  return lines;
+}
+
+function formatAssignments(map = {}) {
+  const keys = Object.keys(map);
+  if (!keys.length) return '';
+  keys.sort((a, b) => a.localeCompare(b));
+  return keys.map(key => key + '=' + formatValue(map[key])).join(', ');
+}
+
+function formatValue(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) {
+    return '[' + value.map(formatValue).join(', ') + ']';
+  }
+  if (typeof value === 'object') {
+    return formatObject(value);
+  }
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') return String(value);
+  return JSON.stringify(value);
+}
+
+const IDENT_KEY = /^[A-Za-z_][A-Za-z0-9_\-.]*$/;
+
+function formatObject(obj) {
+  const keys = Object.keys(obj || {});
+  if (!keys.length) return '{}';
+  keys.sort((a, b) => a.localeCompare(b));
+  const parts = keys.map(key => formatObjectKey(key) + ':' + formatValue(obj[key]));
+  return '{' + parts.join(', ') + '}';
+}
+
+function formatObjectKey(key) {
+  return IDENT_KEY.test(key) ? key : JSON.stringify(key);
+}
+
+function regionKeyword(kind) {
+  if (kind === 'Authorize') return 'authorize';
+  if (kind === 'Transaction') return 'txn';
+  return (kind || 'region').toLowerCase();
+}
+
+function indent(depth) {
+  return INDENT.repeat(depth);
+}
+
+function treeLines(node, depth) {
+  if (!node) return [];
+  switch (node.node) {
+    case 'Prim': {
+      const args = formatArgsObject(node.args);
+      const label = indent(depth) + 'Prim: ' + node.prim + (args ? ' ' + args : '');
+      return [label];
+    }
+    case 'Seq':
+      return [indent(depth) + 'Seq', ...treeChildren(node.children, depth + 1)];
+    case 'Par':
+      return [indent(depth) + 'Par', ...treeChildren(node.children, depth + 1)];
+    case 'Region': {
+      const keyword = regionKeyword(node.kind);
+      const attrs = formatAssignments(node.attrs);
+      const label = indent(depth) + 'Region: ' + keyword + (attrs ? ' (' + attrs + ')' : '');
+      return [label, ...treeChildren(node.children, depth + 1)];
+    }
+    default:
+      return [indent(depth) + String(node)];
+  }
+}
+
+function treeChildren(children = [], depth) {
+  const lines = [];
+  for (const child of children || []) {
+    lines.push(...treeLines(child, depth));
+  }
+  return lines;
+}
+
+function formatArgsObject(args = {}) {
+  const keys = Object.keys(args);
+  if (!keys.length) return '';
+  return formatObject(args);
+}

--- a/tests/dsl-fmt.test.mjs
+++ b/tests/dsl-fmt.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const CLI = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+
+test('fmt produces canonical formatting and is idempotent', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'dsl-fmt-'));
+  const file = join(dir, 'flow.tf');
+  const messy = 'seq{write-object( key ="b",uri="res://kv/x", meta={ retry:{ count:2, }, }, list=[true,false,], value=-3.5 );par{ hash ; write-object( uri="res://kv/x",key="a") }}';
+  await writeFile(file, messy, 'utf8');
+
+  const { stdout } = await execFileAsync(process.execPath, [CLI, 'fmt', file]);
+  const expected = [
+    'seq{',
+    '  write-object(key="b", list=[true, false], meta={retry:{count:2}}, uri="res://kv/x", value=-3.5);',
+    '  par{',
+    '    hash;',
+    '    write-object(key="a", uri="res://kv/x")',
+    '  }',
+    '}'
+  ].join('\n');
+  assert.equal(stdout, expected + '\n');
+
+  await writeFile(file, stdout, 'utf8');
+  const second = await execFileAsync(process.execPath, [CLI, 'fmt', file]);
+  assert.equal(second.stdout, stdout);
+});

--- a/tests/dsl-literals.test.mjs
+++ b/tests/dsl-literals.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+
+test('parses extended literal values', () => {
+  const src = 'write-object(num=-3, ratio=2.5, flag=true, other=false, none=null, list=[1, 2, {inner:"y"},], meta={retry:{count:2,},})';
+  const ir = parseDSL(src);
+  assert.equal(ir.node, 'Prim');
+  const args = ir.args;
+  assert.equal(args.num, -3);
+  assert.equal(args.ratio, 2.5);
+  assert.equal(args.flag, true);
+  assert.equal(args.other, false);
+  assert.equal(args.none, null);
+  assert.deepEqual(args.list, [1, 2, { inner: 'y' }]);
+  assert.deepEqual(args.meta, { retry: { count: 2 } });
+});
+
+test('parse errors include line, column, and caret span', () => {
+  const cases = [
+    'write-object(list=[1,,2])',
+    'write-object(name="abc)',
+    'write-object(obj={a:1)'
+  ];
+
+  for (const src of cases) {
+    try {
+      parseDSL(src);
+      assert.fail('Expected parse failure for ' + src);
+    } catch (err) {
+      assert.match(err.message, /\b\d+:\d+\b/, 'includes line:col');
+      const lines = err.message.split('\n');
+      const pointer = lines[lines.length - 1];
+      assert.match(pointer, /\^\^/, 'caret span present');
+    }
+  }
+});

--- a/tests/dsl-show.test.mjs
+++ b/tests/dsl-show.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const CLI = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+
+test('show renders tree view with ordered children', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'dsl-show-'));
+  const seqFile = join(dir, 'seq.tf');
+  const seqSrc = 'seq{ write-object(uri="res://kv/x", key="a"); write-object(uri="res://kv/x", key="b") }';
+  await writeFile(seqFile, seqSrc, 'utf8');
+
+  const { stdout } = await execFileAsync(process.execPath, [CLI, 'show', seqFile]);
+  const lines = stdout.trim().split('\n');
+  assert.equal(lines[0], 'Seq');
+  const first = lines.findIndex(line => line.includes('key:"a"'));
+  const second = lines.findIndex(line => line.includes('key:"b"'));
+  assert(first >= 0 && second >= 0);
+  assert(first < second);
+
+  const primFile = join(dir, 'prim.tf');
+  await writeFile(primFile, 'hash', 'utf8');
+  const { stdout: primOut } = await execFileAsync(process.execPath, [CLI, 'show', primFile]);
+  assert.ok(primOut.trim().startsWith('Prim'));
+});


### PR DESCRIPTION
## Summary
- extend the DSL parser with numbers, booleans, nulls, arrays, and objects plus richer error messages
- add a formatter and tree printer wired into new `tf fmt` and `tf show` CLI commands
- cover the new syntax and commands with unit tests and documentation updates

## Testing
- pnpm -w -r test *(fails: unrelated packages in the workspace)*
- node --test tests/dsl-literals.test.mjs tests/dsl-fmt.test.mjs tests/dsl-show.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf3977ecc48320a7aae27ca5ad0a12