### PR TITLE
feat: add Rust pipeline codegen scaffolding

### DIFF
--- a/packages/tf-l0-codegen-rs/Cargo.toml
+++ b/packages/tf-l0-codegen-rs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tf-l0-codegen-rs"
+version = "0.1.0"
+edition = "2021"
+description = "Rust pipeline scaffolding generator"
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "generate"
+path = "src/generate.rs"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/packages/tf-l0-codegen-rs/src/generate.rs
+++ b/packages/tf-l0-codegen-rs/src/generate.rs
@@ -1,0 +1,59 @@
+use std::{
+    env,
+    io::{self, Read},
+    path::PathBuf,
+};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+use tf_l0_codegen_rs::generate_workspace;
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("error: {err:?}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let mut out_dir: Option<PathBuf> = None;
+    let mut package_name: Option<String> = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--out-dir" => {
+                let value = args.next().context("--out-dir requires a value")?;
+                out_dir = Some(PathBuf::from(value));
+            }
+            "--package-name" => {
+                let value = args.next().context("--package-name requires a value")?;
+                package_name = Some(value);
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            other => return Err(anyhow!("unexpected argument: {other}")),
+        }
+    }
+
+    let out_dir = out_dir.context("missing --out-dir")?;
+    let package_name = package_name.unwrap_or_else(|| "tf_generated".to_string());
+
+    let mut buffer = String::new();
+    io::stdin()
+        .read_to_string(&mut buffer)
+        .context("reading IR from stdin")?;
+
+    if buffer.trim().is_empty() {
+        return Err(anyhow!("expected IR JSON on stdin"));
+    }
+
+    let ir: Value = serde_json::from_str(&buffer).context("parsing IR JSON")?;
+    generate_workspace(&ir, &out_dir, &package_name)
+}
+
+fn print_usage() {
+    eprintln!("Usage: generate --out-dir <path> [--package-name <name>] < ir.json");
+}

--- a/packages/tf-l0-codegen-rs/src/lib.rs
+++ b/packages/tf-l0-codegen-rs/src/lib.rs
@@ -1,0 +1,165 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::{collections::BTreeSet, fs, path::Path};
+
+/// Trait requirements exposed by the generated pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TraitRequirement {
+    Codec,
+    Kv,
+    Crypto,
+    Messaging,
+    Metrics,
+}
+
+impl TraitRequirement {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Codec => "Codec",
+            Self::Kv => "Kv",
+            Self::Crypto => "Crypto",
+            Self::Messaging => "Messaging",
+            Self::Metrics => "Metrics",
+        }
+    }
+
+    fn definition(&self) -> &'static str {
+        match self {
+            Self::Codec => "pub trait Codec {\n    fn serialize(&self, value: &str) -> anyhow::Result<Vec<u8>>;\n    fn deserialize(&self, data: &[u8]) -> anyhow::Result<String>;\n    fn hash(&self, data: &[u8]) -> anyhow::Result<Vec<u8>>;\n}\n",
+            Self::Kv => "pub trait Kv {\n    fn write_object(&self, uri: &str, key: &str, value: &str);\n    fn read_object(&self, uri: &str, key: &str) -> Option<String>;\n    fn delete_object(&self, uri: &str, key: &str);\n    fn compare_and_swap(&self, uri: &str, key: &str, expected: &str, value: &str) -> bool;\n}\n",
+            Self::Crypto => "pub trait Crypto {\n    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;\n    fn verify(&self, key: &str, data: &[u8], signature: &[u8]) -> anyhow::Result<bool>;\n}\n",
+            Self::Messaging => "pub trait Messaging {\n    fn publish(&self, topic: &str, payload: &[u8]) -> anyhow::Result<()>;\n    fn request(&self, endpoint: &str, payload: &[u8]) -> anyhow::Result<Vec<u8>>;\n    fn subscribe(&self, topic: &str) -> anyhow::Result<Vec<u8>>;\n    fn acknowledge(&self, token: &str) -> anyhow::Result<()>;\n}\n",
+            Self::Metrics => "pub trait Metrics {\n    fn emit_metric(&self, name: &str, value: f64);\n}\n",
+        }
+    }
+}
+
+/// Generate a Rust workspace containing pipeline scaffolding for the provided IR.
+pub fn generate_workspace(ir: &Value, out_dir: &Path, package_name: &str) -> Result<()> {
+    let traits = infer_traits(ir);
+    fs::create_dir_all(out_dir.join("src")).context("creating src directory")?;
+
+    let cargo = render_cargo_toml(package_name);
+    fs::write(out_dir.join("Cargo.toml"), cargo).context("writing Cargo.toml")?;
+
+    let lib_rs = render_lib_rs();
+    fs::write(out_dir.join("src/lib.rs"), lib_rs).context("writing src/lib.rs")?;
+
+    let pipeline = render_pipeline(&traits);
+    fs::write(out_dir.join("src/pipeline.rs"), pipeline).context("writing src/pipeline.rs")?;
+
+    Ok(())
+}
+
+fn infer_traits(value: &Value) -> BTreeSet<TraitRequirement> {
+    let mut out = BTreeSet::new();
+    collect_primitives(value, &mut out);
+    out
+}
+
+fn collect_primitives(value: &Value, out: &mut BTreeSet<TraitRequirement>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(kind)) = map.get("node") {
+                if kind == "Prim" {
+                    if let Some(Value::String(prim)) = map.get("prim") {
+                        if let Some(req) = trait_for_primitive(prim) {
+                            out.insert(req);
+                        }
+                    }
+                }
+            }
+            if let Some(Value::Array(children)) = map.get("children") {
+                for child in children {
+                    collect_primitives(child, out);
+                }
+            }
+            for (key, value) in map {
+                if key != "children" {
+                    collect_primitives(value, out);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_primitives(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn trait_for_primitive(name: &str) -> Option<TraitRequirement> {
+    match name {
+        "serialize" | "deserialize" | "hash" => Some(TraitRequirement::Codec),
+        "write-object" | "read-object" | "delete-object" | "compare-and-swap" => {
+            Some(TraitRequirement::Kv)
+        }
+        "sign-data" | "verify-signature" => Some(TraitRequirement::Crypto),
+        "publish" | "request" | "subscribe" | "acknowledge" => Some(TraitRequirement::Messaging),
+        "emit-metric" => Some(TraitRequirement::Metrics),
+        _ => None,
+    }
+}
+
+fn render_cargo_toml(package_name: &str) -> String {
+    format!(
+        "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nanyhow = \"1\"\n\n",
+        name = package_name
+    )
+}
+
+fn render_lib_rs() -> String {
+    "pub mod pipeline;\n\npub use pipeline::run_pipeline;\n".to_string()
+}
+
+fn render_pipeline(traits: &BTreeSet<TraitRequirement>) -> String {
+    let mut sections = String::new();
+    for definition in traits.iter().map(TraitRequirement::definition) {
+        sections.push_str(definition);
+        sections.push('\n');
+    }
+
+    if traits.is_empty() {
+        sections.push_str("pub trait PipelineAdapters {}\n\nimpl<T> PipelineAdapters for T {}\n");
+    }
+
+    let adapter_bounds = if traits.is_empty() {
+        "PipelineAdapters".to_string()
+    } else {
+        traits
+            .iter()
+            .map(TraitRequirement::name)
+            .collect::<Vec<_>>()
+            .join(" + ")
+    };
+
+    sections.push_str("#[allow(unused_variables)]\n");
+    sections.push_str(&format!(
+        "pub fn run_pipeline(adapters: &(impl {bounds})) -> anyhow::Result<()> {{\n    let _ = adapters;\n    Ok(())\n}}\n",
+        bounds = adapter_bounds
+    ));
+
+    sections
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn infer_traits_from_ir() {
+        let ir = json!({
+            "node": "Seq",
+            "children": [
+                {"node": "Prim", "prim": "write-object"},
+                {"node": "Prim", "prim": "sign-data"}
+            ]
+        });
+
+        let traits = infer_traits(&ir);
+        assert!(traits.contains(&TraitRequirement::Kv));
+        assert!(traits.contains(&TraitRequirement::Crypto));
+    }
+}

--- a/scripts/generate-rs.mjs
+++ b/scripts/generate-rs.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { readFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const irPath = args[0];
+  if (!irPath) {
+    throw new Error('IR path is required');
+  }
+
+  let outDir = null;
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
+      i += 1;
+      outDir = args[i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!outDir) {
+    throw new Error('Output directory required via -o or --out');
+  }
+
+  const raw = await readFile(irPath, 'utf8');
+  const ir = JSON.parse(raw);
+
+  const resolvedOutDir = resolve(outDir);
+  await mkdir(resolvedOutDir, { recursive: true });
+
+  const crateName = deriveCrateName(ir, resolvedOutDir, irPath);
+  await runGenerator(ir, resolvedOutDir, crateName);
+}
+
+function deriveCrateName(ir, outDir, irPath) {
+  const baseName =
+    (ir && typeof ir === 'object' && (ir.name || ir.pipeline?.name || ir.metadata?.name)) ||
+    basename(outDir) ||
+    basename(irPath).replace(/\.ir\.json$/i, '');
+  return sanitizeCrateName(baseName);
+}
+
+function sanitizeCrateName(value) {
+  const safe = String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+/, '')
+    .replace(/_+$/, '');
+  return safe || 'tf_generated';
+}
+
+async function runGenerator(ir, outDir, packageName) {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const manifestPath = resolve(moduleDir, '..', 'packages', 'tf-l0-codegen-rs', 'Cargo.toml');
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(
+      'cargo',
+      [
+        'run',
+        '--quiet',
+        '--manifest-path',
+        manifestPath,
+        '--bin',
+        'generate',
+        '--',
+        '--out-dir',
+        outDir,
+        '--package-name',
+        packageName,
+      ],
+      { stdio: ['pipe', 'inherit', 'inherit'] },
+    );
+
+    child.on('error', rejectPromise);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        rejectPromise(new Error(`cargo run exited with code ${code}`));
+      }
+    });
+
+    child.stdin.write(JSON.stringify(ir));
+    child.stdin.end();
+  });
+}
+
+function printUsage() {
+  console.log('Usage: node scripts/generate-rs.mjs <ir.json> -o <output dir>');
+}
+
+main().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a minimal Rust crate that turns IR JSON into a pipeline scaffold
- infer primitive requirements to emit trait stubs and run_pipeline signature
- provide a node-based shim that feeds IR into the Rust generator and writes a workspace

## Testing
- pnpm run a0
- pnpm run a1
- pnpm run tf -- parse examples/flows/signing.tf -o out/0.4/ir/signing.ir.json
- node scripts/generate-rs.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing
- (cd out/0.4/codegen-rs/signing && cargo build)
- cargo test --manifest-path packages/tf-l0-codegen-rs/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68cf550a8e7c8320bf66f4459ae88579