### PR TITLE
Add order publish app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-filter.m
 Tip: malformed lines are skipped with a warning; pass --quiet to suppress it.
 ```
 
+### Example App: Order Publish
+node scripts/app-order-publish.mjs
+cat out/0.4/apps/order_publish/status.json
+cat out/0.4/apps/order_publish/summary.json | jq .
+Caps file: /tmp/caps.order.json with {"effects":["Network.Out","Observability","Pure"],"allow_writes_prefixes":[]}.
+The generated runner enforces those capabilities before publishing orders.
+Trace summary highlights tf:network/publish@1 counts and Network.Out usage.
+Artifacts live under out/0.4/apps/order_publish/ for reuse.
+
 ### Tree
 - `catalogs/` — legacy YAMLs (frontend_primitives.yaml, information_primitives.yaml, interaction_interface.yaml, observability_telemetry.yaml, policy_governance.yaml, process_computation.yaml, resource_infrastructure.yaml, security_primitives.yaml, state_identity.yaml)
 - `packages/`

--- a/examples/flows/app_order_publish.tf
+++ b/examples/flows/app_order_publish.tf
@@ -1,0 +1,4 @@
+seq{
+  publish(topic="orders", key="o-1", payload="{}");
+  emit-metric(name="sent");
+}

--- a/scripts/app-order-publish.mjs
+++ b/scripts/app-order-publish.mjs
@@ -1,0 +1,114 @@
+import { spawn } from 'node:child_process';
+import { access, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const tfCli = join(repoRoot, 'packages/tf-compose/bin/tf.mjs');
+const flowPath = join(repoRoot, 'examples/flows/app_order_publish.tf');
+const outDir = join(repoRoot, 'out/0.4/apps/order_publish');
+const runScriptPath = join(outDir, 'run.mjs');
+const statusPath = join(outDir, 'status.json');
+const tracePath = join(outDir, 'trace.jsonl');
+const summaryPath = join(outDir, 'summary.json');
+const capsPath = '/tmp/caps.order.json';
+const traceSummaryCli = join(repoRoot, 'packages/tf-l0-tools/trace-summary.mjs');
+
+function runProcess(command, args, { cwd = repoRoot, env = process.env, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function ensureNonEmpty(content, fallbackName) {
+  if (content && content.trim().length > 0) {
+    return content;
+  }
+  throw new Error(`No trace data captured from ${fallbackName}`);
+}
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+
+const emitResult = await runProcess(process.execPath, [tfCli, 'emit', '--lang', 'ts', flowPath, '--out', outDir]);
+if (emitResult.code !== 0) {
+  throw new Error(`tf emit failed: ${emitResult.stderr || emitResult.stdout}`);
+}
+
+await writeFile(
+  capsPath,
+  `${JSON.stringify({ effects: ['Network.Out', 'Observability', 'Pure'], allow_writes_prefixes: [] })}\n`,
+);
+
+const runEnv = {
+  ...process.env,
+  TF_STATUS_PATH: statusPath,
+  TF_TRACE_PATH: tracePath,
+};
+
+const runResult = await runProcess(process.execPath, [runScriptPath, '--caps', capsPath], { env: runEnv });
+if (runResult.code !== 0) {
+  throw new Error(`run.mjs failed: ${runResult.stderr || runResult.stdout}`);
+}
+
+let traceData = '';
+let traceSource = 'stdout';
+try {
+  await access(tracePath);
+  const stats = await stat(tracePath);
+  if (stats.size > 0) {
+    traceData = await readFile(tracePath, 'utf8');
+    traceSource = tracePath;
+  }
+} catch {}
+
+if (!traceData) {
+  traceData = ensureNonEmpty(runResult.stdout, 'run.mjs stdout');
+}
+
+const statusJson = await readFile(statusPath, 'utf8');
+const status = JSON.parse(statusJson);
+let augmentedTrace = traceData;
+if (Array.isArray(status.effects) && status.effects.length > 0) {
+  const effectLines = status.effects.map((effect) => JSON.stringify({ effect }));
+  augmentedTrace = `${traceData.trimEnd()}\n${effectLines.join('\n')}\n`;
+}
+
+const summaryResult = await runProcess(process.execPath, [traceSummaryCli, '--pretty'], { input: augmentedTrace });
+if (summaryResult.code !== 0) {
+  throw new Error(`trace-summary failed: ${summaryResult.stderr || summaryResult.stdout}`);
+}
+
+await writeFile(summaryPath, summaryResult.stdout);
+
+console.log(`status: ${statusPath} summary: ${summaryPath}`);
+if (traceSource === tracePath) {
+  console.log(`trace captured at ${tracePath}`);
+}

--- a/tests/app-order-publish.test.mjs
+++ b/tests/app-order-publish.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { access, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const scriptPath = fileURLToPath(new URL('../scripts/app-order-publish.mjs', import.meta.url));
+const outDir = join(repoRoot, 'out/0.4/apps/order_publish');
+const statusPath = join(outDir, 'status.json');
+const summaryPath = join(outDir, 'summary.json');
+
+function runNodeScript(path) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [path], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test('app order publish script emits artifacts and summary', async () => {
+  const { code, stderr } = await runNodeScript(scriptPath);
+  assert.equal(code, 0, stderr);
+
+  await access(statusPath);
+  await access(summaryPath);
+
+  const rawSummary = await readFile(summaryPath, 'utf8');
+  const summary = JSON.parse(rawSummary);
+
+  assert.ok(summary.total >= 1, 'summary.total should be >= 1');
+  assert.ok(summary.by_prim?.['tf:network/publish@1'] >= 1, 'summary.by_prim should count publish');
+  assert.ok(summary.by_effect?.['Network.Out'] >= 1, 'summary.by_effect should count Network.Out');
+});


### PR DESCRIPTION
## Summary
- add an order publish example flow that publishes an order and emits a metric
- add a runnable script that emits the flow, enforces capabilities, and summarizes the trace
- add a test and README instructions covering the new example

## Testing
- node --test tests/app-order-publish.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf4bcfac248320afd312d9ccf35088