### PR TITLE
Add Alloy emitter and CLI for write conflict analysis

### DIFF
--- a/packages/tf-l0-proofs/src/alloy.mjs
+++ b/packages/tf-l0-proofs/src/alloy.mjs
@@ -1,0 +1,221 @@
+const BASE_MODULE = `module tf_lang_l0
+
+abstract sig Node {}
+abstract sig Prim extends Node { id: one String }
+
+sig Par extends Node { children: set Node }
+sig Seq extends Node { children: seq Node }
+
+// Writes footprint (abstracted to URIs as Strings)
+one sig URI extends String {}
+sig Writes { node: one Prim, uri: one String }
+
+// Conflict: two writes to the same URI under the same Par
+pred Conflicting[p: Par] {
+  some disj a, b: Writes | a.node in p.children && b.node in p.children && a.uri = b.uri
+}
+
+// Sanity: no conflicts is allowed model property
+pred NoConflict[p: Par] { not Conflicting[p] }
+`;
+
+export function emitAlloy(ir) {
+  const ctx = createContext();
+  collectNodes(ir, ctx);
+  const lines = [BASE_MODULE.trimEnd()];
+
+  if (ctx.nodes.length > 0) {
+    lines.push('');
+    for (const record of ctx.nodes) {
+      lines.push(`one sig ${record.name} extends ${record.type} {}`);
+    }
+  }
+
+  if (ctx.writes.length > 0) {
+    lines.push('');
+    for (const write of ctx.writes) {
+      lines.push(`one sig ${write.name} extends Writes {}`);
+    }
+  }
+
+  const facts = buildFacts(ctx);
+  if (facts.length > 0) {
+    lines.push('');
+    lines.push(...facts);
+  }
+
+  lines.push('');
+  lines.push('run { some p: Par | Conflicting[p] } for 5');
+  lines.push('run { all p: Par | NoConflict[p] } for 5');
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function createContext() {
+  return {
+    counters: { Prim: 0, Par: 0, Seq: 0, Writes: 0 },
+    nodes: [],
+    writes: [],
+    map: new Map()
+  };
+}
+
+function collectNodes(node, ctx) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  if (ctx.map.has(node)) {
+    return ctx.map.get(node);
+  }
+  const type = classifyNode(node);
+  if (!type) {
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        collectNodes(child, ctx);
+      }
+    }
+    return null;
+  }
+  const name = `${type}${ctx.counters[type]++}`;
+  const record = initializeRecord(type, name, node, ctx);
+  ctx.map.set(node, record);
+  ctx.nodes.push(record);
+  if (type === 'Prim') {
+    populatePrim(record, node, ctx);
+  } else {
+    const children = Array.isArray(node.children) ? node.children : [];
+    for (const child of children) {
+      const childRecord = collectNodes(child, ctx);
+      if (childRecord) {
+        record.children.push(childRecord.name);
+      }
+    }
+  }
+  return record;
+}
+
+function classifyNode(node) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  switch (node.node) {
+    case 'Prim':
+      return 'Prim';
+    case 'Par':
+      return 'Par';
+    case 'Seq':
+    case 'Region':
+      return 'Seq';
+    default:
+      return null;
+  }
+}
+
+function initializeRecord(type, name, node, ctx) {
+  if (type === 'Prim') {
+    return {
+      type,
+      name,
+      id: typeof node.prim === 'string' && node.prim.length > 0 ? node.prim : 'unknown-prim',
+      children: [],
+      writes: []
+    };
+  }
+  return {
+    type,
+    name,
+    children: []
+  };
+}
+
+function populatePrim(record, node, ctx) {
+  const uris = extractUris(node);
+  record.writes = uris;
+  for (const uri of uris) {
+    const writeName = `Write${ctx.counters.Writes++}`;
+    ctx.writes.push({ name: writeName, node: record.name, uri });
+  }
+}
+
+function extractUris(node) {
+  const seen = new Set();
+  const uris = [];
+  if (Array.isArray(node.writes)) {
+    for (const entry of node.writes) {
+      const uri = extractUriValue(entry);
+      if (isConcreteUri(uri) && !seen.has(uri)) {
+        seen.add(uri);
+        uris.push(uri);
+      }
+    }
+  }
+  if (uris.length === 0) {
+    const fallback = typeof node?.args?.uri === 'string' ? node.args.uri : null;
+    if (isConcreteUri(fallback) && !seen.has(fallback)) {
+      seen.add(fallback);
+      uris.push(fallback);
+    }
+  }
+  return uris;
+}
+
+function extractUriValue(entry) {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+  if (entry && typeof entry === 'object' && typeof entry.uri === 'string') {
+    return entry.uri;
+  }
+  return null;
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && uri !== 'res://unknown' && !/[<>]/.test(uri);
+}
+
+function buildFacts(ctx) {
+  const lines = [];
+  for (const record of ctx.nodes) {
+    if (record.type === 'Prim') {
+      lines.push(`fact ${record.name}_id { ${record.name}.id = ${stringLiteral(record.id)} }`);
+    }
+  }
+  for (const record of ctx.nodes) {
+    if (record.type === 'Par') {
+      lines.push(...renderParFact(record));
+    } else if (record.type === 'Seq') {
+      lines.push(...renderSeqFact(record));
+    }
+  }
+  for (const write of ctx.writes) {
+    lines.push(
+      `fact ${write.name}_binding { ${write.name}.node = ${write.node} && ${write.name}.uri = ${stringLiteral(write.uri)} }`
+    );
+  }
+  return lines;
+}
+
+function renderParFact(record) {
+  const childrenExpr = record.children.length === 0 ? 'none' : record.children.join(' + ');
+  return [`fact ${record.name}_children { ${record.name}.children = ${childrenExpr} }`];
+}
+
+function renderSeqFact(record) {
+  const sizeLine = `  #${record.name}.children = ${record.children.length}`;
+  if (record.children.length === 0) {
+    return [`fact ${record.name}_children {`, `${sizeLine}`, `}`];
+  }
+  const lines = [`fact ${record.name}_children {`, sizeLine];
+  record.children.forEach((child, index) => {
+    lines.push(`  && ${record.name}.children[${index}] = ${child}`);
+  });
+  lines.push('}');
+  return lines;
+}
+
+function stringLiteral(value) {
+  const s = typeof value === 'string' ? value : '';
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}

--- a/scripts/emit-alloy.mjs
+++ b/scripts/emit-alloy.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, extname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: { out: { type: 'string', short: 'o' } },
+    allowPositionals: true
+  });
+
+  if (positionals.length !== 1) {
+    usage();
+    process.exit(1);
+  }
+
+  const inputPath = positionals[0];
+  const outputArg = values.out ?? defaultOut(inputPath);
+  const srcPath = resolve(inputPath);
+  const outPath = resolve(outputArg);
+
+  const ir = await loadIR(srcPath);
+  const alloy = emitAlloy(ir);
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, alloy, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage() {
+  process.stderr.write(
+    'Usage: node scripts/emit-alloy.mjs <input.ir.json|input.tf> [-o out/0.4/proofs/<name>.als>]\n'
+  );
+}
+
+function defaultOut(inputPath) {
+  const base = basename(inputPath);
+  if (base.endsWith('.ir.json')) {
+    const stem = base.slice(0, -'.ir.json'.length);
+    return `out/0.4/proofs/${stem}.als`;
+  }
+  const ext = extname(base);
+  const stem = ext ? base.slice(0, -ext.length) : base;
+  return `out/0.4/proofs/${stem}.als`;
+}
+
+async function loadIR(srcPath) {
+  if (srcPath.endsWith('.ir.json')) {
+    const raw = await readFile(srcPath, 'utf8');
+    return JSON.parse(raw);
+  }
+  if (srcPath.endsWith('.tf')) {
+    const raw = await readFile(srcPath, 'utf8');
+    return parseDSL(raw);
+  }
+  throw new Error('Unsupported input type; expected .ir.json or .tf');
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(String(err?.stack || err));
+  process.stderr.write('\n');
+  process.exit(1);
+});

--- a/tests/alloy-emit.test.mjs
+++ b/tests/alloy-emit.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+function prim(prim, uri) {
+  return { node: 'Prim', prim, args: { uri } };
+}
+
+test('conflicting writes emit Par and duplicated URIs', () => {
+  const ir = {
+    node: 'Par',
+    children: [prim('write-object', 'res://kv/x'), prim('write-object', 'res://kv/x')]
+  };
+  const alloy = emitAlloy(ir);
+  assert.ok(/one sig Par0 extends Par/.test(alloy), 'includes a Par atom');
+  const matches = alloy.match(/uri = "res:\/\/kv\/x"/g) || [];
+  assert.equal(matches.length, 2, 'two write bindings with same URI');
+  assert.ok(
+    /run \{ some p: Par \| Conflicting\[p\] \} for 5/.test(alloy),
+    'conflict run command present'
+  );
+  assert.ok(
+    /run \{ all p: Par \| NoConflict\[p\] \} for 5/.test(alloy),
+    'no-conflict run command present'
+  );
+});
+
+test('non-conflicting writes avoid duplicate URIs and are deterministic', () => {
+  const ir = {
+    node: 'Par',
+    children: [prim('write-object', 'res://kv/a'), prim('write-object', 'res://kv/b')]
+  };
+  const first = emitAlloy(ir);
+  const second = emitAlloy(ir);
+  assert.equal(first, second, 'emission is deterministic');
+  const uriMatches = [...first.matchAll(/uri = "([^"]+)"/g)].map(([, value]) => value);
+  const unique = new Set(uriMatches);
+  assert.equal(uriMatches.length, unique.size, 'no duplicate URI bindings');
+});


### PR DESCRIPTION
## Summary
- add an Alloy emitter that instantiates nodes, write facts, and conflict commands from the IR
- provide a CLI to emit Alloy models from .tf or .ir.json inputs
- cover the emitter with tests for conflict detection, duplicate URIs, and determinism

## Testing
- pnpm -w -r test *(fails: coverage-generator vitest run)*
- node --test tests/alloy-emit.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf43e6936483208b145cc33c36c23d