### PR TITLE
Add SMT law obligations emitter

### DIFF
--- a/docs/l0-proofs.md
+++ b/docs/l0-proofs.md
@@ -1,0 +1,16 @@
+# L0 Proofs
+
+## Law obligations
+
+We encode algebraic laws for core primitives as small SMT-LIB v2 obligations. Use the CLI to emit either standalone axioms or flow equivalence checks:
+
+```bash
+node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2
+node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf \
+  --laws idempotent:hash,inverse:serialize-deserialize \
+  -o out/0.4/proofs/laws/roundtrip_equiv.smt2
+```
+
+The generated files assert the relevant axioms, compare symbolic outputs, and end with `(check-sat)`. CI does not invoke an SMT solver—these files are produced for human review and audit trails alongside our Alloy exports.
+
+See also the [SMT emitter](../scripts/emit-smt.mjs) and [Alloy exporter](../scripts/emit-alloy.mjs) for the broader proof pipeline.

--- a/docs/l0-proofs.md
+++ b/docs/l0-proofs.md
@@ -13,4 +13,6 @@ node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples
 
 The generated files assert the relevant axioms, compare symbolic outputs, and end with `(check-sat)`. CI does not invoke an SMT solver—these files are produced for human review and audit trails alongside our Alloy exports.
 
+Current obligations are structural over uninterpreted functions and deliberately ignore primitive arguments. They justify algebraic rewrites (idempotency, inverse, commutation) rather than semantic equality of parameterized calls. We plan to model arguments later—likely by indexing symbols—but that work is outside D2’s scope.
+
 See also the [SMT emitter](../scripts/emit-smt.mjs) and [Alloy exporter](../scripts/emit-alloy.mjs) for the broader proof pipeline.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "a1": "node packages/tf-l0-spec/scripts/build-catalog.mjs && node packages/tf-l0-spec/scripts/derive-effects.mjs && node packages/tf-l0-spec/scripts/build-laws.mjs && node packages/tf-l0-spec/scripts/finalize-a1.mjs",
     "a1:summary": "node scripts/effects-summary.mjs",
     "a1:all": "pnpm run a1 && pnpm run a1:summary",
+    "proofs:laws:axioms": "node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2 && node scripts/emit-smt-laws.mjs --law inverse:serialize-deserialize -o out/0.4/proofs/laws/inverse_roundtrip.smt2 && node scripts/emit-smt-laws.mjs --law commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute.smt2",
+    "proofs:laws:equiv": "node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2",
     "tf": "node packages/tf-compose/bin/tf.mjs",
     "trace:filter": "node packages/tf-l0-tools/trace-filter.mjs",
     "validate:ids": "node scripts/validate-ids.mjs",

--- a/packages/tf-l0-proofs/src/smt-laws.mjs
+++ b/packages/tf-l0-proofs/src/smt-laws.mjs
@@ -1,0 +1,274 @@
+const SORTS = {
+  Val: { arity: 0 },
+  Bytes: { arity: 0 },
+};
+
+const FUNCTIONS = {
+  H: { domain: ['Val'], codomain: 'Val' },
+  S: { domain: ['Val'], codomain: 'Bytes' },
+  D: { domain: ['Bytes'], codomain: 'Val' },
+  E: { domain: ['Val'], codomain: 'Val' },
+};
+
+const LAW_DEFINITIONS = {
+  'idempotent:hash': {
+    sorts: ['Val'],
+    functions: ['H'],
+    axioms: ['(assert (forall ((x Val)) (= (H (H x)) (H x))))'],
+  },
+  'inverse:serialize-deserialize': {
+    sorts: ['Val', 'Bytes'],
+    functions: ['S', 'D'],
+    axioms: ['(assert (forall ((v Val)) (= (D (S v)) v)))'],
+  },
+  'commute:emit-metric-with-pure': {
+    sorts: ['Val'],
+    functions: ['E', 'H'],
+    axioms: ['(assert (forall ((x Val)) (= (E (H x)) (H (E x)))))'],
+  },
+};
+
+const OPERATION_DEFINITIONS = {
+  hash: { symbol: 'H', domain: 'Val', codomain: 'Val' },
+  serialize: { symbol: 'S', domain: 'Val', codomain: 'Bytes' },
+  deserialize: { symbol: 'D', domain: 'Bytes', codomain: 'Val' },
+  'emit-metric': { symbol: 'E', domain: 'Val', codomain: 'Val' },
+};
+
+export function emitLaw(law, opts = {}) {
+  const definition = LAW_DEFINITIONS[law];
+  if (!definition) {
+    throw new Error(`Unknown law: ${law}`);
+  }
+  const sorts = collectSorts(definition.sorts || []);
+  const functions = collectFunctions(definition.functions || []);
+  const body = [];
+  body.push(...emitSorts(sorts));
+  body.push(...emitFunctions(functions));
+  body.push(...definition.axioms);
+  body.push('(check-sat)');
+  return body.join('\n') + '\n';
+}
+
+export function emitFlowEquivalence(flowA, flowB, lawSet = []) {
+  const laws = normalizeLawList(lawSet);
+  const definitionList = laws.map((name) => {
+    const definition = LAW_DEFINITIONS[name];
+    if (!definition) {
+      throw new Error(`Unknown law: ${name}`);
+    }
+    return definition;
+  });
+
+  const a = analyzeFlow(flowA);
+  const b = analyzeFlow(flowB);
+
+  if (a.startSort !== b.startSort) {
+    throw new Error(
+      `Flow domains must match (got ${a.startSort ?? 'unknown'} vs ${
+        b.startSort ?? 'unknown'
+      })`
+    );
+  }
+  if (a.endSort !== b.endSort) {
+    throw new Error(
+      `Flow codomains must match (got ${a.endSort ?? 'unknown'} vs ${
+        b.endSort ?? 'unknown'
+      })`
+    );
+  }
+
+  const sorts = new Set();
+  const functions = new Set();
+  for (const def of definitionList) {
+    for (const sort of def.sorts || []) {
+      sorts.add(sort);
+    }
+    for (const fn of def.functions || []) {
+      functions.add(fn);
+    }
+  }
+  for (const sort of a.sorts) {
+    sorts.add(sort);
+  }
+  for (const sort of b.sorts) {
+    sorts.add(sort);
+  }
+  for (const fn of a.functions) {
+    functions.add(fn);
+  }
+  for (const fn of b.functions) {
+    functions.add(fn);
+  }
+
+  const body = [];
+  body.push(...emitSorts(sorts));
+  body.push(...emitFunctions(functions));
+
+  const inputName = 'x';
+  body.push(`(declare-const ${inputName} ${a.startSort ?? 'Val'})`);
+
+  for (const name of laws) {
+    const definition = LAW_DEFINITIONS[name];
+    body.push(...definition.axioms);
+  }
+
+  body.push(`(define-fun outA () ${a.endSort ?? 'Val'} ${a.expression(inputName)})`);
+  body.push(`(define-fun outB () ${b.endSort ?? 'Val'} ${b.expression(inputName)})`);
+  body.push('(assert (not (= outA outB)))');
+  body.push('(check-sat)');
+  return body.join('\n') + '\n';
+}
+
+function analyzeFlow(flow) {
+  if (!Array.isArray(flow)) {
+    throw new Error('Flow must be an array of operation names');
+  }
+  const operations = flow
+    .map((entry) => normalizeOperation(entry))
+    .filter((name) => name.length > 0);
+  let startSort = null;
+  let currentSort = null;
+  const sorts = new Set();
+  const functions = new Set();
+  const steps = [];
+
+  for (const opName of operations) {
+    const op = OPERATION_DEFINITIONS[opName];
+    if (!op) {
+      throw new Error(`Unknown operation: ${opName}`);
+    }
+    if (startSort === null) {
+      startSort = op.domain;
+      currentSort = op.domain;
+      sorts.add(op.domain);
+    }
+    if (currentSort !== op.domain) {
+      throw new Error(
+        `Operation ${opName} expects ${op.domain} but received ${currentSort}`
+      );
+    }
+    functions.add(op.symbol);
+    sorts.add(op.codomain);
+    steps.push(op.symbol);
+    currentSort = op.codomain;
+  }
+
+  if (startSort === null) {
+    startSort = 'Val';
+    currentSort = 'Val';
+    sorts.add('Val');
+  }
+
+  return {
+    startSort,
+    endSort: currentSort,
+    sorts,
+    functions,
+    expression(inputName) {
+      let expr = inputName;
+      for (const symbol of steps) {
+        expr = `(${symbol} ${expr})`;
+      }
+      return expr;
+    },
+  };
+}
+
+function normalizeOperation(entry) {
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) {
+      return '';
+    }
+    const hashIndex = trimmed.indexOf('#');
+    const segment = hashIndex >= 0 ? trimmed.slice(0, hashIndex).trim() : trimmed;
+    if (segment.length === 0) {
+      return '';
+    }
+    const parenIndex = segment.indexOf('(');
+    const withoutArgs = parenIndex >= 0 ? segment.slice(0, parenIndex) : segment;
+    const spaceIndex = withoutArgs.indexOf(' ');
+    const base = spaceIndex >= 0 ? withoutArgs.slice(0, spaceIndex) : withoutArgs;
+    return base.trim().toLowerCase();
+  }
+  throw new Error('Operation names must be strings');
+}
+
+function normalizeLawList(value) {
+  if (!value) {
+    return [];
+  }
+  if (typeof value === 'string') {
+    return [value];
+  }
+  const list = Array.from(value);
+  const seen = new Set();
+  const result = [];
+  for (const law of list) {
+    if (typeof law !== 'string') {
+      throw new Error('Law names must be strings');
+    }
+    if (seen.has(law)) {
+      continue;
+    }
+    seen.add(law);
+    result.push(law);
+  }
+  result.sort();
+  return result;
+}
+
+function collectSorts(names) {
+  const unique = new Set(names || []);
+  const result = [];
+  for (const name of unique) {
+    if (!(name in SORTS)) {
+      throw new Error(`Unknown sort: ${name}`);
+    }
+    result.push(name);
+  }
+  result.sort();
+  return result;
+}
+
+function collectFunctions(names) {
+  const unique = new Set(names || []);
+  const result = [];
+  for (const name of unique) {
+    if (!(name in FUNCTIONS)) {
+      throw new Error(`Unknown function: ${name}`);
+    }
+    result.push(name);
+  }
+  result.sort();
+  return result;
+}
+
+function emitSorts(sorts) {
+  const lines = [];
+  const list = Array.isArray(sorts) ? sorts : Array.from(sorts);
+  list.sort();
+  for (const name of list) {
+    const sort = SORTS[name];
+    if (!sort) {
+      throw new Error(`Unknown sort: ${name}`);
+    }
+    lines.push(`(declare-sort ${name} ${sort.arity})`);
+  }
+  return lines;
+}
+
+function emitFunctions(functions) {
+  const lines = [];
+  const list = Array.isArray(functions) ? functions : Array.from(functions);
+  list.sort();
+  for (const name of list) {
+    const fn = FUNCTIONS[name];
+    if (!fn) {
+      throw new Error(`Unknown function: ${name}`);
+    }
+    lines.push(`(declare-fun ${name} (${fn.domain.join(' ')}) ${fn.codomain})`);
+  }
+  return lines;
+}

--- a/packages/tf-l0-proofs/src/smt-laws.mjs
+++ b/packages/tf-l0-proofs/src/smt-laws.mjs
@@ -19,7 +19,10 @@ const LAW_DEFINITIONS = {
   'inverse:serialize-deserialize': {
     sorts: ['Val', 'Bytes'],
     functions: ['S', 'D'],
-    axioms: ['(assert (forall ((v Val)) (= (D (S v)) v)))'],
+    axioms: [
+      '(assert (forall ((v Val)) (= (D (S v)) v)))',
+      '(assert (forall ((b Bytes)) (= (S (D b)) b)))',
+    ],
   },
   'commute:emit-metric-with-pure': {
     sorts: ['Val'],

--- a/scripts/emit-smt-laws.mjs
+++ b/scripts/emit-smt-laws.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      law: { type: 'string' },
+      equiv: { type: 'string' },
+      laws: { type: 'string' },
+      out: { type: 'string', short: 'o' },
+    },
+    allowPositionals: true,
+  });
+
+  const outPath = typeof values.out === 'string' ? resolve(values.out) : null;
+  if (!outPath) {
+    usage('missing --out <file>');
+    process.exit(2);
+  }
+
+  const lawName = values.law ?? null;
+  const flowPaths = [];
+  if (typeof values.equiv === 'string') {
+    flowPaths.push(values.equiv);
+  }
+  flowPaths.push(...positionals);
+
+  if (lawName && flowPaths.length > 0) {
+    usage('use either --law or --equiv, not both');
+    process.exit(2);
+  }
+
+  if (lawName) {
+    const smt = emitLaw(lawName);
+    await writeOutput(outPath, smt);
+    process.stdout.write(`wrote ${outPath}\n`);
+    return;
+  }
+
+  if (flowPaths.length !== 2) {
+    usage('expected --equiv <flowA> <flowB>');
+    process.exit(2);
+  }
+
+  const [leftPath, rightPath] = flowPaths.map((entry) => resolve(entry));
+  const [left, right] = await Promise.all([
+    loadFlow(leftPath),
+    loadFlow(rightPath),
+  ]);
+
+  const laws = parseLawList(values.laws);
+  const smt = emitFlowEquivalence(left, right, laws);
+  await writeOutput(outPath, smt);
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage(message) {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.stderr.write(
+    'Usage:\n' +
+      '  node scripts/emit-smt-laws.mjs --law <name> -o <out.smt2>\n' +
+      '  node scripts/emit-smt-laws.mjs --equiv <flowA> <flowB> --laws a,b -o <out.smt2>\n'
+  );
+}
+
+async function loadFlow(srcPath) {
+  const raw = await readFile(srcPath, 'utf8');
+  return parseFlow(raw);
+}
+
+function parseFlow(source) {
+  return source
+    .split('|>')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+function parseLawList(raw) {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+async function writeOutput(filePath, content) {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, ensureTrailingNewline(content), 'utf8');
+}
+
+function ensureTrailingNewline(text) {
+  if (text.endsWith('\n')) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -12,21 +12,25 @@ test('law axioms emit expected quantifiers', () => {
     idempotent.includes('(forall ((x Val)) (= (H (H x)) (H x)))'),
     'idempotent law includes quantifier'
   );
-  assert.ok(idempotent.trim().endsWith('(check-sat)'), 'idempotent law ends with check-sat');
+  assert.ok(idempotent.endsWith('(check-sat)\n'), 'idempotent law ends with check-sat');
 
   const inverse = emitLaw('inverse:serialize-deserialize');
   assert.ok(
     inverse.includes('(forall ((v Val)) (= (D (S v)) v))'),
     'inverse law includes quantifier'
   );
-  assert.ok(inverse.trim().endsWith('(check-sat)'), 'inverse law ends with check-sat');
+  assert.ok(
+    inverse.includes('(forall ((b Bytes)) (= (S (D b)) b))'),
+    'inverse law includes symmetric quantifier'
+  );
+  assert.ok(inverse.endsWith('(check-sat)\n'), 'inverse law ends with check-sat');
 
   const commute = emitLaw('commute:emit-metric-with-pure');
   assert.ok(
     commute.includes('(forall ((x Val)) (= (E (H x)) (H (E x))))'),
     'commute law includes quantifier'
   );
-  assert.ok(commute.trim().endsWith('(check-sat)'), 'commute law ends with check-sat');
+  assert.ok(commute.endsWith('(check-sat)\n'), 'commute law ends with check-sat');
 });
 
 test('law emission is deterministic', () => {
@@ -52,4 +56,33 @@ test('flow equivalence encodes commute obligation', () => {
   assert.ok(/\(declare-fun\s+E\s+\(Val\)\s+Val\)/.test(smt), 'declares E function');
   assert.ok(/\(declare-fun\s+H\s+\(Val\)\s+Val\)/.test(smt), 'declares H function');
   assert.ok(smt.trim().endsWith('(check-sat)'), 'equivalence ends with check-sat');
+});
+
+test('flow equivalence respects domain boundaries', () => {
+  assert.doesNotThrow(() =>
+    emitFlowEquivalence(
+      ['deserialize'],
+      ['deserialize'],
+      ['inverse:serialize-deserialize']
+    )
+  );
+
+  assert.throws(
+    () => emitFlowEquivalence(['deserialize'], ['hash'], []),
+    /Flow domains must match/
+  );
+
+  assert.throws(
+    () => emitFlowEquivalence(['serialize'], ['hash'], []),
+    /Flow codomains must match/
+  );
+});
+
+test('flow equivalence emission is deterministic', () => {
+  const flowA = ['emit-metric', 'hash'];
+  const flowB = ['hash', 'emit-metric'];
+  const laws = ['commute:emit-metric-with-pure'];
+  const first = emitFlowEquivalence(flowA, flowB, laws);
+  const second = emitFlowEquivalence(flowA, flowB, laws);
+  assert.equal(first, second);
 });

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  emitLaw,
+  emitFlowEquivalence,
+} from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+test('law axioms emit expected quantifiers', () => {
+  const idempotent = emitLaw('idempotent:hash');
+  assert.ok(
+    idempotent.includes('(forall ((x Val)) (= (H (H x)) (H x)))'),
+    'idempotent law includes quantifier'
+  );
+  assert.ok(idempotent.trim().endsWith('(check-sat)'), 'idempotent law ends with check-sat');
+
+  const inverse = emitLaw('inverse:serialize-deserialize');
+  assert.ok(
+    inverse.includes('(forall ((v Val)) (= (D (S v)) v))'),
+    'inverse law includes quantifier'
+  );
+  assert.ok(inverse.trim().endsWith('(check-sat)'), 'inverse law ends with check-sat');
+
+  const commute = emitLaw('commute:emit-metric-with-pure');
+  assert.ok(
+    commute.includes('(forall ((x Val)) (= (E (H x)) (H (E x))))'),
+    'commute law includes quantifier'
+  );
+  assert.ok(commute.trim().endsWith('(check-sat)'), 'commute law ends with check-sat');
+});
+
+test('law emission is deterministic', () => {
+  const first = emitLaw('idempotent:hash');
+  const second = emitLaw('idempotent:hash');
+  assert.equal(first, second);
+});
+
+test('flow equivalence encodes commute obligation', () => {
+  const smt = emitFlowEquivalence(
+    ['emit-metric', 'hash'],
+    ['hash', 'emit-metric'],
+    ['commute:emit-metric-with-pure']
+  );
+  assert.ok(
+    smt.includes('(assert (not (= outA outB)))'),
+    'flow equivalence asserts disequality'
+  );
+  assert.ok(
+    smt.includes('(forall ((x Val)) (= (E (H x)) (H (E x))))'),
+    'axioms mention commute law'
+  );
+  assert.ok(/\(declare-fun\s+E\s+\(Val\)\s+Val\)/.test(smt), 'declares E function');
+  assert.ok(/\(declare-fun\s+H\s+\(Val\)\s+Val\)/.test(smt), 'declares H function');
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'equivalence ends with check-sat');
+});


### PR DESCRIPTION
## Summary
- add SMT law emission helpers for algebraic axioms and flow equivalence checks
- wire a CLI to generate SMT-LIB obligations for laws or flow comparisons
- document the workflow and cover it with unit tests

## Testing
- node --test tests/smt-laws.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf565443cc83209c96349ab3b0b5d1