### PR TITLE
Add order publish example app and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out
 # Summarize traces
 cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
+### Example App: Order Publish
+
+Capability-gated runner writes `/tmp/caps.order.json` with `{"effects":["Network.Out","Observability","Pure"],"allow_writes_prefixes":[]}`.
+It emits TypeScript from `examples/flows/app_order_publish.tf`, runs with the in-memory runtime, and records status + trace artifacts.
+```bash
+node scripts/app-order-publish.mjs
+cat out/0.4/apps/order_publish/summary.json | jq .
+```
+Inspect the pretty summary to confirm publish counts and Network.Out coverage enforced by the manifest.
+
 # Generate capability manifest
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_publish.tf
 node packages/tf-compose/bin/tf-manifest.mjs examples/flows/manifest_storage.tf -o out/0.4/manifests/storage.json

--- a/examples/flows/app_order_publish.tf
+++ b/examples/flows/app_order_publish.tf
@@ -1,0 +1,4 @@
+seq{
+  publish(topic="orders", key="o-1", payload="{}");
+  emit-metric(name="sent")
+}

--- a/scripts/app-order-publish.mjs
+++ b/scripts/app-order-publish.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import { mkdir, writeFile, readFile, access } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tfCli = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+const flowPath = fileURLToPath(new URL('../examples/flows/app_order_publish.tf', import.meta.url));
+const outDir = fileURLToPath(new URL('../out/0.4/apps/order_publish', import.meta.url));
+const runScript = join(outDir, 'run.mjs');
+const statusPath = join(outDir, 'status.json');
+const tracePath = join(outDir, 'trace.jsonl');
+const summaryPath = join(outDir, 'summary.json');
+const capsPath = '/tmp/caps.order.json';
+const traceSummaryCli = fileURLToPath(new URL('../packages/tf-l0-tools/trace-summary.mjs', import.meta.url));
+const runtimeModulePath = new URL('../out/0.4/apps/order_publish/runtime/inmem.mjs', import.meta.url);
+
+async function runProcess(command, args, { cwd = here, env, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: env ? { ...process.env, ...env } : process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+await mkdir(outDir, { recursive: true });
+
+const emitResult = await runProcess(process.execPath, [tfCli, 'emit', '--lang', 'ts', flowPath, '--out', outDir]);
+if (emitResult.code !== 0) {
+  console.error(emitResult.stderr || emitResult.stdout);
+  process.exit(emitResult.code ?? 1);
+}
+
+const caps = {
+  effects: ['Network.Out', 'Observability', 'Pure'],
+  allow_writes_prefixes: [],
+};
+await writeFile(capsPath, JSON.stringify(caps, null, 2) + '\n', 'utf8');
+
+const runEnv = {
+  TF_STATUS_PATH: statusPath,
+  TF_TRACE_PATH: tracePath,
+};
+const runResult = await runProcess(process.execPath, [runScript, '--caps', capsPath], { env: runEnv });
+if (runResult.code !== 0) {
+  console.error(runResult.stderr || runResult.stdout);
+  process.exit(runResult.code ?? 1);
+}
+
+await access(statusPath);
+
+let traceInput;
+try {
+  traceInput = await readFile(tracePath, 'utf8');
+} catch (error) {
+  if (error && error.code !== 'ENOENT') {
+    throw error;
+  }
+  traceInput = runResult.stdout;
+}
+
+if (!traceInput || !traceInput.trim()) {
+  throw new Error('no trace data produced by runner');
+}
+
+async function annotateTrace(raw) {
+  const { default: runtime } = await import(runtimeModulePath);
+  const effectFor = (prim) => {
+    if (!prim) return null;
+    if (runtime && typeof runtime.effectFor === 'function') {
+      return runtime.effectFor(prim);
+    }
+    if (runtime?.effects && prim in runtime.effects) {
+      return runtime.effects[prim];
+    }
+    return null;
+  };
+  const lines = raw.split(/\r?\n/);
+  const out = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed.prim_id === 'string') {
+        if (parsed.effect === undefined) {
+          const effect = effectFor(parsed.prim_id);
+          if (effect) {
+            parsed.effect = effect;
+          }
+        }
+        out.push(JSON.stringify(parsed));
+      }
+    } catch (err) {
+      // ignore malformed lines here; the summary tool will warn if needed
+    }
+  }
+  return out.join('\n');
+}
+
+const annotatedTrace = (await annotateTrace(traceInput)).trimEnd();
+if (!annotatedTrace) {
+  throw new Error('no usable trace events produced by runner');
+}
+
+const summaryResult = await runProcess(process.execPath, [traceSummaryCli, '--pretty'], {
+  input: `${annotatedTrace}\n`,
+});
+if (summaryResult.code !== 0) {
+  console.error(summaryResult.stderr);
+  process.exit(summaryResult.code ?? 1);
+}
+
+await writeFile(summaryPath, summaryResult.stdout.endsWith('\n') ? summaryResult.stdout : `${summaryResult.stdout}\n`, 'utf8');
+
+console.log(`${statusPath} ${summaryPath}`);

--- a/tests/app-order-publish.test.mjs
+++ b/tests/app-order-publish.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { access, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(new URL('../scripts/app-order-publish.mjs', import.meta.url));
+const statusPath = fileURLToPath(new URL('../out/0.4/apps/order_publish/status.json', import.meta.url));
+const summaryPath = fileURLToPath(new URL('../out/0.4/apps/order_publish/summary.json', import.meta.url));
+
+async function runScript() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test('app-order-publish script emits and summarizes order publish flow', async () => {
+  const result = await runScript();
+  assert.equal(result.code, 0, result.stderr);
+
+  await access(statusPath);
+  await access(summaryPath);
+
+  const rawSummary = await readFile(summaryPath, 'utf8');
+  const summary = JSON.parse(rawSummary);
+
+  assert.ok(summary.total >= 1, 'expected total events >= 1');
+  assert.ok(summary.by_prim?.['tf:network/publish@1'] >= 1, 'expected publish primitive count');
+  assert.ok(summary.by_effect?.['Network.Out'] >= 1, 'expected Network.Out effect count');
+});


### PR DESCRIPTION
## Summary
- add an order publish flow example and helper script that emits code, enforces caps, and produces trace summaries
- document how to run the capability-gated example and inspect its artifacts
- add a test that runs the helper script and checks the generated summary contents

## Testing
- node scripts/app-order-publish.mjs
- node --test tests/app-order-publish.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf4bcfac248320afd312d9ccf35088