### PR TITLE
Add authorize scope checker and CLI

### DIFF
--- a/examples/flows/auth_missing.tf
+++ b/examples/flows/auth_missing.tf
@@ -1,0 +1,1 @@
+sign-data(key="k1")

--- a/examples/flows/auth_ok.tf
+++ b/examples/flows/auth_ok.tf
@@ -1,0 +1,1 @@
+authorize(scope="kms.sign"){ sign-data(key="k1") }

--- a/examples/flows/auth_wrong_scope.tf
+++ b/examples/flows/auth_wrong_scope.tf
@@ -1,0 +1,1 @@
+authorize(scope="kms.decrypt"){ sign-data(key="k1") }

--- a/packages/tf-compose/bin/tf-policy-auth.mjs
+++ b/packages/tf-compose/bin/tf-policy-auth.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { canonicalize } from '../../tf-l0-ir/src/hash.mjs';
+
+const usage = 'Usage: node packages/tf-compose/bin/tf-policy-auth.mjs check <flow.tf> [--catalog path] [--rules path] [--warn-unused] [--strict-warns]';
+
+class CLIError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      catalog: { type: 'string' },
+      rules: { type: 'string' },
+      'warn-unused': { type: 'boolean' },
+      'strict-warns': { type: 'boolean' }
+    },
+    allowPositionals: true
+  });
+
+  if (positionals.length === 0) {
+    throw new CLIError('Missing command');
+  }
+  const command = positionals[0];
+  if (command !== 'check') {
+    throw new CLIError(`Unknown command: ${command}`);
+  }
+  if (positionals.length < 2) {
+    throw new CLIError('Missing flow path');
+  }
+  if (positionals.length > 2) {
+    throw new CLIError(`Unexpected argument: ${positionals[2]}`);
+  }
+
+  const flowPath = path.resolve(process.cwd(), positionals[1]);
+  const warnUnused = Boolean(values['warn-unused']);
+  const strictWarns = Boolean(values['strict-warns']);
+
+  const [{ parseDSL }, { checkAuthorize }] = await Promise.all([
+    import('../src/parser.mjs'),
+    import('../../tf-l0-check/src/authorize.mjs')
+  ]);
+
+  let flowSource;
+  try {
+    flowSource = await readFile(flowPath, 'utf8');
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to read flow at ${flowPath}: ${reason}`, 1);
+  }
+
+  const ir = parseDSL(flowSource);
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const [catalog, rules] = await Promise.all([
+    loadCatalog(values.catalog, scriptDir),
+    loadRules(values.rules, scriptDir)
+  ]);
+
+  const verdict = checkAuthorize(ir, catalog, rules, {
+    warnUnused,
+    strictWarnsFail: strictWarns
+  });
+
+  const payload = {
+    ok: Boolean(verdict?.ok),
+    reasons: [...(verdict?.reasons || [])],
+    warnings: [...(verdict?.warnings || [])]
+  };
+
+  const output = `${canonicalize(payload)}\n`;
+  process.stdout.write(output);
+
+  if (!payload.ok) {
+    process.exitCode = 1;
+  }
+}
+
+async function loadCatalog(overridePath, scriptDir) {
+  const target = resolvePath(overridePath, scriptDir, '../../tf-l0-spec/spec/catalog.json');
+  if (!target) {
+    return null;
+  }
+  try {
+    const contents = await readFile(target, 'utf8');
+    return JSON.parse(contents);
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to read catalog at ${target}: ${reason}`, 1);
+  }
+}
+
+async function loadRules(overridePath, scriptDir) {
+  const target = resolvePath(overridePath, scriptDir, '../../tf-l0-check/rules/authorize-scopes.json');
+  if (!target) {
+    throw new CLIError('Rules path could not be resolved', 1);
+  }
+  try {
+    const contents = await readFile(target, 'utf8');
+    return JSON.parse(contents);
+  } catch (err) {
+    const reason = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new CLIError(`Failed to read rules at ${target}: ${reason}`, 1);
+  }
+}
+
+function resolvePath(overridePath, scriptDir, relativeDefault) {
+  if (typeof overridePath === 'string' && overridePath.length > 0) {
+    return path.resolve(process.cwd(), overridePath);
+  }
+  if (!scriptDir) {
+    return null;
+  }
+  return path.resolve(scriptDir, relativeDefault);
+}
+
+main(process.argv).catch((err) => {
+  const exitCode = err instanceof CLIError ? err.exitCode : 1;
+  const message = err && typeof err.message === 'string' ? err.message : String(err);
+  console.error(message);
+  console.error(usage);
+  process.exit(exitCode);
+});

--- a/packages/tf-l0-check/rules/authorize-scopes.json
+++ b/packages/tf-l0-check/rules/authorize-scopes.json
@@ -1,0 +1,6 @@
+{
+  "tf:security/sign-data@1": ["kms.sign"],
+  "tf:security/verify-signature@1": [],
+  "tf:security/encrypt@1": ["kms.encrypt"],
+  "tf:security/decrypt@1": ["kms.decrypt"]
+}

--- a/packages/tf-l0-check/src/authorize.mjs
+++ b/packages/tf-l0-check/src/authorize.mjs
@@ -1,0 +1,301 @@
+const PROTECTED_NAMES = ['sign-data', 'encrypt', 'decrypt'];
+
+const DEFAULT_OPTS = {
+  warnUnused: false,
+  strictWarnsFail: false
+};
+
+export function checkAuthorize(ir, catalog, rules, opts = DEFAULT_OPTS) {
+  const options = { ...DEFAULT_OPTS, ...(opts || {}) };
+  const ruleMap = buildRuleMap(rules);
+  const reasons = [];
+  const warnings = [];
+
+  function visit(node, stack) {
+    if (node == null) {
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        visit(child, stack);
+      }
+      return;
+    }
+    if (typeof node !== 'object') {
+      return;
+    }
+
+    if (node.node === 'Region') {
+      if (node.kind === 'Authorize') {
+        const scopes = extractScopes(node.attrs);
+        const entry = { scopes, used: false };
+        const nextStack = stack.concat(entry);
+        const children = Array.isArray(node.children) ? node.children : [];
+        for (const child of children) {
+          visit(child, nextStack);
+        }
+        if (options.warnUnused && !entry.used) {
+          for (const scope of entry.scopes) {
+            warnings.push(`auth: unused authorize scope "${scope}"`);
+          }
+        }
+        return;
+      }
+      const children = Array.isArray(node.children) ? node.children : [];
+      for (const child of children) {
+        visit(child, stack);
+      }
+      return;
+    }
+
+    if (node.node === 'Prim') {
+      handlePrim(node, stack);
+      return;
+    }
+
+    const children = Array.isArray(node.children) ? node.children : [];
+    for (const child of children) {
+      visit(child, stack);
+    }
+  }
+
+  function handlePrim(node, stack) {
+    const baseName = normalizeName(node.prim);
+    if (!baseName) {
+      return;
+    }
+
+    const catalogEntry = lookupCatalogEntry(catalog, node, baseName);
+    const canonicalCandidates = [];
+    const fromNode = inferCanonicalId(node);
+    if (fromNode) {
+      canonicalCandidates.push(fromNode);
+    }
+    if (catalogEntry?.id && !canonicalCandidates.includes(catalogEntry.id)) {
+      canonicalCandidates.push(catalogEntry.id);
+    }
+
+    let matchedId = null;
+    let requiredScopes = [];
+    for (const candidate of canonicalCandidates) {
+      const scopes = getRuleScopes(ruleMap, candidate);
+      if (scopes.length > 0) {
+        matchedId = candidate;
+        requiredScopes = scopes;
+        break;
+      }
+    }
+
+    if (requiredScopes.length === 0 && catalogEntry && isCryptoPrimitive(catalogEntry, baseName)) {
+      const scopes = getRuleScopes(ruleMap, catalogEntry.id);
+      if (scopes.length > 0) {
+        matchedId = catalogEntry.id;
+        requiredScopes = scopes;
+      }
+    }
+
+    if (requiredScopes.length === 0) {
+      return;
+    }
+
+    const label = matchedId || baseName;
+
+    if (stack.length === 0) {
+      reasons.push(`auth: ${label} requires Authorize{scope in [${requiredScopes.join(', ')}]}`);
+      return;
+    }
+
+    const matchedAuthorize = findMatchingAuthorize(stack, requiredScopes);
+    if (matchedAuthorize) {
+      matchedAuthorize.used = true;
+      return;
+    }
+
+    const haveScopes = collectScopes(stack);
+    reasons.push(`auth: scope mismatch for ${label} (have [${haveScopes.join(', ')}], need one of [${requiredScopes.join(', ')}])`);
+  }
+
+  visit(ir, []);
+
+  const ok = reasons.length === 0 && (!options.strictWarnsFail || warnings.length === 0);
+  return { ok, reasons, warnings };
+}
+
+function buildRuleMap(rules) {
+  const map = new Map();
+  if (!rules || typeof rules !== 'object') {
+    return map;
+  }
+  const entries = rules instanceof Map ? rules.entries() : Object.entries(rules);
+  for (const [key, value] of entries) {
+    if (typeof key !== 'string') {
+      continue;
+    }
+    const normalizedKey = key.toLowerCase();
+    if (Array.isArray(value)) {
+      const scopes = value.filter((v) => typeof v === 'string' && v.length > 0);
+      map.set(normalizedKey, scopes);
+      continue;
+    }
+    if (typeof value === 'string' && value.length > 0) {
+      map.set(normalizedKey, [value]);
+    }
+  }
+  return map;
+}
+
+function getRuleScopes(ruleMap, canonicalId) {
+  if (!canonicalId || typeof canonicalId !== 'string') {
+    return [];
+  }
+  const scopes = ruleMap.get(canonicalId.toLowerCase());
+  if (!Array.isArray(scopes)) {
+    return [];
+  }
+  return scopes;
+}
+
+function inferCanonicalId(node) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  const candidates = [
+    node.id,
+    node.canonical,
+    node.canonicalId,
+    node.canonical_id,
+    node?.spec?.id,
+    node?.ref?.canonical,
+    node?.ref?.canonicalId,
+    node?.ref?.canonical_id
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.includes('@')) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function lookupCatalogEntry(catalog, node, baseName) {
+  const primitives = Array.isArray(catalog?.primitives) ? catalog.primitives : [];
+  if (primitives.length === 0) {
+    return null;
+  }
+  const fromNode = inferCanonicalId(node);
+  if (fromNode) {
+    const lowerId = fromNode.toLowerCase();
+    for (const prim of primitives) {
+      if (typeof prim?.id === 'string' && prim.id.toLowerCase() === lowerId) {
+        return prim;
+      }
+    }
+  }
+  if (!baseName) {
+    return null;
+  }
+  const lowerName = baseName.toLowerCase();
+  for (const prim of primitives) {
+    if (typeof prim?.name === 'string' && prim.name.toLowerCase() === lowerName) {
+      return prim;
+    }
+  }
+  const idRegex = new RegExp(`/${escapeRegex(lowerName)}@\\d+$`, 'i');
+  for (const prim of primitives) {
+    if (typeof prim?.id === 'string' && idRegex.test(prim.id)) {
+      return prim;
+    }
+  }
+  return null;
+}
+
+function extractScopes(attrs) {
+  if (!attrs || typeof attrs !== 'object') {
+    return [];
+  }
+  const values = [];
+  if ('scope' in attrs) {
+    values.push(attrs.scope);
+  }
+  if ('scopes' in attrs) {
+    values.push(attrs.scopes);
+  }
+  const scopes = [];
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string' && item.length > 0) {
+          scopes.push(item);
+        }
+      }
+      continue;
+    }
+    if (typeof value === 'string' && value.length > 0) {
+      scopes.push(value);
+    }
+  }
+  return dedupe(scopes);
+}
+
+function dedupe(list) {
+  const out = [];
+  const seen = new Set();
+  for (const item of list) {
+    if (seen.has(item)) {
+      continue;
+    }
+    seen.add(item);
+    out.push(item);
+  }
+  return out;
+}
+
+function normalizeName(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.toLowerCase();
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isCryptoPrimitive(entry, baseName) {
+  if (!entry || typeof entry !== 'object') {
+    return false;
+  }
+  const effects = Array.isArray(entry.effects) ? entry.effects : [];
+  if (!effects.includes('Crypto')) {
+    return false;
+  }
+  return PROTECTED_NAMES.includes(baseName.toLowerCase());
+}
+
+function findMatchingAuthorize(stack, requiredScopes) {
+  for (let i = stack.length - 1; i >= 0; i -= 1) {
+    const entry = stack[i];
+    if (!entry || !Array.isArray(entry.scopes)) {
+      continue;
+    }
+    for (const scope of entry.scopes) {
+      if (requiredScopes.includes(scope)) {
+        return entry;
+      }
+    }
+  }
+  return null;
+}
+
+function collectScopes(stack) {
+  const set = new Set();
+  for (const entry of stack) {
+    if (!entry || !Array.isArray(entry.scopes)) {
+      continue;
+    }
+    for (const scope of entry.scopes) {
+      set.add(scope);
+    }
+  }
+  return Array.from(set);
+}

--- a/tests/policy-authorize.test.mjs
+++ b/tests/policy-authorize.test.mjs
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, writeFile, mkdtemp } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+const { checkAuthorize } = await import('../packages/tf-l0-check/src/authorize.mjs');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+async function loadCatalog() {
+  const catalogPath = path.resolve(repoRoot, 'packages/tf-l0-spec/spec/catalog.json');
+  const contents = await readFile(catalogPath, 'utf8');
+  return JSON.parse(contents);
+}
+
+async function loadRules() {
+  const rulesPath = path.resolve(repoRoot, 'packages/tf-l0-check/rules/authorize-scopes.json');
+  const contents = await readFile(rulesPath, 'utf8');
+  return JSON.parse(contents);
+}
+
+const [catalog, rules] = await Promise.all([loadCatalog(), loadRules()]);
+
+async function readFlow(relativePath) {
+  return readFile(path.resolve(repoRoot, relativePath), 'utf8');
+}
+
+async function runAuthCli(args) {
+  const cliPath = path.resolve(repoRoot, 'packages/tf-compose/bin/tf-policy-auth.mjs');
+  const child = spawn(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  const stdoutChunks = [];
+  const stderrChunks = [];
+
+  child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+  child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+  const code = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', resolve);
+  });
+
+  return {
+    code,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8')
+  };
+}
+
+function parseCliOutput(stdout) {
+  try {
+    return JSON.parse(stdout);
+  } catch (err) {
+    throw new Error(`Failed to parse CLI output: ${stdout}\n${err}`);
+  }
+}
+
+test('authorize check passes when scope matches', async () => {
+  const src = await readFlow('examples/flows/auth_ok.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('authorize check detects wrong scope', async () => {
+  const src = await readFlow('examples/flows/auth_wrong_scope.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, false);
+  assert.equal(verdict.reasons.length, 1);
+  assert.match(verdict.reasons[0], /scope mismatch/);
+});
+
+test('authorize check detects missing authorize region', async () => {
+  const src = await readFlow('examples/flows/auth_missing.tf');
+  const ir = parseDSL(src);
+  const verdict = checkAuthorize(ir, catalog, rules);
+
+  assert.equal(verdict.ok, false);
+  assert.equal(verdict.reasons.length, 1);
+  assert.match(verdict.reasons[0], /requires Authorize/);
+});
+
+test('CLI reports unused authorize scopes as warnings', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'tf-auth-'));
+  const flowPath = path.join(tmpDir, 'unused.tf');
+  await writeFile(flowPath, 'authorize(scope="kms.sign"){ emit-metric(key="foo") }', 'utf8');
+
+  const result = await runAuthCli(['check', flowPath, '--warn-unused']);
+  assert.equal(result.code, 0);
+
+  const parsed = parseCliOutput(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.reasons, []);
+  assert.equal(parsed.warnings.length, 1);
+  assert.match(parsed.warnings[0], /unused authorize scope/);
+});
+
+test('CLI treats warnings as failures when strict flag is set', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'tf-auth-'));
+  const flowPath = path.join(tmpDir, 'unused-strict.tf');
+  await writeFile(flowPath, 'authorize(scope="kms.sign"){ emit-metric(key="foo") }', 'utf8');
+
+  const result = await runAuthCli(['check', flowPath, '--warn-unused', '--strict-warns']);
+  assert.equal(result.code, 1);
+
+  const parsed = parseCliOutput(result.stdout);
+  assert.equal(parsed.ok, false);
+  assert.deepEqual(parsed.reasons, []);
+  assert.equal(parsed.warnings.length, 1);
+  assert.match(parsed.warnings[0], /unused authorize scope/);
+});


### PR DESCRIPTION
## Summary
- add an authorization dominance checker with scope validation and unused warnings
- provide default authorize scope rules and sample flows for common crypto primitives
- expose a tf-policy-auth CLI and regression tests covering success, failure, and warn paths

## Testing
- pnpm run test:l0

------
https://chatgpt.com/codex/tasks/task_e_68cf4bb9a98883209762256fb1c0d925