### PR TITLE
Add Alloy emitter and CLI

### DIFF
--- a/packages/tf-l0-proofs/src/alloy.mjs
+++ b/packages/tf-l0-proofs/src/alloy.mjs
@@ -1,0 +1,294 @@
+const PRIM_PREFIX = 'Prim';
+const PAR_PREFIX = 'Par';
+const SEQ_PREFIX = 'Seq';
+const WRITES_PREFIX = 'Writes';
+
+export function emitAlloy(ir) {
+  const context = {
+    prims: [],
+    pars: [],
+    seqs: [],
+    writes: [],
+    counters: new Map(),
+    names: new WeakMap()
+  };
+
+  processNode(ir, context);
+
+  const lines = [];
+  lines.push('module tf_lang_l0');
+  lines.push('');
+  lines.push('abstract sig Node {}');
+  lines.push('abstract sig Prim extends Node { id: one String }');
+  lines.push('');
+  lines.push('sig Par extends Node { children: set Node }');
+  lines.push('sig Seq extends Node { children: seq Node }');
+  lines.push('');
+  lines.push('// Writes footprint (abstracted to URIs as Strings)');
+  lines.push('one sig URI extends String {}');
+  lines.push('sig Writes { node: one Prim, uri: one String }');
+  lines.push('');
+  lines.push('// Conflict: two writes to the same URI under the same Par');
+  lines.push('pred Conflicting[p: Par] {');
+  lines.push(
+    '  some disj a, b: Writes | a.node in p.children && b.node in p.children && a.uri = b.uri'
+  );
+  lines.push('}');
+  lines.push('');
+  lines.push('// Sanity: no conflicts is allowed model property');
+  lines.push('pred NoConflict[p: Par] { not Conflicting[p] }');
+  lines.push('');
+
+  appendDeclarations(lines, context);
+  appendFacts(lines, context);
+
+  lines.push('run { some p: Par | Conflicting[p] } for 5');
+  lines.push('run { all p: Par | NoConflict[p] } for 5');
+
+  return lines.join('\n') + '\n';
+}
+
+function appendDeclarations(lines, context) {
+  if (context.prims.length > 0) {
+    for (const prim of context.prims) {
+      lines.push(`one sig ${prim.name} extends Prim {}`);
+    }
+    lines.push('');
+  }
+  if (context.pars.length > 0) {
+    for (const par of context.pars) {
+      lines.push(`one sig ${par.name} extends Par {}`);
+    }
+    lines.push('');
+  }
+  if (context.seqs.length > 0) {
+    for (const seq of context.seqs) {
+      lines.push(`one sig ${seq.name} extends Seq {}`);
+    }
+    lines.push('');
+  }
+  if (context.writes.length > 0) {
+    for (const write of context.writes) {
+      lines.push(`one sig ${write.name} extends Writes {}`);
+    }
+    lines.push('');
+  }
+}
+
+function appendFacts(lines, context) {
+  if (context.prims.length > 0) {
+    lines.push('fact PrimIds {');
+    for (const prim of context.prims) {
+      lines.push(`  ${prim.name}.id = ${stringLiteral(prim.id)}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+
+  if (context.pars.length > 0) {
+    lines.push('fact ParChildren {');
+    for (const par of context.pars) {
+      const expr = formatSetExpression(par.children);
+      lines.push(`  ${par.name}.children = ${expr}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+
+  if (context.seqs.length > 0) {
+    lines.push('fact SeqChildren {');
+    for (const seq of context.seqs) {
+      const expr = formatSeqExpression(seq.children);
+      lines.push(`  ${seq.name}.children = ${expr}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+
+  if (context.writes.length > 0) {
+    lines.push('fact WriteLinks {');
+    for (const write of context.writes) {
+      lines.push(`  ${write.name}.node = ${write.node}`);
+      lines.push(`  ${write.name}.uri = ${stringLiteral(write.uri)}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+}
+
+function formatSetExpression(children) {
+  if (!children || children.length === 0) {
+    return 'none';
+  }
+  if (children.length === 1) {
+    return children[0];
+  }
+  return children.join(' + ');
+}
+
+function formatSeqExpression(children) {
+  if (!children || children.length === 0) {
+    return 'none';
+  }
+  const pairs = children.map((child, index) => `${index} -> ${child}`);
+  return pairs.join(' + ');
+}
+
+function processNode(node, context) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  if (context.names.has(node)) {
+    return context.names.get(node);
+  }
+  const type = typeof node.node === 'string' ? node.node : '';
+  if (type === 'Prim') {
+    return registerPrim(node, context);
+  }
+  if (type === 'Par') {
+    return registerPar(node, context);
+  }
+  if (type === 'Seq' || Array.isArray(node.children)) {
+    return registerSeq(node, context);
+  }
+  return null;
+}
+
+function registerPrim(node, context) {
+  const index = nextIndex(context, PRIM_PREFIX);
+  const name = `${PRIM_PREFIX}${index}`;
+  const primName = typeof node.prim === 'string' ? node.prim : null;
+  const id = typeof node.id === 'string' && node.id.length > 0
+    ? node.id
+    : primName
+    ? `${primName}#${index}`
+    : name;
+  const entry = { type: 'Prim', name, id };
+  context.prims.push(entry);
+  context.names.set(node, entry);
+
+  const uris = collectWriteUris(node);
+  for (const uri of uris) {
+    registerWrite(entry.name, uri, context);
+  }
+  return entry;
+}
+
+function registerPar(node, context) {
+  const index = nextIndex(context, PAR_PREFIX);
+  const name = `${PAR_PREFIX}${index}`;
+  const children = [];
+  for (const child of node.children || []) {
+    const result = processNode(child, context);
+    if (result) {
+      children.push(result.name);
+    }
+  }
+  const entry = { type: 'Par', name, children };
+  context.pars.push(entry);
+  context.names.set(node, entry);
+  return entry;
+}
+
+function registerSeq(node, context) {
+  const index = nextIndex(context, SEQ_PREFIX);
+  const name = `${SEQ_PREFIX}${index}`;
+  const children = [];
+  for (const child of node.children || []) {
+    const result = processNode(child, context);
+    if (result) {
+      children.push(result.name);
+    }
+  }
+  const entry = { type: 'Seq', name, children };
+  context.seqs.push(entry);
+  context.names.set(node, entry);
+  return entry;
+}
+
+function registerWrite(nodeName, uri, context) {
+  const index = nextIndex(context, WRITES_PREFIX);
+  const name = `${WRITES_PREFIX}${index}`;
+  context.writes.push({ name, node: nodeName, uri });
+}
+
+function nextIndex(context, prefix) {
+  const current = context.counters.get(prefix) ?? 0;
+  context.counters.set(prefix, current + 1);
+  return current;
+}
+
+function collectWriteUris(node) {
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+  const urisFromWrites = collectUrisFromWrites(node);
+  if (urisFromWrites.length > 0) {
+    return urisFromWrites;
+  }
+  if (!isWritePrimName(node.prim)) {
+    return [];
+  }
+  const fromArgs = selectUriFromArgs(node.args);
+  return fromArgs ? [fromArgs] : [];
+}
+
+function collectUrisFromWrites(node) {
+  if (!Array.isArray(node.writes) || node.writes.length === 0) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const entry of node.writes) {
+    const uri = concretizeUri(entry);
+    if (!uri || seen.has(uri)) {
+      continue;
+    }
+    seen.add(uri);
+    result.push(uri);
+  }
+  result.sort();
+  return result;
+}
+
+function concretizeUri(entry) {
+  if (typeof entry === 'string') {
+    return isConcreteUri(entry) ? entry : null;
+  }
+  if (entry && typeof entry === 'object' && typeof entry.uri === 'string') {
+    return isConcreteUri(entry.uri) ? entry.uri : null;
+  }
+  return null;
+}
+
+function selectUriFromArgs(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const value = args[key];
+    if (isConcreteUri(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && uri !== 'res://unknown' && !/[<>]/.test(uri);
+}
+
+function isWritePrimName(name) {
+  if (typeof name !== 'string') {
+    return false;
+  }
+  const lower = name.toLowerCase();
+  return lower.includes('write') || lower.includes('put') || lower.includes('update') || lower.includes('set');
+}
+
+function stringLiteral(value) {
+  const s = typeof value === 'string' ? value : '';
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}

--- a/scripts/emit-alloy.mjs
+++ b/scripts/emit-alloy.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, extname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: { out: { type: 'string', short: 'o' } },
+    allowPositionals: true
+  });
+
+  if (positionals.length !== 1) {
+    usage();
+    process.exit(1);
+  }
+
+  const inputPath = positionals[0];
+  const outputArg = values.out ?? defaultOut(inputPath);
+  const srcPath = resolve(inputPath);
+  const outPath = resolve(outputArg);
+
+  const ir = await loadIR(srcPath);
+  const alloy = emitAlloy(ir);
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, alloy, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage() {
+  process.stderr.write(
+    'Usage: node scripts/emit-alloy.mjs <input.ir.json|input.tf> [-o out/0.4/proofs/<name>.als]\n'
+  );
+}
+
+function defaultOut(inputPath) {
+  const base = basename(inputPath);
+  if (base.endsWith('.ir.json')) {
+    const stem = base.slice(0, -'.ir.json'.length);
+    return `out/0.4/proofs/${stem}.als`;
+  }
+  const ext = extname(base);
+  const stem = ext ? base.slice(0, -ext.length) : base;
+  return `out/0.4/proofs/${stem}.als`;
+}
+
+async function loadIR(srcPath) {
+  if (srcPath.endsWith('.tf')) {
+    const [ir, catalog] = await Promise.all([loadFlow(srcPath), loadCatalog()]);
+    annotateWrites(ir, catalog);
+    return ir;
+  }
+  if (srcPath.endsWith('.ir.json')) {
+    const raw = await readFile(srcPath, 'utf8');
+    const ir = JSON.parse(raw);
+    const catalog = await loadCatalog();
+    annotateWrites(ir, catalog);
+    return ir;
+  }
+  throw new Error('unsupported input; expected .tf or .ir.json');
+}
+
+async function loadFlow(srcPath) {
+  const raw = await readFile(srcPath, 'utf8');
+  return parseDSL(raw);
+}
+
+async function loadCatalog() {
+  const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+  const raw = await readFile(catalogUrl, 'utf8');
+  return JSON.parse(raw);
+}
+
+function annotateWrites(ir, catalog) {
+  const index = buildCatalogIndex(catalog);
+  walk(ir, (node) => {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node !== 'Prim') {
+      return;
+    }
+    if (Array.isArray(node.writes) && node.writes.length > 0) {
+      return;
+    }
+    const primName = typeof node.prim === 'string' ? node.prim.toLowerCase() : '';
+    const prim = index.get(primName);
+    if (!prim) {
+      return;
+    }
+    const concretized = concretizeWrites(prim.writes, node.args);
+    if (concretized.length > 0) {
+      node.writes = concretized;
+    }
+  });
+}
+
+function buildCatalogIndex(catalog = {}) {
+  const index = new Map();
+  for (const prim of catalog.primitives || []) {
+    if (prim && typeof prim.name === 'string') {
+      index.set(prim.name.toLowerCase(), prim);
+    }
+  }
+  return index;
+}
+
+function concretizeWrites(writes = [], args = {}) {
+  if (!Array.isArray(writes) || writes.length === 0) {
+    return [];
+  }
+  const seen = new Set();
+  const result = [];
+  for (const entry of writes) {
+    const uri = concretizeUri(entry?.uri, args);
+    if (!uri || seen.has(uri)) {
+      continue;
+    }
+    seen.add(uri);
+    result.push({ ...entry, uri });
+  }
+  result.sort((a, b) => a.uri.localeCompare(b.uri));
+  return result;
+}
+
+function concretizeUri(uri, args = {}) {
+  if (isConcreteUri(uri)) {
+    return uri;
+  }
+  const fromArgs = selectUriFromArgs(args);
+  return isConcreteUri(fromArgs) ? fromArgs : null;
+}
+
+function isConcreteUri(uri) {
+  return typeof uri === 'string' && uri.length > 0 && uri !== 'res://unknown' && !/[<>]/.test(uri);
+}
+
+function selectUriFromArgs(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(String(err?.stack || err));
+  process.stderr.write('\n');
+  process.exit(1);
+});

--- a/tests/alloy-emit.test.mjs
+++ b/tests/alloy-emit.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+function makePrim(uri, overrides = {}) {
+  return {
+    node: 'Prim',
+    prim: 'write-object',
+    writes: uri ? [{ uri }] : [],
+    args: uri ? { uri } : {},
+    ...overrides
+  };
+}
+
+test('conflict model emits writes with identical uri', () => {
+  const ir = {
+    node: 'Par',
+    children: [makePrim('res://kv/x'), makePrim('res://kv/x')]
+  };
+
+  const alloy = emitAlloy(ir);
+  assert.match(alloy, /one sig Par0 extends Par/, 'should declare a Par atom');
+  const uriMatches = alloy.match(/Writes\d+\.uri = "res:\/\/kv\/x"/g) || [];
+  assert.equal(uriMatches.length, 2, 'expected two writes targeting the same URI');
+  assert.ok(alloy.includes('run { some p: Par | Conflicting[p] } for 5'));
+  assert.ok(alloy.includes('run { all p: Par | NoConflict[p] } for 5'));
+});
+
+test('non-conflict model omits duplicate uri writes', () => {
+  const ir = {
+    node: 'Par',
+    children: [makePrim('res://kv/a'), makePrim('res://kv/b')]
+  };
+
+  const alloy = emitAlloy(ir);
+  const uriMatches = [...alloy.matchAll(/Writes\d+\.uri = "([^"]+)"/g)];
+  const uris = uriMatches.map((match) => match[1]);
+  const unique = new Set(uris);
+  assert.equal(unique.size, uris.length, 'writes should not reuse the same URI');
+});
+
+test('emission is deterministic', () => {
+  const ir = {
+    node: 'Par',
+    children: [makePrim('res://kv/a'), makePrim('res://kv/b')]
+  };
+
+  const first = emitAlloy(ir);
+  const second = emitAlloy(ir);
+  assert.equal(first, second);
+});


### PR DESCRIPTION
## Summary
- add an Alloy emitter that materializes nodes, hierarchy, and write footprints from the IR
- add a CLI to load `.tf` or `.ir.json` inputs, annotate writes, and emit `.als` files
- cover the emitter with unit tests for conflict detection, uniqueness, and determinism

## Testing
- node --test tests/alloy-emit.test.mjs
- pnpm -w -r test *(fails: @tf-lang/adapter-execution-ts@0.1.0 test requires vitest success)*

------
https://chatgpt.com/codex/tasks/task_e_68cf43e6936483208b145cc33c36c23d