### PR TITLE
Add authorize scope policy checker and CLI

### DIFF
--- a/examples/flows/auth_missing.tf
+++ b/examples/flows/auth_missing.tf
@@ -1,0 +1,1 @@
+sign-data(key="k1")

--- a/examples/flows/auth_ok.tf
+++ b/examples/flows/auth_ok.tf
@@ -1,0 +1,1 @@
+authorize(scope="kms.sign"){ sign-data(key="k1") }

--- a/examples/flows/auth_wrong_scope.tf
+++ b/examples/flows/auth_wrong_scope.tf
@@ -1,0 +1,1 @@
+authorize(scope="kms.decrypt"){ sign-data(key="k1") }

--- a/packages/tf-compose/bin/tf-policy-auth.mjs
+++ b/packages/tf-compose/bin/tf-policy-auth.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+
+const usage =
+  'Usage: node packages/tf-compose/bin/tf-policy-auth.mjs check <flow.tf> [--catalog <path>] [--rules <path>] [--warn-unused] [--strict-warns]';
+
+class CLIError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      catalog: { type: 'string' },
+      rules: { type: 'string' },
+      'warn-unused': { type: 'boolean' },
+      'strict-warns': { type: 'boolean' }
+    },
+    allowPositionals: true
+  });
+
+  if (positionals.length === 0) {
+    throw new CLIError('Missing command');
+  }
+
+  const command = positionals[0];
+  if (command !== 'check') {
+    throw new CLIError(`Unknown command: ${command}`);
+  }
+
+  if (positionals.length < 2) {
+    throw new CLIError('Missing flow path');
+  }
+  if (positionals.length > 2) {
+    throw new CLIError(`Unexpected argument: ${positionals[2]}`);
+  }
+
+  const flowPath = path.resolve(process.cwd(), positionals[1]);
+  const warnUnused = Boolean(values['warn-unused']);
+  const strictWarns = Boolean(values['strict-warns']);
+
+  const [{ parseDSL }, { checkAuthorize }] = await Promise.all([
+    import('../src/parser.mjs'),
+    import('../../tf-l0-check/src/authorize.mjs')
+  ]);
+
+  let flowSource;
+  try {
+    flowSource = await readFile(flowPath, 'utf8');
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to read flow at ${flowPath}: ${reason}`, 1);
+  }
+
+  const ir = parseDSL(flowSource);
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const catalogPath = resolveCatalogPath(values.catalog, scriptDir);
+  const rulesPath = resolveRulesPath(values.rules, scriptDir);
+
+  const [catalog, rules] = await Promise.all([
+    loadJson(catalogPath, 'catalog'),
+    loadJson(rulesPath, 'rules')
+  ]);
+
+  const verdict = checkAuthorize(ir, catalog, rules, {
+    warnUnused,
+    strictWarnsFail: strictWarns
+  });
+
+  const payload = {
+    ok: Boolean(verdict?.ok),
+    reasons: [...(verdict?.reasons || [])],
+    warnings: [...(verdict?.warnings || [])]
+  };
+
+  const output = `${canonicalize(payload)}\n`;
+  process.stdout.write(output);
+
+  if (!payload.ok) {
+    process.exitCode = 1;
+  }
+}
+
+function resolveCatalogPath(override, scriptDir) {
+  if (typeof override === 'string' && override.length > 0) {
+    return path.resolve(process.cwd(), override);
+  }
+  return path.resolve(scriptDir, '..', '..', 'tf-l0-spec', 'spec', 'catalog.json');
+}
+
+function resolveRulesPath(override, scriptDir) {
+  if (typeof override === 'string' && override.length > 0) {
+    return path.resolve(process.cwd(), override);
+  }
+  return path.resolve(scriptDir, '..', '..', 'tf-l0-check', 'rules', 'authorize-scopes.json');
+}
+
+async function loadJson(targetPath, label) {
+  try {
+    const contents = await readFile(targetPath, 'utf8');
+    return JSON.parse(contents);
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to load ${label} JSON at ${targetPath}: ${reason}`, 1);
+  }
+}
+
+main(process.argv).catch((err) => {
+  const exitCode = err instanceof CLIError ? err.exitCode : 1;
+  const message = err && typeof err.message === 'string' ? err.message : String(err);
+  console.error(message);
+  console.error(usage);
+  process.exit(exitCode);
+});

--- a/packages/tf-l0-check/rules/authorize-scopes.json
+++ b/packages/tf-l0-check/rules/authorize-scopes.json
@@ -1,0 +1,6 @@
+{
+  "tf:security/sign-data@1": ["kms.sign"],
+  "tf:security/verify-signature@1": [],
+  "tf:security/encrypt@1": ["kms.encrypt"],
+  "tf:security/decrypt@1": ["kms.decrypt"]
+}

--- a/packages/tf-l0-check/src/authorize.mjs
+++ b/packages/tf-l0-check/src/authorize.mjs
@@ -1,0 +1,369 @@
+const DEFAULT_OPTS = {
+  warnUnused: false,
+  strictWarnsFail: false
+};
+
+const PROTECTED_NAME_PATTERN = /^(sign-data|encrypt|decrypt)$/i;
+
+export function checkAuthorize(ir, catalog, rules, opts = {}) {
+  const options = { ...DEFAULT_OPTS, ...(opts || {}) };
+  const normalizedRules = isObject(rules) ? rules : {};
+  const reasons = [];
+  const warnings = [];
+  const scopeStack = [];
+  const authorizeEntries = [];
+
+  visit(ir);
+
+  if (options.warnUnused) {
+    for (const entry of authorizeEntries) {
+      for (const scope of entry.scopes) {
+        if (!entry.usedScopes.has(scope)) {
+          warnings.push(`auth: unused authorize scope "${scope}"`);
+        }
+      }
+    }
+  }
+
+  const ok =
+    reasons.length === 0 && (!options.strictWarnsFail || warnings.length === 0);
+
+  return { ok, reasons, warnings };
+
+  function visit(node) {
+    if (node == null) {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        visit(child);
+      }
+      return;
+    }
+
+    if (typeof node !== 'object') {
+      return;
+    }
+
+    if (node.node === 'Region' && node.kind === 'Authorize') {
+      const scopes = extractAuthorizeScopes(node?.attrs);
+      const entry = { scopes, usedScopes: new Set() };
+      scopeStack.push(entry);
+      authorizeEntries.push(entry);
+      for (const child of node.children || []) {
+        visit(child);
+      }
+      scopeStack.pop();
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      handlePrim(node);
+    }
+
+    const children = Array.isArray(node.children) ? node.children : [];
+    for (const child of children) {
+      visit(child);
+    }
+  }
+
+  function handlePrim(node) {
+    const requiredScopes = getRequiredScopes(node, catalog, normalizedRules);
+    if (requiredScopes.length === 0) {
+      return;
+    }
+
+    const displayName = getPrimDisplayName(node);
+
+    if (scopeStack.length === 0) {
+      reasons.push(
+        `auth: ${displayName} requires Authorize{scope in [${requiredScopes.join(', ')}]}`
+      );
+      return;
+    }
+
+    let matched = false;
+    for (let i = scopeStack.length - 1; i >= 0; i -= 1) {
+      const entry = scopeStack[i];
+      const intersection = intersectScopes(entry.scopes, requiredScopes);
+      if (intersection.length > 0) {
+        matched = true;
+        for (const scope of intersection) {
+          entry.usedScopes.add(scope);
+        }
+        break;
+      }
+    }
+
+    if (matched) {
+      return;
+    }
+
+    const available = collectAvailableScopes(scopeStack);
+    reasons.push(
+      `auth: scope mismatch for ${displayName} (have [${available.join(', ')}], need one of [${requiredScopes.join(', ')}])`
+    );
+  }
+}
+
+function intersectScopes(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return [];
+  }
+  const setB = new Set(b);
+  const result = [];
+  for (const scope of a) {
+    if (setB.has(scope)) {
+      result.push(scope);
+    }
+  }
+  return result;
+}
+
+function collectAvailableScopes(stack) {
+  const result = [];
+  const seen = new Set();
+  for (const entry of stack) {
+    for (const scope of entry.scopes || []) {
+      if (!seen.has(scope)) {
+        seen.add(scope);
+        result.push(scope);
+      }
+    }
+  }
+  return result;
+}
+
+function extractAuthorizeScopes(attrs) {
+  if (!attrs || typeof attrs !== 'object') {
+    return [];
+  }
+
+  const raw =
+    attrs.scope !== undefined
+      ? attrs.scope
+      : attrs.scopes !== undefined
+      ? attrs.scopes
+      : [];
+
+  if (Array.isArray(raw)) {
+    return normalizeScopeList(raw);
+  }
+
+  if (typeof raw === 'string') {
+    if (raw.includes(',')) {
+      return normalizeScopeList(raw.split(','));
+    }
+    return normalizeScopeList([raw]);
+  }
+
+  return [];
+}
+
+function normalizeScopeList(list) {
+  const result = [];
+  const seen = new Set();
+  for (const value of list || []) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function getRequiredScopes(node, catalog, rules) {
+  const canonicalId = getCanonicalId(node);
+  if (canonicalId) {
+    const direct = rules[canonicalId];
+    if (Array.isArray(direct)) {
+      return normalizeScopeList(direct);
+    }
+    if (direct !== undefined) {
+      return [];
+    }
+  }
+
+  const baseName = getBaseName(node);
+  if (!baseName) {
+    return [];
+  }
+
+  if (!hasCryptoEffect(node, catalog)) {
+    return [];
+  }
+
+  if (!PROTECTED_NAME_PATTERN.test(baseName)) {
+    return [];
+  }
+
+  const fallback = findRuleScopesByBase(rules, baseName);
+  if (Array.isArray(fallback)) {
+    return normalizeScopeList(fallback);
+  }
+
+  return [];
+}
+
+function findRuleScopesByBase(rules, baseName) {
+  const target = typeof baseName === 'string' ? baseName.toLowerCase() : '';
+  if (!target) {
+    return null;
+  }
+
+  for (const [key, value] of Object.entries(rules || {})) {
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    const base = extractBaseNameFromId(key).toLowerCase();
+    if (base === target) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function getPrimDisplayName(node) {
+  const canonicalId = getCanonicalId(node);
+  if (canonicalId) {
+    return canonicalId;
+  }
+  if (typeof node?.prim === 'string' && node.prim.length > 0) {
+    return node.prim;
+  }
+  if (typeof node?.id === 'string' && node.id.length > 0) {
+    return node.id;
+  }
+  return 'primitive';
+}
+
+function getCanonicalId(node) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  const candidates = [
+    node.canonical_id,
+    node.canonicalId,
+    node.prim_id,
+    node.primId,
+    node.id
+  ];
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function getBaseName(node) {
+  const canonicalId = getCanonicalId(node);
+  if (canonicalId) {
+    const baseFromId = extractBaseNameFromId(canonicalId);
+    if (baseFromId) {
+      return baseFromId;
+    }
+  }
+
+  if (typeof node?.prim === 'string' && node.prim.length > 0) {
+    return node.prim;
+  }
+
+  return '';
+}
+
+function extractBaseNameFromId(id) {
+  if (typeof id !== 'string' || id.length === 0) {
+    return '';
+  }
+  const match = /\/([^/@]+)(?:@\d+)?$/.exec(id);
+  if (match) {
+    return match[1];
+  }
+  const trimmed = id.split('@')[0];
+  const slash = trimmed.lastIndexOf('/');
+  if (slash >= 0) {
+    return trimmed.slice(slash + 1);
+  }
+  const colon = trimmed.lastIndexOf(':');
+  if (colon >= 0) {
+    return trimmed.slice(colon + 1);
+  }
+  return trimmed;
+}
+
+function hasCryptoEffect(node, catalog) {
+  const entry = lookupCatalogEntry(node, catalog);
+  const effects = Array.isArray(entry?.effects) ? entry.effects : [];
+  return effects.some(
+    (effect) => typeof effect === 'string' && effect.toLowerCase() === 'crypto'
+  );
+}
+
+function lookupCatalogEntry(node, catalog) {
+  const primitives = Array.isArray(catalog?.primitives)
+    ? catalog.primitives
+    : [];
+  if (primitives.length === 0) {
+    return null;
+  }
+
+  const canonicalId = getCanonicalId(node);
+  if (canonicalId) {
+    const lowered = canonicalId.toLowerCase();
+    const byId = primitives.find(
+      (prim) => typeof prim?.id === 'string' && prim.id.toLowerCase() === lowered
+    );
+    if (byId) {
+      return byId;
+    }
+  }
+
+  const name = typeof node?.prim === 'string' ? node.prim : '';
+  if (name) {
+    const loweredName = name.toLowerCase();
+    const byName = primitives.find(
+      (prim) => typeof prim?.name === 'string' && prim.name.toLowerCase() === loweredName
+    );
+    if (byName) {
+      return byName;
+    }
+
+    const regex = new RegExp(`/${escapeRegex(loweredName)}@\\d+$`, 'i');
+    for (const prim of primitives) {
+      if (typeof prim?.id === 'string' && regex.test(prim.id)) {
+        return prim;
+      }
+    }
+  }
+
+  if (canonicalId) {
+    const base = extractBaseNameFromId(canonicalId);
+    if (base) {
+      const loweredBase = base.toLowerCase();
+      const regex = new RegExp(`/${escapeRegex(loweredBase)}@\\d+$`, 'i');
+      for (const prim of primitives) {
+        if (typeof prim?.id === 'string' && regex.test(prim.id)) {
+          return prim;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object';
+}

--- a/tests/policy-authorize.test.mjs
+++ b/tests/policy-authorize.test.mjs
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkAuthorize } = await import('../packages/tf-l0-check/src/authorize.mjs');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const catalogPath = path.resolve(repoRoot, 'packages/tf-l0-spec/spec/catalog.json');
+const rulesPath = path.resolve(repoRoot, 'packages/tf-l0-check/rules/authorize-scopes.json');
+
+async function loadJson(target) {
+  const contents = await readFile(target, 'utf8');
+  return JSON.parse(contents);
+}
+
+const [catalog, rules] = await Promise.all([
+  loadJson(catalogPath),
+  loadJson(rulesPath)
+]);
+
+async function readFlow(relativePath) {
+  return readFile(path.resolve(repoRoot, relativePath), 'utf8');
+}
+
+async function runAuthCli(args, options = {}) {
+  const cliPath = path.resolve(repoRoot, 'packages/tf-compose/bin/tf-policy-auth.mjs');
+  const child = spawn(process.execPath, [cliPath, ...args], {
+    cwd: options.cwd ?? repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  const stdoutChunks = [];
+  const stderrChunks = [];
+
+  child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+  child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+  const code = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+
+  return {
+    code,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8')
+  };
+}
+
+test('authorize region satisfies scope requirement', async () => {
+  const src = await readFlow('examples/flows/auth_ok.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+  assert.deepEqual(verdict.warnings, []);
+});
+
+test('mismatched authorize scope is flagged', async () => {
+  const src = await readFlow('examples/flows/auth_wrong_scope.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, false);
+  assert.ok(verdict.reasons.some((reason) => reason.includes('scope mismatch')));
+});
+
+test('missing authorize region is flagged', async () => {
+  const src = await readFlow('examples/flows/auth_missing.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, false);
+  assert.ok(verdict.reasons.some((reason) => reason.includes('requires Authorize')));
+});
+
+test('warn-unused option marks unused authorize scopes', async () => {
+  const ir = parseDSL('authorize(scope="kms.sign"){ emit-metric(key="ok") }');
+  const verdict = checkAuthorize(ir, catalog, rules, { warnUnused: true });
+
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+  assert.deepEqual(verdict.warnings, ['auth: unused authorize scope "kms.sign"']);
+});
+
+test('strict-warns option fails when warnings are present', async () => {
+  const ir = parseDSL('authorize(scope="kms.sign"){ emit-metric(key="ok") }');
+  const verdict = checkAuthorize(ir, catalog, rules, {
+    warnUnused: true,
+    strictWarnsFail: true
+  });
+
+  assert.equal(verdict.ok, false);
+  assert.deepEqual(verdict.reasons, []);
+  assert.deepEqual(verdict.warnings, ['auth: unused authorize scope "kms.sign"']);
+});
+
+test('auth policy CLI reports success for valid flow', async () => {
+  const result = await runAuthCli(['check', 'examples/flows/auth_ok.tf']);
+
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.reasons, []);
+  assert.deepEqual(parsed.warnings, []);
+});
+
+test('auth policy CLI exposes reasons on failure', async () => {
+  const result = await runAuthCli(['check', 'examples/flows/auth_wrong_scope.tf']);
+
+  assert.equal(result.code, 1);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, false);
+  assert.ok(parsed.reasons.some((reason) => reason.includes('scope mismatch')));
+  assert.equal(Array.isArray(parsed.warnings), true);
+});


### PR DESCRIPTION
## Summary
- add an authorization dominance checker capable of validating authorize scope coverage and reporting unused scopes
- wire the checker into a new tf-policy-auth CLI with support for optional catalog/rules paths and warning controls
- cover the feature with dedicated examples and node:test coverage for happy-path, failure, warnings, and CLI flows

## Testing
- node --test tests/policy-authorize.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf4bb9a98883209762256fb1c0d925