### PR TITLE
feat: add trace verifier tool

### DIFF
--- a/packages/tf-compose/bin/tf-verify-trace.mjs
+++ b/packages/tf-compose/bin/tf-verify-trace.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { canonicalJson, verifyTrace } from '../../tf-l0-tools/verify-trace.mjs';
+
+const usage = 'Usage: node packages/tf-compose/bin/tf-verify-trace.mjs --ir <file.ir.json> --trace <file.jsonl> [--manifest <manifest.json>] [--catalog <catalog.json>]';
+
+function parseJsonl(content, source) {
+  const records = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch (err) {
+      const message = err && err.message ? err.message : String(err);
+      throw new Error(`Failed to parse JSON on line ${i + 1} of ${source}: ${message}`);
+    }
+  }
+  return records;
+}
+
+async function loadJson(path) {
+  const text = await readFile(path, 'utf8');
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    throw new Error(`Failed to parse JSON from ${path}: ${message}`);
+  }
+}
+
+async function main(argv) {
+  const { values } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      ir: { type: 'string' },
+      trace: { type: 'string' },
+      manifest: { type: 'string' },
+      catalog: { type: 'string' },
+    },
+  });
+
+  if (!values.ir || !values.trace) {
+    throw new Error('Missing required arguments --ir and --trace');
+  }
+
+  const ir = await loadJson(values.ir);
+  const traceText = await readFile(values.trace, 'utf8');
+  const trace = parseJsonl(traceText, values.trace);
+
+  const manifest = values.manifest ? await loadJson(values.manifest) : null;
+  const catalog = values.catalog ? await loadJson(values.catalog) : null;
+
+  const result = verifyTrace(ir, trace, { manifest, catalog });
+  const output = canonicalJson(result);
+  process.stdout.write(output + '\n');
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main(process.argv).catch((err) => {
+  const message = err && err.message ? err.message : String(err);
+  console.error(message);
+  console.error(usage);
+  process.exitCode = 2;
+});

--- a/packages/tf-l0-tools/verify-trace.mjs
+++ b/packages/tf-l0-tools/verify-trace.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+function primVariants(prim) {
+  if (typeof prim !== 'string') return [];
+  const variants = new Set();
+  const trimmed = prim.trim();
+  if (!trimmed) return [];
+  variants.add(trimmed);
+  variants.add(trimmed.toLowerCase());
+
+  const parts = trimmed.split('/');
+  const last = parts[parts.length - 1] || '';
+  const [namePart, versionPart] = last.split('@');
+  const nameLower = (namePart || '').toLowerCase();
+  const version = versionPart || '';
+  if (nameLower) {
+    variants.add(nameLower);
+    if (version) {
+      variants.add(`${nameLower}@${version}`);
+    }
+  }
+  if (parts.length > 1) {
+    const domain = parts.slice(0, -1).join('/').toLowerCase();
+    if (nameLower) {
+      const canonical = `${domain}/${nameLower}${version ? `@${version}` : ''}`;
+      variants.add(canonical);
+      if (canonical.startsWith('tf:')) {
+        variants.add(canonical.slice(3));
+      } else {
+        variants.add(`tf:${canonical}`);
+      }
+    }
+  }
+  return Array.from(variants);
+}
+
+function collectPrimSet(ir, out = new Set()) {
+  if (!ir || typeof ir !== 'object') {
+    return out;
+  }
+  if (ir.node === 'Prim' && typeof ir.prim === 'string') {
+    for (const variant of primVariants(ir.prim)) {
+      out.add(variant);
+    }
+  }
+  if (Array.isArray(ir.children)) {
+    for (const child of ir.children) {
+      collectPrimSet(child, out);
+    }
+  }
+  for (const key of Object.keys(ir)) {
+    if (key === 'children') continue;
+    const value = ir[key];
+    if (value && typeof value === 'object') {
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          collectPrimSet(entry, out);
+        }
+      } else if (value.node) {
+        collectPrimSet(value, out);
+      }
+    }
+  }
+  return out;
+}
+
+function toPrimKeySet(ir) {
+  const variants = collectPrimSet(ir);
+  const sorted = Array.from(variants).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const result = new Set(sorted);
+  return result;
+}
+
+function extractName(primId) {
+  if (typeof primId !== 'string') return '';
+  const parts = primId.split('/');
+  const last = parts[parts.length - 1] || '';
+  const [name] = last.split('@');
+  return (name || '').toLowerCase();
+}
+
+function effectsForPrim(primId, catalog) {
+  if (!catalog) return null;
+  const primitives = Array.isArray(catalog.primitives) ? catalog.primitives : [];
+  const lowerId = typeof primId === 'string' ? primId.toLowerCase() : '';
+  const name = extractName(primId);
+  for (const entry of primitives) {
+    const entryId = typeof entry?.id === 'string' ? entry.id.toLowerCase() : '';
+    const entryName = typeof entry?.name === 'string' ? entry.name.toLowerCase() : '';
+    if (entryId && entryId === lowerId) {
+      return Array.isArray(entry.effects) ? entry.effects : [];
+    }
+    if (name && entryName && entryName === name) {
+      return Array.isArray(entry.effects) ? entry.effects : [];
+    }
+    if (name && entryId && entryId.endsWith(`/${name}${entryId.includes('@') ? entryId.slice(entryId.indexOf('@')) : ''}`)) {
+      return Array.isArray(entry.effects) ? entry.effects : [];
+    }
+  }
+  return null;
+}
+
+function isStorageWrite(primId, catalog) {
+  const effects = effectsForPrim(primId, catalog);
+  if (effects !== null) {
+    return effects.some((effect) => effect === 'Storage.Write');
+  }
+  const name = extractName(primId);
+  return /^(write-object|delete-object|compare-and-swap)$/.test(name);
+}
+
+function buildAllowedPrefixes(manifest) {
+  const writes = manifest?.footprints_rw?.writes;
+  if (!Array.isArray(writes)) return [];
+  const prefixes = new Set();
+  for (const entry of writes) {
+    const uri = typeof entry?.uri === 'string' ? entry.uri : null;
+    if (!uri) continue;
+    const angle = uri.indexOf('<');
+    if (angle !== -1) {
+      prefixes.add(uri.slice(0, angle));
+      continue;
+    }
+    const colon = uri.indexOf(':<');
+    if (colon !== -1) {
+      prefixes.add(uri.slice(0, colon));
+      continue;
+    }
+    prefixes.add(uri);
+  }
+  return Array.from(prefixes).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+export function verifyTrace(ir, traceRecords, options = {}) {
+  const { manifest = null, catalog = null } = options;
+  const primSet = toPrimKeySet(ir);
+  const allowedPrefixes = manifest ? buildAllowedPrefixes(manifest) : [];
+
+  let records = 0;
+  let unknownPrims = 0;
+  let deniedWrites = 0;
+  const issues = [];
+
+  for (const record of traceRecords) {
+    if (!record || typeof record !== 'object') {
+      continue;
+    }
+    records += 1;
+    const primId = record.prim_id;
+    const primIdStr = typeof primId === 'string' ? primId : '';
+
+    let known = false;
+    for (const variant of primVariants(primIdStr)) {
+      if (primSet.has(variant)) {
+        known = true;
+        break;
+      }
+    }
+    if (!known && primIdStr) {
+      issues.push(`unknown prim: ${primIdStr}`);
+      unknownPrims += 1;
+    }
+
+    if (manifest && isStorageWrite(primIdStr, catalog)) {
+      const uriValue = record?.args?.uri;
+      const uri = typeof uriValue === 'string' ? uriValue : '';
+      let allowed = false;
+      if (uri) {
+        for (const prefix of allowedPrefixes) {
+          if (uri.startsWith(prefix)) {
+            allowed = true;
+            break;
+          }
+        }
+      }
+      if (!allowed) {
+        deniedWrites += 1;
+        const display =
+          typeof uriValue === 'string' && uriValue.length > 0 ? uriValue : '(missing uri)';
+        issues.push(`write denied: ${display}`);
+      }
+    }
+  }
+
+  issues.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  const result = {
+    ok: issues.length === 0,
+    issues,
+    counts: {
+      records,
+      unknown_prims: unknownPrims,
+      denied_writes: deniedWrites,
+    },
+  };
+
+  return result;
+}
+
+export { canonicalJson };
+
+export default verifyTrace;

--- a/tests/fixtures/trace-denied.jsonl
+++ b/tests/fixtures/trace-denied.jsonl
@@ -1,0 +1,1 @@
+{"prim_id":"tf:resource/write-object@1","args":{"uri":"res://kv/blocked/item"}}

--- a/tests/fixtures/trace-ok.jsonl
+++ b/tests/fixtures/trace-ok.jsonl
@@ -1,0 +1,2 @@
+{"prim_id":"tf:resource/write-object@1","args":{"uri":"res://kv/allowed/item"}}
+{"prim_id":"tf:observability/emit-metric@1","args":{}}

--- a/tests/fixtures/trace-unknown.jsonl
+++ b/tests/fixtures/trace-unknown.jsonl
@@ -1,0 +1,1 @@
+{"prim_id":"tf:resource/unknown@1","args":{}}

--- a/tests/fixtures/verify-ir.json
+++ b/tests/fixtures/verify-ir.json
@@ -1,0 +1,7 @@
+{
+  "node": "Seq",
+  "children": [
+    { "node": "Prim", "prim": "tf:resource/write-object@1", "args": {} },
+    { "node": "Prim", "prim": "tf:observability/emit-metric@1", "args": {} }
+  ]
+}

--- a/tests/fixtures/verify-manifest.json
+++ b/tests/fixtures/verify-manifest.json
@@ -1,0 +1,7 @@
+{
+  "footprints_rw": {
+    "writes": [
+      { "uri": "res://kv/allowed/<bucket>/:<key>" }
+    ]
+  }
+}

--- a/tests/verify-trace.test.mjs
+++ b/tests/verify-trace.test.mjs
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(new URL('../packages/tf-compose/bin/tf-verify-trace.mjs', import.meta.url));
+const irPath = fileURLToPath(new URL('./fixtures/verify-ir.json', import.meta.url));
+const traceOkPath = fileURLToPath(new URL('./fixtures/trace-ok.jsonl', import.meta.url));
+const traceUnknownPath = fileURLToPath(new URL('./fixtures/trace-unknown.jsonl', import.meta.url));
+const traceDeniedPath = fileURLToPath(new URL('./fixtures/trace-denied.jsonl', import.meta.url));
+const manifestPath = fileURLToPath(new URL('./fixtures/verify-manifest.json', import.meta.url));
+const catalogPath = fileURLToPath(new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url));
+
+function runCli(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+test('ok case without manifest', async () => {
+  const { code, stdout, stderr } = await runCli([
+    '--ir',
+    irPath,
+    '--trace',
+    traceOkPath,
+  ]);
+  assert.equal(code, 0, stderr);
+  const result = JSON.parse(stdout.trim());
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.issues, []);
+  assert.equal(result.counts.records, 2);
+  assert.equal(result.counts.unknown_prims, 0);
+  assert.equal(result.counts.denied_writes, 0);
+  assert.equal(stdout.trim(), canonicalJson(result));
+});
+
+test('catalog optionality produces same output', async () => {
+  const base = await runCli([
+    '--ir',
+    irPath,
+    '--trace',
+    traceOkPath,
+  ]);
+  const withCatalog = await runCli([
+    '--ir',
+    irPath,
+    '--trace',
+    traceOkPath,
+    '--catalog',
+    catalogPath,
+  ]);
+
+  assert.equal(base.code, 0, base.stderr);
+  assert.equal(withCatalog.code, 0, withCatalog.stderr);
+  assert.equal(base.stdout, withCatalog.stdout);
+});
+
+test('flags unknown primitives', async () => {
+  const { code, stdout } = await runCli([
+    '--ir',
+    irPath,
+    '--trace',
+    traceUnknownPath,
+  ]);
+  assert.equal(code, 1);
+  const result = JSON.parse(stdout.trim());
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.includes('unknown prim: tf:resource/unknown@1'));
+  assert.equal(result.counts.records, 1);
+  assert.equal(result.counts.unknown_prims, 1);
+  assert.equal(result.counts.denied_writes, 0);
+  assert.equal(stdout.trim(), canonicalJson(result));
+});
+
+test('denies writes outside manifest prefixes', async () => {
+  const { code, stdout } = await runCli([
+    '--ir',
+    irPath,
+    '--trace',
+    traceDeniedPath,
+    '--manifest',
+    manifestPath,
+  ]);
+  assert.equal(code, 1);
+  const result = JSON.parse(stdout.trim());
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.includes('write denied: res://kv/blocked/item'));
+  assert.equal(result.counts.records, 1);
+  assert.equal(result.counts.unknown_prims, 0);
+  assert.equal(result.counts.denied_writes, 1);
+  assert.equal(stdout.trim(), canonicalJson(result));
+});


### PR DESCRIPTION
## Summary
- add a tf-verify-trace CLI for validating trace JSONL files against IR, manifest, and optional catalog inputs
- implement verification logic that canonicalizes primitive IDs, checks manifest write prefixes, and emits canonical JSON
- cover the verifier with fixtures and node:test cases for success, unknown prims, catalog usage, and denied writes

## Testing
- node --test tests/verify-trace.test.mjs
- pnpm run a0
- pnpm run a1

------
https://chatgpt.com/codex/tasks/task_e_68cf43cba8e08320863f696d437fe732