### PR TITLE
Add trace verifier CLI and tests

### DIFF
--- a/packages/tf-compose/bin/tf-verify-trace.mjs
+++ b/packages/tf-compose/bin/tf-verify-trace.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+
+import { verifyTrace, canonicalJson } from '../../tf-l0-tools/verify-trace.mjs';
+
+async function loadJson(path) {
+  try {
+    const data = await readFile(path, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    throw new Error(`failed to read ${path}: ${err.message}`);
+  }
+}
+
+async function loadText(path) {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (err) {
+    throw new Error(`failed to read ${path}: ${err.message}`);
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      ir: { type: 'string' },
+      trace: { type: 'string' },
+      manifest: { type: 'string' },
+      catalog: { type: 'string' },
+    },
+  });
+
+  if (!values.ir || !values.trace) {
+    console.error('Usage: tf-verify-trace --ir <file.ir.json> --trace <file.jsonl> [--manifest <manifest.json>] [--catalog <catalog.json>]');
+    process.exit(2);
+  }
+
+  try {
+    const ir = await loadJson(values.ir);
+    const trace = await loadText(values.trace);
+    const manifest = values.manifest ? await loadJson(values.manifest) : null;
+    const catalog = values.catalog ? await loadJson(values.catalog) : null;
+
+    const result = verifyTrace({ ir, trace, manifest, catalog });
+    process.stdout.write(canonicalJson(result) + '\n');
+    process.exit(result.ok ? 0 : 1);
+  } catch (err) {
+    console.error(err.message || String(err));
+    process.exit(2);
+  }
+}
+
+await main();

--- a/packages/tf-l0-tools/verify-trace.mjs
+++ b/packages/tf-l0-tools/verify-trace.mjs
@@ -1,0 +1,230 @@
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+function normalizePrimId(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const match = /^tf:([^/]+)\/([^@]+)@(\d+)$/i.exec(trimmed);
+  if (!match) return null;
+  const [, domain, name, major] = match;
+  const lowerName = name.toLowerCase();
+  return {
+    normalized: `tf:${domain}/${lowerName}@${major}`,
+    name: lowerName,
+  };
+}
+
+function addPrimIdentifier(target, names, value) {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  const normalized = normalizePrimId(trimmed);
+  if (normalized) {
+    target.add(normalized.normalized);
+    names.add(normalized.name);
+    return;
+  }
+  names.add(trimmed.toLowerCase());
+}
+
+function collectPrimIdentifiers(ir) {
+  const full = new Set();
+  const names = new Set();
+  const stack = [ir];
+  const seen = new WeakSet();
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) continue;
+    if (typeof current !== 'object') continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    if (Array.isArray(current)) {
+      for (const entry of current) {
+        stack.push(entry);
+      }
+      continue;
+    }
+    if (current.node === 'Prim') {
+      if (typeof current.prim === 'string') {
+        addPrimIdentifier(full, names, current.prim);
+      }
+      if (typeof current.prim_id === 'string') {
+        addPrimIdentifier(full, names, current.prim_id);
+      }
+      if (typeof current.id === 'string') {
+        addPrimIdentifier(full, names, current.id);
+      }
+    }
+    for (const value of Object.values(current)) {
+      if (value && typeof value === 'object') {
+        stack.push(value);
+      }
+    }
+  }
+  return { full, names };
+}
+
+function buildWriteSets(catalog) {
+  const full = new Set();
+  const names = new Set();
+  if (catalog && Array.isArray(catalog.primitives)) {
+    for (const primitive of catalog.primitives) {
+      if (!primitive) continue;
+      const effects = Array.isArray(primitive.effects) ? primitive.effects : [];
+      if (!effects.some((effect) => effect === 'Storage.Write')) {
+        continue;
+      }
+      if (typeof primitive.id === 'string') {
+        const normalized = normalizePrimId(primitive.id);
+        if (normalized) {
+          full.add(normalized.normalized);
+          names.add(normalized.name);
+        }
+      }
+      if (typeof primitive.name === 'string') {
+        names.add(primitive.name.toLowerCase());
+      }
+    }
+  }
+  return { full, names, hasCatalog: Boolean(catalog) };
+}
+
+function isWritePrim(primId, writeSets) {
+  if (!primId || typeof primId !== 'string') {
+    return false;
+  }
+  const trimmed = primId.trim();
+  if (!trimmed) return false;
+  const normalized = normalizePrimId(trimmed);
+  const name = normalized ? normalized.name : trimmed.toLowerCase();
+  if (normalized && writeSets.full.has(normalized.normalized)) {
+    return true;
+  }
+  if (writeSets.names.has(name)) {
+    return true;
+  }
+  return /^(write-object|delete-object|compare-and-swap)$/.test(name);
+}
+
+function extractAllowedPrefixes(manifest) {
+  const writes = manifest?.footprints_rw?.writes;
+  if (!Array.isArray(writes)) {
+    return [];
+  }
+  const prefixes = [];
+  for (const entry of writes) {
+    if (!entry) continue;
+    let pattern = null;
+    if (typeof entry === 'string') {
+      pattern = entry;
+    } else if (typeof entry.uri === 'string') {
+      pattern = entry.uri;
+    }
+    if (!pattern) continue;
+    const trimmed = pattern.trim();
+    if (!trimmed) continue;
+    const idxLt = trimmed.indexOf('<');
+    const idxColonLt = trimmed.indexOf(':<');
+    let cut = trimmed.length;
+    if (idxLt >= 0) cut = Math.min(cut, idxLt);
+    if (idxColonLt >= 0) cut = Math.min(cut, idxColonLt);
+    const prefix = trimmed.slice(0, cut);
+    if (prefix) {
+      prefixes.push(prefix);
+    }
+  }
+  prefixes.sort();
+  return prefixes;
+}
+
+function isAllowedPrim(primId, primSets) {
+  if (!primId || typeof primId !== 'string') {
+    return false;
+  }
+  const trimmed = primId.trim();
+  if (!trimmed) return false;
+  const normalized = normalizePrimId(trimmed);
+  if (normalized) {
+    if (primSets.full.has(normalized.normalized)) {
+      return true;
+    }
+    if (primSets.names.has(normalized.name)) {
+      return true;
+    }
+    return false;
+  }
+  return primSets.names.has(trimmed.toLowerCase());
+}
+
+export function verifyTrace({ ir, trace, manifest = null, catalog = null }) {
+  if (!ir || typeof ir !== 'object') {
+    throw new Error('verify-trace: IR object required');
+  }
+  if (typeof trace !== 'string') {
+    throw new Error('verify-trace: trace content required');
+  }
+
+  const primSets = collectPrimIdentifiers(ir);
+  const writeSets = buildWriteSets(catalog);
+  const prefixes = manifest ? extractAllowedPrefixes(manifest) : [];
+
+  const issues = [];
+  let unknownCount = 0;
+  let deniedCount = 0;
+  let records = 0;
+
+  const lines = trace.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (!raw) continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    let entry;
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      issues.push(`invalid json at line ${i + 1}`);
+      continue;
+    }
+    records += 1;
+    const primId = typeof entry?.prim_id === 'string' ? entry.prim_id : null;
+    if (!primId || !isAllowedPrim(primId, primSets)) {
+      unknownCount += 1;
+      issues.push(`unknown prim: ${primId ?? '(missing)'}`);
+    }
+    if (manifest && primId && isWritePrim(primId, writeSets)) {
+      const uri = entry?.args?.uri;
+      if (typeof uri !== 'string' || uri.length === 0) {
+        deniedCount += 1;
+        issues.push('write denied: (missing uri)');
+      } else if (prefixes.length === 0 || !prefixes.some((prefix) => uri.startsWith(prefix))) {
+        deniedCount += 1;
+        issues.push(`write denied: ${uri}`);
+      }
+    }
+  }
+
+  issues.sort((a, b) => a.localeCompare(b));
+
+  const ok = issues.length === 0;
+  return {
+    ok,
+    issues,
+    counts: {
+      records,
+      unknown_prims: unknownCount,
+      denied_writes: deniedCount,
+    },
+  };
+}
+
+export { canonicalJson };

--- a/tests/fixtures/manifest-allowed.json
+++ b/tests/fixtures/manifest-allowed.json
@@ -1,0 +1,7 @@
+{
+  "footprints_rw": {
+    "writes": [
+      { "uri": "res://kv/allowed/<bucket>/:<key>" }
+    ]
+  }
+}

--- a/tests/fixtures/trace-denied.jsonl
+++ b/tests/fixtures/trace-denied.jsonl
@@ -1,0 +1,2 @@
+{"prim_id":"tf:resource/write-object@1","args":{"uri":"res://kv/blocked/item","value":"data"}}
+{"prim_id":"tf:observability/emit-metric@1","args":{"name":"ok"}}

--- a/tests/fixtures/trace-ok.jsonl
+++ b/tests/fixtures/trace-ok.jsonl
@@ -1,0 +1,2 @@
+{"prim_id":"tf:resource/write-object@1","args":{"uri":"res://kv/allowed/item","value":"data"}}
+{"prim_id":"tf:observability/emit-metric@1","args":{"name":"ok"}}

--- a/tests/fixtures/trace-unknown.jsonl
+++ b/tests/fixtures/trace-unknown.jsonl
@@ -1,0 +1,1 @@
+{"prim_id":"tf:resource/unknown@1","args":{"uri":"res://kv/allowed/item"}}

--- a/tests/fixtures/verify-trace.ir.json
+++ b/tests/fixtures/verify-trace.ir.json
@@ -1,0 +1,14 @@
+{
+  "node": "Seq",
+  "children": [
+    {
+      "node": "Prim",
+      "prim": "write-object",
+      "prim_id": "tf:resource/write-object@1"
+    },
+    {
+      "node": "Prim",
+      "prim": "tf:observability/emit-metric@1"
+    }
+  ]
+}

--- a/tests/verify-trace.test.mjs
+++ b/tests/verify-trace.test.mjs
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const cliPath = fileURLToPath(new URL('../packages/tf-compose/bin/tf-verify-trace.mjs', import.meta.url));
+const irPath = fileURLToPath(new URL('./fixtures/verify-trace.ir.json', import.meta.url));
+const traceOkPath = fileURLToPath(new URL('./fixtures/trace-ok.jsonl', import.meta.url));
+const traceDeniedPath = fileURLToPath(new URL('./fixtures/trace-denied.jsonl', import.meta.url));
+const traceUnknownPath = fileURLToPath(new URL('./fixtures/trace-unknown.jsonl', import.meta.url));
+const manifestPath = fileURLToPath(new URL('./fixtures/manifest-allowed.json', import.meta.url));
+const catalogPath = fileURLToPath(new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url));
+
+function runCli(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+test('accepts traces whose primitives appear in the IR', async () => {
+  const { code, stdout, stderr } = await runCli(['--ir', irPath, '--trace', traceOkPath]);
+  assert.equal(code, 0, stderr);
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.ok, true);
+  assert.deepEqual(payload.issues, []);
+  assert.equal(payload.counts.records, 2);
+  assert.equal(payload.counts.unknown_prims, 0);
+  assert.equal(payload.counts.denied_writes, 0);
+  assert.equal(stdout.trim(), canonicalJson(payload));
+});
+
+test('flags unknown primitives from the trace', async () => {
+  const { code, stdout } = await runCli(['--ir', irPath, '--trace', traceUnknownPath]);
+  assert.equal(code, 1);
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.ok, false);
+  assert.ok(payload.issues.includes('unknown prim: tf:resource/unknown@1'));
+  assert.equal(payload.counts.unknown_prims, 1);
+  assert.equal(stdout.trim(), canonicalJson(payload));
+});
+
+test('denies writes outside manifest prefixes', async () => {
+  const { code, stdout } = await runCli([
+    '--ir', irPath,
+    '--trace', traceDeniedPath,
+    '--manifest', manifestPath,
+  ]);
+  assert.equal(code, 1);
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.ok, false);
+  assert.ok(payload.issues.includes('write denied: res://kv/blocked/item'));
+  assert.equal(payload.counts.denied_writes, 1);
+  assert.equal(stdout.trim(), canonicalJson(payload));
+});
+
+test('catalog is optional for identifying writes', async () => {
+  const withoutCatalog = await runCli(['--ir', irPath, '--trace', traceOkPath]);
+  assert.equal(withoutCatalog.code, 0, withoutCatalog.stderr);
+  const withCatalog = await runCli([
+    '--ir', irPath,
+    '--trace', traceOkPath,
+    '--catalog', catalogPath,
+  ]);
+  assert.equal(withCatalog.code, 0, withCatalog.stderr);
+  assert.equal(withoutCatalog.stdout.trim(), withCatalog.stdout.trim());
+  const payload = JSON.parse(withCatalog.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(withCatalog.stdout.trim(), canonicalJson(payload));
+});


### PR DESCRIPTION
## Summary
- add a tf-verify-trace CLI for validating JSONL traces against IR and optional manifest/catalog inputs
- implement shared verification logic that enforces primitive membership and manifest write policies
- introduce fixtures and tests that cover success, unknown primitive, denied write, and catalog optionality scenarios

## Testing
- node --test tests/verify-trace.test.mjs
- pnpm -w -r test *(fails: @tf-lang/adapter-execution-ts@0.1.0 test: `vitest run`)*

------
https://chatgpt.com/codex/tasks/task_e_68cf43cba8e08320863f696d437fe732