### PR TITLE
feat: add alloy emitter

### DIFF
--- a/packages/tf-l0-proofs/src/alloy.mjs
+++ b/packages/tf-l0-proofs/src/alloy.mjs
@@ -1,0 +1,224 @@
+export function emitAlloy(ir) {
+  const ctx = {
+    prims: [],
+    pars: [],
+    seqs: [],
+    writes: [],
+    counters: {
+      Prim: 0,
+      Par: 0,
+      Seq: 0,
+      Writes: 0,
+    },
+  };
+
+  visitNode(ir, ctx);
+
+  const lines = [];
+  lines.push('module tf_lang_l0');
+  lines.push('');
+  lines.push('open util/seq[Node]');
+  lines.push('');
+  lines.push('abstract sig Node {}');
+  lines.push('abstract sig Prim extends Node { id: one String }');
+  lines.push('');
+  lines.push('sig Par extends Node { children: set Node }');
+  lines.push('sig Seq extends Node { children: seq Node }');
+  lines.push('');
+  lines.push('// Writes footprint (abstracted to URIs as Strings)');
+  lines.push('one sig URI extends String {}');
+  lines.push('sig Writes { node: one Prim, uri: one String }');
+  lines.push('');
+  lines.push('// Conflict: two writes to the same URI under the same Par');
+  lines.push('pred Conflicting[p: Par] {');
+  lines.push(
+    '  some disj a, b: Writes | a.node in p.children && b.node in p.children && a.uri = b.uri'
+  );
+  lines.push('}');
+  lines.push('');
+  lines.push('// Sanity: no conflicts is allowed model property');
+  lines.push('pred NoConflict[p: Par] { not Conflicting[p] }');
+  lines.push('');
+
+  for (const prim of ctx.prims) {
+    lines.push(`one sig ${prim.name} extends Prim {}`);
+  }
+  for (const par of ctx.pars) {
+    lines.push(`one sig ${par.name} extends Par {}`);
+  }
+  for (const seq of ctx.seqs) {
+    lines.push(`one sig ${seq.name} extends Seq {}`);
+  }
+  for (const write of ctx.writes) {
+    lines.push(`one sig ${write.name} extends Writes {}`);
+  }
+
+  const facts = [];
+  for (const prim of ctx.prims) {
+    facts.push(`  ${prim.name}.id = ${stringLiteral(prim.id)}`);
+  }
+  for (const par of ctx.pars) {
+    facts.push(`  ${par.name}.children = ${setExpression(par.children)}`);
+  }
+  for (const seq of ctx.seqs) {
+    facts.push(`  ${seq.name}.children = ${sequenceExpression(seq.children)}`);
+  }
+  for (const write of ctx.writes) {
+    facts.push(
+      `  ${write.name}.node = ${write.prim} && ${write.name}.uri = ${stringLiteral(write.uri)}`
+    );
+  }
+
+  if (facts.length > 0) {
+    lines.push('');
+    lines.push('fact {');
+    lines.push(facts.join('\n'));
+    lines.push('}');
+  }
+
+  lines.push('');
+  lines.push('run { some p: Par | Conflicting[p] } for 5');
+  lines.push('run { all p: Par | NoConflict[p] } for 5');
+
+  return lines.join('\n') + '\n';
+}
+
+function visitNode(node, ctx) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+
+  switch (node.node) {
+    case 'Prim':
+      return registerPrim(node, ctx);
+    case 'Par':
+      return registerPar(node, ctx);
+    case 'Seq':
+      return registerSeq(node, ctx);
+    default:
+      break;
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      visitNode(child, ctx);
+    }
+  }
+
+  return null;
+}
+
+function registerPrim(node, ctx) {
+  const name = `Prim${ctx.counters.Prim++}`;
+  const id = primIdentifier(node, name);
+  const record = { name, id };
+  ctx.prims.push(record);
+
+  const uris = extractWriteUris(node);
+  for (const uri of uris) {
+    const writeName = `Writes${ctx.counters.Writes++}`;
+    ctx.writes.push({ name: writeName, prim: name, uri });
+  }
+
+  return name;
+}
+
+function registerPar(node, ctx) {
+  const name = `Par${ctx.counters.Par++}`;
+  const record = { name, children: [] };
+  ctx.pars.push(record);
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const childName = visitNode(child, ctx);
+      if (childName) {
+        record.children.push(childName);
+      }
+    }
+  }
+
+  record.children = dedupePreserveOrder(record.children);
+  return name;
+}
+
+function registerSeq(node, ctx) {
+  const name = `Seq${ctx.counters.Seq++}`;
+  const record = { name, children: [] };
+  ctx.seqs.push(record);
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const childName = visitNode(child, ctx);
+      if (childName) {
+        record.children.push(childName);
+      }
+    }
+  }
+
+  return name;
+}
+
+function primIdentifier(node, fallback) {
+  if (typeof node?.id === 'string' && node.id.length > 0) {
+    return node.id;
+  }
+  if (typeof node?.prim === 'string' && node.prim.length > 0) {
+    return node.prim;
+  }
+  return fallback;
+}
+
+function extractWriteUris(node) {
+  const uris = [];
+  if (Array.isArray(node?.writes) && node.writes.length > 0) {
+    for (const entry of node.writes) {
+      const uri = entry?.uri;
+      if (typeof uri === 'string' && uri.length > 0) {
+        uris.push(uri);
+      }
+    }
+  }
+
+  if (uris.length === 0) {
+    const fallback = node?.args?.uri;
+    if (typeof fallback === 'string' && fallback.length > 0) {
+      uris.push(fallback);
+    }
+  }
+
+  return Array.from(new Set(uris)).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function setExpression(children) {
+  if (!Array.isArray(children) || children.length === 0) {
+    return 'none';
+  }
+  return children.join(' + ');
+}
+
+function sequenceExpression(children) {
+  if (!Array.isArray(children) || children.length === 0) {
+    return 'none';
+  }
+  return children
+    .map((child, index) => `${index} -> ${child}`)
+    .join(' + ');
+}
+
+function stringLiteral(value) {
+  const raw = typeof value === 'string' ? value : '';
+  const escaped = raw.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function dedupePreserveOrder(values = []) {
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}

--- a/scripts/emit-alloy.mjs
+++ b/scripts/emit-alloy.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+
+async function main() {
+  const [input, ...rest] = process.argv.slice(2);
+  if (!input) {
+    usage('missing input file');
+  }
+
+  let output = null;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === '-o') {
+      output = rest[++i];
+    }
+  }
+
+  if (!output) {
+    usage('missing -o <output> option');
+  }
+
+  const resolvedInput = path.resolve(process.cwd(), input);
+  const resolvedOutput = path.resolve(process.cwd(), output);
+
+  const ir = await loadIR(resolvedInput);
+  const alloy = emitAlloy(ir);
+
+  await mkdir(path.dirname(resolvedOutput), { recursive: true });
+  await writeFile(resolvedOutput, alloy, 'utf8');
+  process.stdout.write(`wrote ${resolvedOutput}\n`);
+}
+
+async function loadIR(inputPath) {
+  if (inputPath.endsWith('.ir.json')) {
+    const raw = await readFile(inputPath, 'utf8');
+    return JSON.parse(raw);
+  }
+  if (inputPath.endsWith('.tf')) {
+    const source = await readFile(inputPath, 'utf8');
+    return parseDSL(source);
+  }
+  throw new Error(`unsupported input format for ${inputPath}`);
+}
+
+function usage(message) {
+  const text = message ? `${message}\n` : '';
+  process.stderr.write(
+    `${text}usage: node scripts/emit-alloy.mjs <input.ir.json|input.tf> -o <output.als>\n`
+  );
+  process.exit(1);
+}
+
+await main().catch((err) => {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(1);
+});

--- a/tests/alloy-emit.test.mjs
+++ b/tests/alloy-emit.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { emitAlloy } from '../packages/tf-l0-proofs/src/alloy.mjs';
+
+const duplicateUri = 'res://kv/x';
+const uniqueUri = 'res://kv/y';
+
+const conflictIR = {
+  node: 'Region',
+  children: [
+    {
+      node: 'Par',
+      children: [
+        {
+          node: 'Prim',
+          prim: 'write-object',
+          writes: [{ uri: duplicateUri }],
+        },
+        {
+          node: 'Prim',
+          prim: 'write-object',
+          writes: [{ uri: duplicateUri }],
+        },
+      ],
+    },
+  ],
+};
+
+const okIR = {
+  node: 'Region',
+  children: [
+    {
+      node: 'Par',
+      children: [
+        {
+          node: 'Prim',
+          prim: 'write-object',
+          writes: [{ uri: duplicateUri }],
+        },
+        {
+          node: 'Prim',
+          prim: 'write-object',
+          writes: [{ uri: uniqueUri }],
+        },
+      ],
+    },
+  ],
+};
+
+test('conflict IR emits duplicate write URIs', () => {
+  const alloy = emitAlloy(conflictIR);
+  assert.ok(/one sig Par0 extends Par/.test(alloy), 'Par atom should be declared');
+  const uris = collectWriteUris(alloy);
+  assert.equal(uris.filter((uri) => uri === duplicateUri).length, 2, 'two identical writes');
+  assert.ok(
+    alloy.includes('run { some p: Par | Conflicting[p] } for 5'),
+    'conflict run command present'
+  );
+});
+
+test('ok IR has no duplicate write URIs', () => {
+  const alloy = emitAlloy(okIR);
+  const uris = collectWriteUris(alloy);
+  const duplicates = new Set();
+  for (const uri of uris) {
+    if (duplicates.has(uri)) {
+      assert.fail(`duplicate URI detected: ${uri}`);
+    }
+    duplicates.add(uri);
+  }
+  assert.ok(
+    alloy.includes('run { some p: Par | Conflicting[p] } for 5'),
+    'commands are present for completeness'
+  );
+});
+
+test('emission is deterministic', () => {
+  const first = emitAlloy(okIR);
+  const second = emitAlloy(okIR);
+  assert.equal(first, second);
+});
+
+function collectWriteUris(alloy) {
+  const matches = alloy.matchAll(/\.uri = "([^"]*)"/g);
+  const uris = [];
+  for (const match of matches) {
+    uris.push(match[1]);
+  }
+  return uris;
+}


### PR DESCRIPTION
## Summary
- add an Alloy emitter that instantiates nodes, hierarchy, and writes from the IR
- provide a CLI utility to emit Alloy models from IR JSON or TF sources
- cover the emitter with unit tests for conflicts, distinct writes, and determinism

## Testing
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf43e6936483208b145cc33c36c23d