### PR TITLE
Add authorize policy checker and CLI

### DIFF
--- a/examples/flows/auth_missing.tf
+++ b/examples/flows/auth_missing.tf
@@ -1,0 +1,1 @@
+sign-data(key="k1")

--- a/examples/flows/auth_ok.tf
+++ b/examples/flows/auth_ok.tf
@@ -1,0 +1,3 @@
+authorize(scope="kms.sign"){
+  sign-data(key="k1")
+}

--- a/examples/flows/auth_wrong_scope.tf
+++ b/examples/flows/auth_wrong_scope.tf
@@ -1,0 +1,3 @@
+authorize(scope="kms.decrypt"){
+  sign-data(key="k1")
+}

--- a/packages/tf-compose/bin/tf-policy-auth.mjs
+++ b/packages/tf-compose/bin/tf-policy-auth.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+
+const usage = 'Usage: node packages/tf-compose/bin/tf-policy-auth.mjs check <flow.tf> [--catalog <path>] [--rules <path>] [--warn-unused] [--strict-warns]';
+
+class CLIError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      catalog: { type: 'string' },
+      rules: { type: 'string' },
+      'warn-unused': { type: 'boolean' },
+      'strict-warns': { type: 'boolean' }
+    },
+    allowPositionals: true
+  });
+
+  if (positionals.length === 0) {
+    throw new CLIError('Missing command');
+  }
+
+  const command = positionals[0];
+  if (command !== 'check') {
+    throw new CLIError(`Unknown command: ${command}`);
+  }
+
+  if (positionals.length < 2) {
+    throw new CLIError('Missing flow path');
+  }
+  if (positionals.length > 2) {
+    throw new CLIError(`Unexpected argument: ${positionals[2]}`);
+  }
+
+  const flowPath = path.resolve(process.cwd(), positionals[1]);
+  const warnUnused = Boolean(values['warn-unused']);
+  const strictWarns = Boolean(values['strict-warns']);
+
+  const [{ parseDSL }, { checkAuthorize }] = await Promise.all([
+    import('../src/parser.mjs'),
+    import('../../tf-l0-check/src/authorize.mjs')
+  ]);
+
+  let flowSource;
+  try {
+    flowSource = await readFile(flowPath, 'utf8');
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to read flow at ${flowPath}: ${reason}`, 1);
+  }
+
+  const ir = parseDSL(flowSource);
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const catalogPath = resolvePathOption(values.catalog, scriptDir, ['..', '..', 'tf-l0-spec', 'spec', 'catalog.json']);
+  const rulesPath = resolvePathOption(values.rules, scriptDir, ['..', '..', 'tf-l0-check', 'rules', 'authorize-scopes.json']);
+
+  let catalog;
+  try {
+    const contents = await readFile(catalogPath, 'utf8');
+    catalog = JSON.parse(contents);
+  } catch (err) {
+    console.error('warn: catalog not found or invalid; falling back to name-based detection');
+    catalog = { primitives: [] };
+  }
+
+  let rules;
+  try {
+    const contents = await readFile(rulesPath, 'utf8');
+    rules = JSON.parse(contents);
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to load authorize rules at ${rulesPath}: ${reason}`, 1);
+  }
+
+  const verdict = checkAuthorize(ir, catalog, rules, {
+    warnUnused,
+    strictWarnsFail: strictWarns
+  });
+
+  const payload = {
+    ok: Boolean(verdict?.ok),
+    reasons: [...(verdict?.reasons || [])],
+    warnings: [...(verdict?.warnings || [])]
+  };
+
+  const output = `${canonicalize(payload)}\n`;
+  process.stdout.write(output);
+
+  if (!payload.ok) {
+    process.exitCode = 1;
+  }
+}
+
+function resolvePathOption(overridePath, scriptDir, relativeSegments) {
+  if (typeof overridePath === 'string' && overridePath.length > 0) {
+    return path.resolve(process.cwd(), overridePath);
+  }
+  return path.resolve(scriptDir, ...relativeSegments);
+}
+
+main(process.argv).catch((err) => {
+  const exitCode = err instanceof CLIError ? err.exitCode : 1;
+  const message = err && typeof err.message === 'string' ? err.message : String(err);
+  console.error(message);
+  console.error(usage);
+  process.exit(exitCode);
+});

--- a/packages/tf-l0-check/rules/authorize-scopes.json
+++ b/packages/tf-l0-check/rules/authorize-scopes.json
@@ -1,0 +1,6 @@
+{
+  "tf:security/sign-data@1": ["kms.sign"],
+  "tf:security/verify-signature@1": [],
+  "tf:security/encrypt@1": ["kms.encrypt"],
+  "tf:security/decrypt@1": ["kms.decrypt"]
+}

--- a/packages/tf-l0-check/src/authorize.mjs
+++ b/packages/tf-l0-check/src/authorize.mjs
@@ -1,0 +1,259 @@
+const DEFAULT_OPTS = {
+  warnUnused: false,
+  strictWarnsFail: false
+};
+
+const FALLBACK_SCOPE_BY_BASENAME = {
+  'sign-data': ['kms.sign'],
+  encrypt: ['kms.encrypt'],
+  decrypt: ['kms.decrypt']
+};
+
+const SPECIAL_REGEX_CHARS = /[.*+?^${}()|[\]\\]/g;
+
+export function checkAuthorize(ir, catalog, rules = {}, opts = {}) {
+  const options = { ...DEFAULT_OPTS, ...(opts || {}) };
+  const ruleMap = buildRuleMap(rules);
+  const reasons = [];
+  const warnings = [];
+  const authorizeStack = [];
+
+  function visit(node) {
+    if (node == null) {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        visit(child);
+      }
+      return;
+    }
+
+    if (typeof node !== 'object') {
+      return;
+    }
+
+    if (node.node === 'Region' && node.kind === 'Authorize') {
+      const scopes = normalizeScopes(node?.attrs);
+      const frame = { scopes, used: false };
+      authorizeStack.push(frame);
+      const children = Array.isArray(node.children) ? node.children : [];
+      for (const child of children) {
+        visit(child);
+      }
+      authorizeStack.pop();
+      if (options.warnUnused && scopes.length > 0 && !frame.used) {
+        for (const scope of scopes) {
+          warnings.push(`auth: unused authorize scope "${scope}"`);
+        }
+      }
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      handlePrim(node);
+    }
+
+    const children = Array.isArray(node.children) ? node.children : [];
+    for (const child of children) {
+      visit(child);
+    }
+  }
+
+  function handlePrim(node) {
+    const rawName = typeof node?.prim === 'string' ? node.prim : '';
+    if (!rawName) {
+      return;
+    }
+
+    const lowerName = rawName.toLowerCase();
+    const catalogEntry = lookupCatalogPrimitive(catalog, lowerName);
+    const canonicalId = catalogEntry?.id?.toLowerCase() ?? (isCanonicalId(lowerName) ? lowerName : null);
+    const baseName = baseNameFromPrim(canonicalId ?? lowerName);
+
+    let requiredScopes = ruleMap.get(canonicalId ?? '') ?? [];
+    if (requiredScopes.length === 0) {
+      const fallback = fallbackScopes(baseName, catalogEntry);
+      if (fallback.length === 0) {
+        return;
+      }
+      requiredScopes = fallback;
+    }
+
+    if (authorizeStack.length === 0) {
+      reasons.push(`auth: ${displayPrim(canonicalId, rawName)} requires Authorize{scope in [${requiredScopes.join(', ')}]}`);
+      return;
+    }
+
+    let satisfied = false;
+    const collectedScopes = [];
+    for (let i = authorizeStack.length - 1; i >= 0; i -= 1) {
+      const frame = authorizeStack[i];
+      for (const scope of frame.scopes) {
+        if (!collectedScopes.includes(scope)) {
+          collectedScopes.push(scope);
+        }
+      }
+      const matches = intersectScopes(frame.scopes, requiredScopes);
+      if (matches.length > 0) {
+        frame.used = true;
+        satisfied = true;
+      }
+    }
+
+    if (!satisfied) {
+      const haveList = collectedScopes.length > 0 ? collectedScopes : ['<none>'];
+      reasons.push(
+        `auth: scope mismatch for ${displayPrim(canonicalId, rawName)} (have [${haveList.join(', ')}], need one of [${requiredScopes.join(', ')}])`
+      );
+    }
+  }
+
+  visit(ir);
+
+  const ok = reasons.length === 0 && (!options.strictWarnsFail || warnings.length === 0);
+
+  return { ok, reasons, warnings };
+}
+
+function buildRuleMap(rules) {
+  const map = new Map();
+  if (rules instanceof Map) {
+    for (const [key, value] of rules.entries()) {
+      const scopes = normalizeScopeList(value);
+      if (key) {
+        map.set(String(key).toLowerCase(), scopes);
+      }
+    }
+    return map;
+  }
+  const entries = rules && typeof rules === 'object' ? Object.entries(rules) : [];
+  for (const [key, value] of entries) {
+    if (!key) continue;
+    map.set(String(key).toLowerCase(), normalizeScopeList(value));
+  }
+  return map;
+}
+
+function normalizeScopeList(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out = [];
+  for (const scope of value) {
+    if (typeof scope === 'string' && scope.length > 0) {
+      if (!out.includes(scope)) {
+        out.push(scope);
+      }
+    }
+  }
+  return out;
+}
+
+function normalizeScopes(attrs = {}) {
+  const source = attrs.scope ?? attrs.scopes ?? [];
+  if (Array.isArray(source)) {
+    return source
+      .filter((value) => typeof value === 'string' && value.length > 0)
+      .map((value) => value)
+      .filter((value, index, arr) => arr.indexOf(value) === index);
+  }
+  if (typeof source === 'string') {
+    return source
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value, index, arr) => value.length > 0 && arr.indexOf(value) === index);
+  }
+  return [];
+}
+
+function fallbackScopes(baseName, catalogEntry) {
+  if (!catalogEntry) {
+    return [];
+  }
+  const effects = Array.isArray(catalogEntry.effects) ? catalogEntry.effects : [];
+  const hasCrypto = effects.some((effect) => typeof effect === 'string' && effect.toLowerCase() === 'crypto');
+  if (!hasCrypto) {
+    return [];
+  }
+  const lowerBase = baseName.toLowerCase();
+  const fallback = FALLBACK_SCOPE_BY_BASENAME[lowerBase];
+  if (!Array.isArray(fallback) || fallback.length === 0) {
+    return [];
+  }
+  return fallback;
+}
+
+function intersectScopes(a = [], b = []) {
+  const result = [];
+  for (const scope of a) {
+    if (b.includes(scope) && !result.includes(scope)) {
+      result.push(scope);
+    }
+  }
+  return result;
+}
+
+function lookupCatalogPrimitive(catalog, name) {
+  const primitives = Array.isArray(catalog?.primitives) ? catalog.primitives : [];
+  if (primitives.length === 0) {
+    return null;
+  }
+  if (!name) {
+    return null;
+  }
+  const lowerName = name.toLowerCase();
+  for (const prim of primitives) {
+    const id = typeof prim?.id === 'string' ? prim.id.toLowerCase() : '';
+    if (id && id === lowerName) {
+      return prim;
+    }
+  }
+  for (const prim of primitives) {
+    const primName = typeof prim?.name === 'string' ? prim.name.toLowerCase() : '';
+    if (primName && primName === lowerName) {
+      return prim;
+    }
+  }
+  if (!lowerName.includes(':') && !lowerName.includes('/')) {
+    const regex = new RegExp(`/${escapeRegex(lowerName)}@\\d+$`, 'i');
+    for (const prim of primitives) {
+      const id = typeof prim?.id === 'string' ? prim.id : '';
+      if (id && regex.test(id)) {
+        return prim;
+      }
+    }
+  }
+  return null;
+}
+
+function escapeRegex(value) {
+  return value.replace(SPECIAL_REGEX_CHARS, '\\$&');
+}
+
+function baseNameFromPrim(primName = '') {
+  if (!primName) {
+    return '';
+  }
+  const afterSlash = primName.lastIndexOf('/');
+  const afterColon = primName.lastIndexOf(':');
+  const start = Math.max(afterSlash, afterColon);
+  let base = start >= 0 ? primName.slice(start + 1) : primName;
+  const at = base.indexOf('@');
+  if (at >= 0) {
+    base = base.slice(0, at);
+  }
+  return base;
+}
+
+function isCanonicalId(value) {
+  return typeof value === 'string' && value.includes(':') && value.includes('/') && value.includes('@');
+}
+
+function displayPrim(canonicalId, rawName) {
+  if (canonicalId) {
+    return canonicalId;
+  }
+  return rawName;
+}

--- a/tests/policy-authorize.test.mjs
+++ b/tests/policy-authorize.test.mjs
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, mkdtemp, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkAuthorize } = await import('../packages/tf-l0-check/src/authorize.mjs');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const catalogPath = path.resolve(repoRoot, 'packages/tf-l0-spec/spec/catalog.json');
+const rulesPath = path.resolve(repoRoot, 'packages/tf-l0-check/rules/authorize-scopes.json');
+
+async function loadJSON(filePath) {
+  const contents = await readFile(filePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+const [catalog, rules] = await Promise.all([loadJSON(catalogPath), loadJSON(rulesPath)]);
+
+async function readFlow(relativePath) {
+  return readFile(path.resolve(repoRoot, relativePath), 'utf8');
+}
+
+async function runAuthCli(args, options = {}) {
+  const cliPath = path.resolve(repoRoot, 'packages/tf-compose/bin/tf-policy-auth.mjs');
+  const child = spawn(process.execPath, [cliPath, ...args], {
+    cwd: options.cwd ?? repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  const stdoutChunks = [];
+  const stderrChunks = [];
+
+  child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+  child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+  const code = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+
+  return {
+    code,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8')
+  };
+}
+
+async function writeTempFlow(contents) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'tf-auth-'));
+  const file = path.join(dir, 'flow.tf');
+  await writeFile(file, contents, 'utf8');
+  return file;
+}
+
+test('authorize checker passes when scope matches requirement', async () => {
+  const src = await readFlow('examples/flows/auth_ok.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+  assert.deepEqual(verdict.warnings, []);
+});
+
+test('authorize checker flags scope mismatch', async () => {
+  const src = await readFlow('examples/flows/auth_wrong_scope.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, false);
+  assert.equal(verdict.reasons.some((msg) => msg.includes('scope mismatch for tf:security/sign-data@1')), true);
+});
+
+test('authorize checker requires authorize region for protected primitive', async () => {
+  const src = await readFlow('examples/flows/auth_missing.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, false);
+  assert.equal(verdict.reasons.some((msg) => msg.includes('requires Authorize{scope in [kms.sign]}')), true);
+});
+
+test('authorize checker reports unused scopes when requested', async () => {
+  const src = 'authorize(scope="kms.sign"){ emit-metric(key="ok") }';
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules, { warnUnused: true });
+
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.warnings, ['auth: unused authorize scope "kms.sign"']);
+});
+
+test('auth policy CLI succeeds on valid flow', async () => {
+  const result = await runAuthCli(['check', 'examples/flows/auth_ok.tf']);
+
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.reasons, []);
+  assert.deepEqual(parsed.warnings, []);
+});
+
+test('auth policy CLI reports scope mismatch', async () => {
+  const result = await runAuthCli(['check', 'examples/flows/auth_wrong_scope.tf']);
+
+  assert.equal(result.code, 1);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reasons.some((msg) => msg.includes('scope mismatch')), true);
+});
+
+test('auth policy CLI reports missing authorize region', async () => {
+  const result = await runAuthCli(['check', 'examples/flows/auth_missing.tf']);
+
+  assert.equal(result.code, 1);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reasons.some((msg) => msg.includes('requires Authorize')), true);
+});
+
+test('auth policy CLI warns on unused scopes when enabled', async () => {
+  const tempFlow = await writeTempFlow('authorize(scope="kms.sign"){ emit-metric(key="ok") }');
+  const relPath = path.relative(repoRoot, tempFlow);
+  const result = await runAuthCli(['check', relPath, '--warn-unused']);
+
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.warnings, ['auth: unused authorize scope "kms.sign"']);
+});
+
+test('auth policy CLI treats warnings as failures when strict', async () => {
+  const tempFlow = await writeTempFlow('authorize(scope="kms.sign"){ emit-metric(key="ok") }');
+  const relPath = path.relative(repoRoot, tempFlow);
+  const result = await runAuthCli(['check', relPath, '--warn-unused', '--strict-warns']);
+
+  assert.equal(result.code, 1);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, false);
+  assert.deepEqual(parsed.warnings, ['auth: unused authorize scope "kms.sign"']);
+});


### PR DESCRIPTION
## Summary
- add an authorization dominance checker that validates primitives against scope rules
- introduce a standalone `tf-policy-auth` CLI backed by JSON rules and catalog-driven fallbacks
- cover the new functionality with dedicated flows and policy tests

## Testing
- node --test tests/policy-authorize.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf4bb9a98883209762256fb1c0d925