### PR TITLE
Add SMT law emitter and CLI

### DIFF
--- a/docs/l0-proofs.md
+++ b/docs/l0-proofs.md
@@ -1,0 +1,16 @@
+# L0 Proofs
+
+## Law obligations
+
+We generate SMT-LIB artefacts for algebraic laws via the `scripts/emit-smt-laws.mjs` helper.
+Use `--law` to write standalone axioms and `--equiv` with `--laws` to compare two
+flow fragments under a set of assumptions. These commands only emit obligations for
+human or offline solver review; CI never attempts to discharge them.
+
+```
+node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2
+node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf \
+  --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2
+```
+
+See also the Alloy and SMT emitters for related modelling flows.

--- a/packages/tf-l0-proofs/src/smt-laws.mjs
+++ b/packages/tf-l0-proofs/src/smt-laws.mjs
@@ -1,0 +1,231 @@
+const SORT_DECLS = {
+  Val: '(declare-sort Val 0)',
+  Bytes: '(declare-sort Bytes 0)'
+};
+
+const LAW_DEFINITIONS = {
+  'idempotent:hash': {
+    sorts: ['Val'],
+    declarations: ['(declare-fun H (Val) Val)'],
+    assertions: ['(assert (forall ((x Val)) (= (H (H x)) (H x))))']
+  },
+  'inverse:serialize-deserialize': {
+    sorts: ['Val', 'Bytes'],
+    declarations: ['(declare-fun S (Val) Bytes)', '(declare-fun D (Bytes) Val)'],
+    assertions: ['(assert (forall ((v Val)) (= (D (S v)) v)))']
+  },
+  'commute:emit-metric-with-pure': {
+    sorts: ['Val'],
+    declarations: ['(declare-fun H (Val) Val)', '(declare-fun E (Val) Val)'],
+    assertions: ['(assert (forall ((x Val)) (= (E (H x)) (H (E x)))))']
+  }
+};
+
+const PRIMITIVES = {
+  hash: {
+    name: 'hash',
+    symbol: 'H',
+    inSort: 'Val',
+    outSort: 'Val',
+    declaration: '(declare-fun H (Val) Val)'
+  },
+  serialize: {
+    name: 'serialize',
+    symbol: 'S',
+    inSort: 'Val',
+    outSort: 'Bytes',
+    declaration: '(declare-fun S (Val) Bytes)'
+  },
+  deserialize: {
+    name: 'deserialize',
+    symbol: 'D',
+    inSort: 'Bytes',
+    outSort: 'Val',
+    declaration: '(declare-fun D (Bytes) Val)'
+  },
+  'emit-metric': {
+    name: 'emit-metric',
+    symbol: 'E',
+    inSort: 'Val',
+    outSort: 'Val',
+    declaration: '(declare-fun E (Val) Val)'
+  }
+};
+
+function pushUnique(list, value) {
+  if (!list.includes(value)) {
+    list.push(value);
+  }
+}
+
+function normalizeLaw(law) {
+  const entry = LAW_DEFINITIONS[law];
+  if (!entry) {
+    throw new Error(`Unknown law: ${law}`);
+  }
+  const sorts = [];
+  const declarations = [];
+  const assertions = [];
+  for (const sort of entry.sorts || []) {
+    if (!SORT_DECLS[sort]) {
+      throw new Error(`Unknown sort "${sort}" for law ${law}`);
+    }
+    pushUnique(sorts, SORT_DECLS[sort]);
+  }
+  for (const decl of entry.declarations || []) {
+    pushUnique(declarations, decl);
+  }
+  for (const assertion of entry.assertions || []) {
+    assertions.push(assertion);
+  }
+  return { sorts, declarations, assertions };
+}
+
+function normalizeFlow(flow) {
+  if (Array.isArray(flow)) {
+    return flow;
+  }
+  if (typeof flow === 'string') {
+    return flow
+      .split('|>')
+      .map((segment) => segment.trim())
+      .filter(Boolean)
+      .map((segment) => {
+        const match = segment.match(/^[a-zA-Z0-9_-]+/);
+        if (!match) {
+          throw new Error(`Unable to parse flow segment: ${segment}`);
+        }
+        return match[0];
+      });
+  }
+  throw new TypeError('Flow must be an array of primitive names or a pipeline string');
+}
+
+function buildFlowExpression(flow, label) {
+  const ops = normalizeFlow(flow);
+  const sorts = [];
+  const declarations = [];
+  if (ops.length === 0) {
+    pushUnique(sorts, SORT_DECLS.Val);
+    return {
+      inputSort: 'Val',
+      resultSort: 'Val',
+      sorts,
+      declarations,
+      defines: [`(define-fun ${label} () Val input)`]
+    };
+  }
+  const first = PRIMITIVES[ops[0]];
+  if (!first) {
+    throw new Error(`Unsupported primitive: ${ops[0]}`);
+  }
+  let currentSort = first.inSort;
+  pushUnique(sorts, SORT_DECLS[currentSort]);
+  pushUnique(declarations, first.declaration);
+  let expr = 'input';
+  for (let i = 0; i < ops.length; i += 1) {
+    const name = ops[i];
+    const prim = PRIMITIVES[name];
+    if (!prim) {
+      throw new Error(`Unsupported primitive: ${name}`);
+    }
+    if (prim.inSort !== currentSort) {
+      throw new Error(`Type mismatch applying ${name}: expected ${prim.inSort} but have ${currentSort}`);
+    }
+    pushUnique(sorts, SORT_DECLS[prim.inSort]);
+    pushUnique(sorts, SORT_DECLS[prim.outSort]);
+    pushUnique(declarations, prim.declaration);
+    expr = `(${prim.symbol} ${expr})`;
+    currentSort = prim.outSort;
+  }
+  const defines = [`(define-fun ${label} () ${currentSort} ${expr})`];
+  return {
+    inputSort: first.inSort,
+    resultSort: currentSort,
+    sorts,
+    declarations,
+    defines
+  };
+}
+
+export function emitLaw(law, opts = {}) {
+  const { sorts, declarations, assertions } = normalizeLaw(law, opts);
+  const lines = [];
+  for (const sort of sorts) {
+    lines.push(sort);
+  }
+  for (const decl of declarations) {
+    lines.push(decl);
+  }
+  for (const assertion of assertions) {
+    lines.push(assertion);
+  }
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+export function emitFlowEquivalence(flowA, flowB, lawSet = []) {
+  const requiredSorts = [];
+  const requiredDecls = [];
+  const assertions = [];
+
+  for (const law of lawSet) {
+    const { sorts, declarations, assertions: ax } = normalizeLaw(law);
+    for (const sort of sorts) {
+      pushUnique(requiredSorts, sort);
+    }
+    for (const decl of declarations) {
+      pushUnique(requiredDecls, decl);
+    }
+    for (const statement of ax) {
+      assertions.push(statement);
+    }
+  }
+
+  const flowInfoA = buildFlowExpression(flowA, 'outA');
+  const flowInfoB = buildFlowExpression(flowB, 'outB');
+
+  if (flowInfoA.inputSort !== flowInfoB.inputSort) {
+    throw new Error('Flow inputs must share the same sort to compare equivalence');
+  }
+  if (flowInfoA.resultSort !== flowInfoB.resultSort) {
+    throw new Error('Flow outputs must share the same sort to compare equivalence');
+  }
+
+  for (const sort of flowInfoA.sorts.concat(flowInfoB.sorts)) {
+    pushUnique(requiredSorts, sort);
+  }
+  for (const decl of flowInfoA.declarations.concat(flowInfoB.declarations)) {
+    pushUnique(requiredDecls, decl);
+  }
+
+  const lines = [];
+  for (const sort of requiredSorts) {
+    lines.push(sort);
+  }
+  for (const decl of requiredDecls) {
+    lines.push(decl);
+  }
+
+  const inputSortDecl = SORT_DECLS[flowInfoA.inputSort];
+  if (!inputSortDecl) {
+    throw new Error(`Unknown input sort: ${flowInfoA.inputSort}`);
+  }
+  if (!requiredSorts.includes(inputSortDecl)) {
+    lines.push(inputSortDecl);
+  }
+  lines.push(`(declare-const input ${flowInfoA.inputSort})`);
+
+  for (const define of flowInfoA.defines) {
+    lines.push(define);
+  }
+  for (const define of flowInfoB.defines) {
+    lines.push(define);
+  }
+  for (const ax of assertions) {
+    lines.push(ax);
+  }
+  lines.push('(assert (not (= outA outB)))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}

--- a/scripts/emit-smt-laws.mjs
+++ b/scripts/emit-smt-laws.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+function parseFlow(source) {
+  return source
+    .split('|>')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => {
+      const match = segment.match(/^[a-zA-Z0-9_-]+/);
+      if (!match) {
+        throw new Error(`Unable to parse flow segment: ${segment}`);
+      }
+      return match[0];
+    });
+}
+
+async function main() {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      law: { type: 'string' },
+      equiv: { type: 'string', multiple: true },
+      laws: { type: 'string' },
+      output: { type: 'string', short: 'o' }
+    }
+  });
+
+  const lawName = values.law;
+  let equivPaths = [];
+  if (typeof values.equiv === 'string') {
+    equivPaths = [values.equiv];
+  } else if (Array.isArray(values.equiv)) {
+    equivPaths = values.equiv.slice();
+  }
+
+  if (equivPaths.length === 1 && positionals.length > 0) {
+    equivPaths.push(positionals[0]);
+  }
+
+  const extraPositionals = positionals.slice(equivPaths.length > 1 ? 1 : 0);
+  if (extraPositionals.length > 0 && !lawName) {
+    throw new Error(`Unexpected arguments: ${extraPositionals.join(', ')}`);
+  }
+
+  if (lawName && equivPaths.length > 0) {
+    throw new Error('Cannot combine --law and --equiv in the same invocation');
+  }
+
+  const lawList = typeof values.laws === 'string' && values.laws.length > 0
+    ? values.laws.split(',').map((item) => item.trim()).filter(Boolean)
+    : [];
+  const outputPath = values.output;
+
+  if (!outputPath) {
+    throw new Error('Output path is required via --output or -o');
+  }
+
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  if (lawName) {
+    const body = emitLaw(lawName);
+    await writeFile(outputPath, body, 'utf8');
+    return;
+  }
+
+  if (equivPaths.length === 2) {
+    const [aPath, bPath] = equivPaths;
+    const [aSource, bSource] = await Promise.all([
+      readFile(aPath, 'utf8'),
+      readFile(bPath, 'utf8')
+    ]);
+    const flowA = parseFlow(aSource);
+    const flowB = parseFlow(bSource);
+    const body = emitFlowEquivalence(flowA, flowB, lawList);
+    await writeFile(outputPath, body, 'utf8');
+    return;
+  }
+
+  throw new Error('Must provide either --law <name> or --equiv <flowA> <flowB>');
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exitCode = 1;
+});

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+test('idempotent law axiom emitted with check-sat', () => {
+  const out = emitLaw('idempotent:hash');
+  assert.ok(out.includes('(forall ((x Val)) (= (H (H x)) (H x))))'));
+  assert.ok(out.includes('(declare-fun H (Val) Val)'));
+  assert.ok(out.endsWith('(check-sat)\n'));
+});
+
+test('inverse law axiom emitted with check-sat', () => {
+  const out = emitLaw('inverse:serialize-deserialize');
+  assert.ok(out.includes('(forall ((v Val)) (= (D (S v)) v)))'));
+  assert.ok(out.includes('(declare-fun S (Val) Bytes)'));
+  assert.ok(out.includes('(declare-fun D (Bytes) Val)'));
+  assert.ok(out.endsWith('(check-sat)\n'));
+});
+
+test('commute law axiom references emit and hash', () => {
+  const out = emitLaw('commute:emit-metric-with-pure');
+  assert.ok(out.includes('(forall ((x Val)) (= (E (H x)) (H (E x)))))'));
+  assert.ok(out.includes('(declare-fun E (Val) Val)'));
+  assert.ok(out.endsWith('(check-sat)\n'));
+});
+
+test('flow equivalence embeds axiom and disequality witness', () => {
+  const out = emitFlowEquivalence(
+    ['emit-metric', 'hash'],
+    ['hash', 'emit-metric'],
+    ['commute:emit-metric-with-pure']
+  );
+  assert.ok(out.includes('(assert (not (= outA outB)))'));
+  assert.ok(out.includes('(assert (forall ((x Val)) (= (E (H x)) (H (E x)))))'));
+  assert.ok(out.includes('(declare-const input Val)'));
+});
+
+test('law emission is deterministic', () => {
+  const first = emitLaw('idempotent:hash');
+  const second = emitLaw('idempotent:hash');
+  assert.equal(first, second);
+});


### PR DESCRIPTION
## Summary
- add SMT law emitter covering idempotent, inverse, and commute laws plus flow equivalence checks
- provide a CLI for emitting SMT obligations and document the workflow
- cover the new emitter with deterministic unit tests

## Testing
- pnpm run a0
- pnpm run a1
- node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2
- node scripts/emit-smt-laws.mjs --equiv examples/flows/emit_commute.tf examples/flows/emit_commute.tf --laws commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute_equiv.smt2
- node --test tests/smt-laws.test.mjs
- pnpm -w -r test *(fails in unrelated packages: vitest runner in trace2tags/coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68cf565443cc83209c96349ab3b0b5d1