### PR TITLE
Add Alloy emitter and CLI for write conflicts

### DIFF
--- a/packages/tf-l0-proofs/src/alloy.mjs
+++ b/packages/tf-l0-proofs/src/alloy.mjs
@@ -1,0 +1,229 @@
+const HEADER = [
+  'module tf_lang_l0',
+  '',
+  'open util/seq[Node]',
+  '',
+  'abstract sig Node {}',
+  'abstract sig Prim extends Node { id: one String }',
+  '',
+  'sig Par extends Node { children: set Node }',
+  'sig Seq extends Node { children: seq Node }',
+  '',
+  'one sig URI extends String {}',
+  'sig Writes { node: one Prim, uri: one String }',
+  '',
+  'pred Conflicting[p: Par] {',
+  '  some disj a, b: Writes | a.node in p.children && b.node in p.children && a.uri = b.uri',
+  '}',
+  '',
+  'pred NoConflict[p: Par] { not Conflicting[p] }',
+  ''
+];
+
+export function emitAlloy(ir) {
+  const state = {
+    counters: { Prim: 0, Par: 0, Seq: 0, Writes: 0 },
+    prims: [],
+    pars: [],
+    seqs: [],
+    writes: []
+  };
+
+  traverse(ir, state);
+
+  const lines = [...HEADER];
+
+  const nodeDecls = [];
+  for (const prim of state.prims) {
+    nodeDecls.push(`one sig ${prim.name} extends Prim {}`);
+  }
+  for (const par of state.pars) {
+    nodeDecls.push(`one sig ${par.name} extends Par {}`);
+  }
+  for (const seq of state.seqs) {
+    nodeDecls.push(`one sig ${seq.name} extends Seq {}`);
+  }
+  for (const write of state.writes) {
+    nodeDecls.push(`one sig ${write.name} extends Writes {}`);
+  }
+  if (nodeDecls.length > 0) {
+    lines.push(...nodeDecls, '');
+  }
+
+  const primIdFacts = state.prims.map((prim) => `${prim.name}.id = ${prim.id}`);
+  addFact(lines, 'PrimIds', primIdFacts);
+
+  for (const par of state.pars) {
+    const factLines = buildParChildrenFact(par);
+    addFact(lines, `${par.name}_Children`, factLines);
+  }
+
+  for (const seq of state.seqs) {
+    const factLines = buildSeqChildrenFact(seq);
+    addFact(lines, `${seq.name}_Children`, factLines);
+  }
+
+  const writeFacts = [];
+  for (const write of state.writes) {
+    writeFacts.push(`${write.name}.node = ${write.node}`);
+    writeFacts.push(`${write.name}.uri = ${write.uri}`);
+  }
+  addFact(lines, 'WritesAssignments', writeFacts);
+
+  lines.push('run { some p: Par | Conflicting[p] } for 5');
+  lines.push('run { all p: Par | NoConflict[p] } for 5');
+
+  return lines.join('\n') + '\n';
+}
+
+function traverse(node, state) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+
+  let record = null;
+  if (node.node === 'Prim') {
+    record = createPrim(node, state);
+  } else if (node.node === 'Par') {
+    record = createPar(state);
+  } else if (node.node === 'Seq') {
+    record = createSeq(state);
+  }
+
+  const children = [];
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const childRecord = traverse(child, state);
+      if (childRecord) {
+        children.push(childRecord);
+      }
+    }
+  }
+
+  if (record) {
+    if (record.type === 'Par') {
+      record.children = children;
+    } else if (record.type === 'Seq') {
+      record.children = children;
+    }
+  }
+
+  return record;
+}
+
+function createPrim(node, state) {
+  const name = `Prim${state.counters.Prim++}`;
+  const idValue = selectPrimId(node, name);
+  const prim = { type: 'Prim', name, id: stringLiteral(idValue) };
+  state.prims.push(prim);
+
+  const uris = extractWriteUris(node);
+  for (const uri of uris) {
+    const writeName = `Write${state.counters.Writes++}`;
+    state.writes.push({ name: writeName, node: name, uri: stringLiteral(uri) });
+  }
+
+  return prim;
+}
+
+function createPar(state) {
+  const name = `Par${state.counters.Par++}`;
+  const par = { type: 'Par', name, children: [] };
+  state.pars.push(par);
+  return par;
+}
+
+function createSeq(state) {
+  const name = `Seq${state.counters.Seq++}`;
+  const seq = { type: 'Seq', name, children: [] };
+  state.seqs.push(seq);
+  return seq;
+}
+
+function selectPrimId(node, fallback) {
+  if (typeof node.id === 'string' && node.id.length > 0) {
+    return node.id;
+  }
+  if (typeof node.prim === 'string' && node.prim.length > 0) {
+    return node.prim;
+  }
+  return fallback;
+}
+
+function extractWriteUris(node) {
+  const fromWrites = Array.isArray(node.writes) ? node.writes : [];
+  const collected = [];
+  for (const entry of fromWrites) {
+    const uri = normalizeUri(entry);
+    if (typeof uri === 'string' && uri.length > 0) {
+      collected.push(uri);
+    }
+  }
+  if (collected.length > 0) {
+    return dedupe(collected);
+  }
+  const fallbackUri = typeof node?.args?.uri === 'string' ? node.args.uri : null;
+  if (fallbackUri && fallbackUri.length > 0) {
+    return [fallbackUri];
+  }
+  return [];
+}
+
+function normalizeUri(entry) {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+  if (entry && typeof entry === 'object' && typeof entry.uri === 'string') {
+    return entry.uri;
+  }
+  return null;
+}
+
+function dedupe(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+function buildParChildrenFact(par) {
+  if (!par.children || par.children.length === 0) {
+    return [`no ${par.name}.children`];
+  }
+  const parts = par.children.map((child) => child.name);
+  return [`${par.name}.children = ${parts.join(' + ')}`];
+}
+
+function buildSeqChildrenFact(seq) {
+  if (!seq.children || seq.children.length === 0) {
+    return [`no ${seq.name}.children`];
+  }
+  const facts = [`#${seq.name}.children = ${seq.children.length}`];
+  seq.children.forEach((child, index) => {
+    facts.push(`${seq.name}.children[${index}] = ${child.name}`);
+  });
+  return facts;
+}
+
+function addFact(lines, name, predicates) {
+  if (!predicates || predicates.length === 0) {
+    return;
+  }
+  lines.push(`fact ${name} {`);
+  predicates.forEach((predicate, index) => {
+    const suffix = index === predicates.length - 1 ? '' : ' &&';
+    lines.push(`  ${predicate}${suffix}`);
+  });
+  lines.push('}', '');
+}
+
+function stringLiteral(value) {
+  const s = typeof value === 'string' ? value : '';
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}

--- a/scripts/emit-alloy.mjs
+++ b/scripts/emit-alloy.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, extname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: { out: { type: 'string', short: 'o' } },
+    allowPositionals: true
+  });
+
+  if (positionals.length !== 1) {
+    usage();
+    process.exit(1);
+  }
+
+  const inputPath = positionals[0];
+  const outputArg = values.out ?? defaultOut(inputPath);
+  const srcPath = resolve(inputPath);
+  const outPath = resolve(outputArg);
+
+  const ir = await loadIR(srcPath);
+  const alloy = emitAlloy(ir);
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, alloy, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage() {
+  process.stderr.write(
+    'Usage: node scripts/emit-alloy.mjs <input.ir.json|input.tf> [-o out/0.4/proofs/<name>.als>]\n'
+  );
+}
+
+function defaultOut(inputPath) {
+  const base = basename(inputPath);
+  if (base.endsWith('.ir.json')) {
+    const stem = base.slice(0, -'.ir.json'.length);
+    return `out/0.4/proofs/${stem}.als`;
+  }
+  const ext = extname(base);
+  const stem = ext ? base.slice(0, -ext.length) : base;
+  return `out/0.4/proofs/${stem}.als`;
+}
+
+async function loadIR(srcPath) {
+  if (srcPath.endsWith('.ir.json')) {
+    const raw = await readFile(srcPath, 'utf8');
+    return JSON.parse(raw);
+  }
+  if (srcPath.endsWith('.tf')) {
+    const [raw, catalog] = await Promise.all([readFile(srcPath, 'utf8'), loadCatalog()]);
+    const ir = parseDSL(raw);
+    annotateWrites(ir, catalog);
+    return ir;
+  }
+  throw new Error('Unsupported input format; expected .ir.json or .tf');
+}
+
+async function loadCatalog() {
+  const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+  const raw = await readFile(catalogUrl, 'utf8');
+  return JSON.parse(raw);
+}
+
+function annotateWrites(ir, catalog) {
+  const index = buildCatalogIndex(catalog);
+  walk(ir, (node) => {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node === 'Prim') {
+      const primName = typeof node.prim === 'string' ? node.prim.toLowerCase() : '';
+      const prim = index.get(primName);
+      if (!prim) {
+        return;
+      }
+      const concretized = concretizeWrites(prim.writes, node.args);
+      if (concretized.length > 0) {
+        node.writes = concretized;
+      }
+    }
+  });
+}
+
+function buildCatalogIndex(catalog = {}) {
+  const index = new Map();
+  for (const prim of catalog.primitives || []) {
+    if (prim && typeof prim.name === 'string') {
+      index.set(prim.name.toLowerCase(), prim);
+    }
+  }
+  return index;
+}
+
+function concretizeWrites(writes = [], args = {}) {
+  if (!Array.isArray(writes) || writes.length === 0) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const entry of writes) {
+    const uri = concretizeUri(entry?.uri, args);
+    if (!uri || seen.has(uri)) {
+      continue;
+    }
+    seen.add(uri);
+    result.push({ ...entry, uri });
+  }
+  result.sort((a, b) => a.uri.localeCompare(b.uri));
+  return result;
+}
+
+function concretizeUri(uri, args = {}) {
+  if (isConcreteUri(uri)) {
+    return uri;
+  }
+  const fromArgs = selectUriFromArgs(args);
+  return isConcreteUri(fromArgs) ? fromArgs : null;
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && uri !== 'res://unknown' && !/[<>]/.test(uri);
+}
+
+function selectUriFromArgs(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(String(err?.stack || err));
+  process.stderr.write('\n');
+  process.exit(1);
+});

--- a/tests/alloy-emit.test.mjs
+++ b/tests/alloy-emit.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+test('emits conflicting writes for same URI children', () => {
+  const ir = {
+    node: 'Authorize',
+    children: [
+      {
+        node: 'Par',
+        children: [
+          {
+            node: 'Prim',
+            id: 'write_a',
+            writes: [{ uri: 'res://kv/x' }]
+          },
+          {
+            node: 'Prim',
+            id: 'write_b',
+            writes: [{ uri: 'res://kv/x' }]
+          }
+        ]
+      }
+    ]
+  };
+
+  const alloy = emitAlloy(ir);
+  assert.match(alloy, /one sig Par0 extends Par/, 'should declare Par atom');
+  const writeEntries = [...alloy.matchAll(/Write\d+\.uri = "res:\/\/kv\/x"/g)];
+  assert.equal(writeEntries.length, 2, 'should emit two writes for same URI');
+  assert.ok(
+    alloy.includes('run { some p: Par | Conflicting[p] } for 5'),
+    'should include conflict run command'
+  );
+});
+
+test('emits distinct URIs for non-conflicting writes', () => {
+  const ir = {
+    node: 'Authorize',
+    children: [
+      {
+        node: 'Par',
+        children: [
+          {
+            node: 'Prim',
+            id: 'write_a',
+            writes: [{ uri: 'res://kv/a' }]
+          },
+          {
+            node: 'Prim',
+            id: 'write_b',
+            writes: [{ uri: 'res://kv/b' }]
+          }
+        ]
+      }
+    ]
+  };
+
+  const alloy = emitAlloy(ir);
+  const sameUri = alloy.match(/"res:\/\/kv\/a"/g) ?? [];
+  assert.equal(sameUri.length, 1, 'only one occurrence of res://kv/a');
+  assert.ok(
+    alloy.includes('run { all p: Par | NoConflict[p] } for 5'),
+    'should include no-conflict run command'
+  );
+});
+
+test('deterministic emission for identical IR', () => {
+  const ir = {
+    node: 'Authorize',
+    children: [
+      {
+        node: 'Par',
+        children: [
+          {
+            node: 'Prim',
+            id: 'write_a',
+            writes: [{ uri: 'res://kv/a' }]
+          },
+          {
+            node: 'Prim',
+            id: 'write_b',
+            writes: [{ uri: 'res://kv/b' }]
+          }
+        ]
+      }
+    ]
+  };
+
+  const first = emitAlloy(ir);
+  const second = emitAlloy(ir);
+  assert.equal(first, second, 'emitter should be deterministic');
+});


### PR DESCRIPTION
## Summary
- add an Alloy emitter that materializes nodes, hierarchy, writes, and commands from the IR
- add a CLI to emit Alloy models from .tf or .ir.json inputs with catalog-backed write annotations
- cover the emitter with tests that check conflict detection, absence of duplicate URIs, and determinism

## Testing
- pnpm -w -r test *(fails: existing workspace packages currently red)*
- node --test tests/alloy-emit.test.mjs


------
https://chatgpt.com/codex/tasks/task_e_68cf43e6936483208b145cc33c36c23d