### PR TITLE
feat: emit SMT obligations for laws

### DIFF
--- a/docs/l0-proofs.md
+++ b/docs/l0-proofs.md
@@ -1,0 +1,17 @@
+# L0 Proofs
+
+## Law obligations
+
+Law proofs are emitted as SMT-LIB obligations under small bounded domains. Use the SMT emitter to materialize the axioms and specific flow-equivalence checks:
+
+```bash
+# Emit axioms for a single law
+node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2
+
+# Emit equivalence checks for concrete flows with their governing laws
+node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf \
+  --laws idempotent:hash,inverse:serialize-deserialize \
+  -o out/0.4/proofs/laws/roundtrip_equiv.smt2
+```
+
+CI does not invoke an SMT solver; emitted files are for human or audit review. See the SMT emitter and Alloy sections for broader proof tooling.

--- a/packages/tf-l0-proofs/src/smt-laws.mjs
+++ b/packages/tf-l0-proofs/src/smt-laws.mjs
@@ -1,0 +1,222 @@
+const PRIMITIVES = {
+  hash: {
+    symbol: 'H',
+    domain: 'Val',
+    codomain: 'Val',
+    pure: true
+  },
+  serialize: {
+    symbol: 'S',
+    domain: 'Val',
+    codomain: 'Bytes',
+    pure: true
+  },
+  deserialize: {
+    symbol: 'D',
+    domain: 'Bytes',
+    codomain: 'Val',
+    pure: true
+  },
+  'emit-metric': {
+    symbol: 'E',
+    domain: 'Val',
+    codomain: 'Val',
+    pure: false
+  }
+};
+
+const FUNCTION_SIGNATURES = {
+  H: { domain: ['Val'], codomain: 'Val' },
+  S: { domain: ['Val'], codomain: 'Bytes' },
+  D: { domain: ['Bytes'], codomain: 'Val' },
+  E: { domain: ['Val'], codomain: 'Val' },
+  P: { domain: ['Val'], codomain: 'Val' }
+};
+
+const LAW_BUILDERS = {
+  'idempotent:hash'() {
+    return {
+      sorts: new Set(['Val']),
+      functions: new Set(['H']),
+      assertions: [
+        '(assert (forall ((x Val)) (= (H (H x)) (H x))))'
+      ]
+    };
+  },
+  'inverse:serialize-deserialize'() {
+    return {
+      sorts: new Set(['Val', 'Bytes']),
+      functions: new Set(['S', 'D']),
+      assertions: [
+        '(assert (forall ((v Val)) (= (D (S v)) v)))'
+      ]
+    };
+  },
+  'commute:emit-metric-with-pure'(context = {}) {
+    const pureFns = Array.from(context.pureValFns || []);
+    if (pureFns.length === 0) {
+      return {
+        sorts: new Set(['Val']),
+        functions: new Set(['E', 'P']),
+        assertions: [
+          '(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))'
+        ]
+      };
+    }
+    const assertions = pureFns
+      .sort()
+      .map(
+        (fn) =>
+          `(assert (forall ((x Val)) (= (E (${fn} x)) (${fn} (E x)))))`
+      );
+    return {
+      sorts: new Set(['Val']),
+      functions: new Set(['E', ...pureFns]),
+      assertions
+    };
+  }
+};
+
+export function emitLaw(law, opts = {}) {
+  const builder = LAW_BUILDERS[law];
+  if (!builder) {
+    throw new Error(`Unknown law: ${law}`);
+  }
+  const { sorts, functions, assertions } = builder(opts.context);
+  const body = [];
+  body.push(...declareSorts(sorts));
+  body.push(...declareFunctions(functions));
+  body.push(...assertions);
+  body.push('(check-sat)');
+  return body.join('\n') + '\n';
+}
+
+export function emitFlowEquivalence(irA, irB, lawSet = []) {
+  const flowA = analyzeFlow(irA);
+  const flowB = analyzeFlow(irB);
+
+  if (flowA.sort !== flowB.sort) {
+    throw new Error(
+      `Flow sort mismatch: ${flowA.sort ?? 'unknown'} vs ${flowB.sort ?? 'unknown'}`
+    );
+  }
+
+  const sorts = new Set(['Val']);
+  const functions = new Set();
+  const assertions = [];
+
+  addAll(sorts, flowA.sorts);
+  addAll(sorts, flowB.sorts);
+  addAll(functions, flowA.functions);
+  addAll(functions, flowB.functions);
+
+  const pureValFns = new Set([...flowA.pureValFns, ...flowB.pureValFns]);
+
+  for (const law of lawSet) {
+    const builder = LAW_BUILDERS[law];
+    if (!builder) {
+      throw new Error(`Unknown law: ${law}`);
+    }
+    const { sorts: lawSorts, functions: lawFns, assertions: lawAssertions } =
+      builder({ pureValFns });
+    addAll(sorts, lawSorts);
+    addAll(functions, lawFns);
+    assertions.push(...lawAssertions);
+  }
+
+  const body = [];
+  body.push(...declareSorts(sorts));
+  body.push(...declareFunctions(functions));
+  body.push('(declare-const x Val)');
+  body.push(`(define-fun outA () ${flowA.sort} ${flowA.term})`);
+  body.push(`(define-fun outB () ${flowB.sort} ${flowB.term})`);
+  body.push(...assertions);
+  body.push('(assert (not (= outA outB)))');
+  body.push('(check-sat)');
+  return body.join('\n') + '\n';
+}
+
+function analyzeFlow(ir) {
+  const stages = Array.isArray(ir) ? ir : parseFlow(ir);
+  const functions = new Set();
+  const sorts = new Set();
+  const pureValFns = new Set();
+
+  let term = 'x';
+  let sort = 'Val';
+
+  for (const stage of stages) {
+    const prim = PRIMITIVES[stage];
+    if (!prim) {
+      throw new Error(`Unsupported primitive in flow: ${stage}`);
+    }
+    if (prim.domain !== sort) {
+      throw new Error(`Sort mismatch for ${stage}: expected ${prim.domain}, saw ${sort}`);
+    }
+    functions.add(prim.symbol);
+    sorts.add(prim.domain);
+    sorts.add(prim.codomain);
+    if (prim.pure && prim.domain === 'Val' && prim.codomain === 'Val') {
+      pureValFns.add(prim.symbol);
+    }
+    term = `(${prim.symbol} ${term})`;
+    sort = prim.codomain;
+  }
+
+  return { term, sort, functions, sorts, pureValFns };
+}
+
+function parseFlow(value) {
+  if (typeof value === 'string') {
+    return value
+      .split('|>')
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0)
+      .map((part) => {
+        const match = part.match(/^([a-zA-Z0-9_-]+)/);
+        if (!match) {
+          throw new Error(`Unable to parse flow segment: ${part}`);
+        }
+        return match[1];
+      });
+  }
+  if (value && typeof value === 'object' && value.node === 'Seq') {
+    return (value.children || []).map((child) => extractPrim(child));
+  }
+  throw new Error('Unsupported flow representation');
+}
+
+function extractPrim(node) {
+  if (node && node.node === 'Prim' && typeof node.prim === 'string') {
+    return node.prim;
+  }
+  if (typeof node.prim === 'string') {
+    return node.prim;
+  }
+  throw new Error('Unsupported IR node for flow');
+}
+
+function declareSorts(sorts = new Set()) {
+  return Array.from(sorts)
+    .sort()
+    .map((sort) => `(declare-sort ${sort} 0)`);
+}
+
+function declareFunctions(functions = new Set()) {
+  return Array.from(functions)
+    .sort()
+    .map((fn) => {
+      const signature = FUNCTION_SIGNATURES[fn];
+      if (!signature) {
+        throw new Error(`Unknown function symbol: ${fn}`);
+      }
+      const domain = signature.domain.join(' ');
+      return `(declare-fun ${fn} (${domain}) ${signature.codomain})`;
+    });
+}
+
+function addAll(target, source = new Set()) {
+  for (const value of source) {
+    target.add(value);
+  }
+}

--- a/scripts/emit-smt-laws.mjs
+++ b/scripts/emit-smt-laws.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+const {
+  values: { law, equiv, laws, o },
+  positionals
+} = parseArgs({
+  options: {
+    law: { type: 'string' },
+    equiv: { type: 'boolean' },
+    laws: { type: 'string' },
+    o: { type: 'string' }
+  },
+  allowPositionals: true
+});
+
+if (!o) {
+  throw new Error('Output path must be provided with -o');
+}
+
+if (law && equiv) {
+  throw new Error('Specify either --law or --equiv, not both');
+}
+
+const outputPath = o;
+await mkdir(path.dirname(outputPath), { recursive: true });
+
+let smt;
+
+if (law) {
+  if (positionals.length > 0) {
+    throw new Error('Unexpected positional arguments when using --law');
+  }
+  smt = emitLaw(law);
+} else if (equiv) {
+  if (positionals.length !== 2) {
+    throw new Error('--equiv expects exactly two flow files');
+  }
+  const [flowAPath, flowBPath] = positionals;
+  const [flowASrc, flowBSrc] = await Promise.all([
+    readFile(flowAPath, 'utf8'),
+    readFile(flowBPath, 'utf8')
+  ]);
+  const lawSet = typeof laws === 'string' && laws.length > 0 ? laws.split(',') : [];
+  smt = emitFlowEquivalence(flowASrc, flowBSrc, lawSet);
+} else {
+  throw new Error('Either --law or --equiv must be specified');
+}
+
+await writeFile(outputPath, smt, 'utf8');

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+test('idempotent law axiom emits expected forall', () => {
+  const smt = emitLaw('idempotent:hash');
+  assert.match(
+    smt,
+    /\(assert \(forall \(\(x Val\)\) \(= \(H \(H x\)\) \(H x\)\)\)\)/
+  );
+  assert.ok(smt.trim().endsWith('(check-sat)'));
+});
+
+test('inverse law axiom includes serialize/deserialize relation', () => {
+  const smt = emitLaw('inverse:serialize-deserialize');
+  assert.match(
+    smt,
+    /\(assert \(forall \(\(v Val\)\) \(= \(D \(S v\)\) v\)\)\)/
+  );
+  assert.ok(smt.includes('(declare-fun S (Val) Bytes)'));
+  assert.ok(smt.includes('(declare-fun D (Bytes) Val)'));
+});
+
+test('commute law axiom defaults to generic pure function', () => {
+  const smt = emitLaw('commute:emit-metric-with-pure');
+  assert.match(
+    smt,
+    /\(assert \(forall \(\(x Val\)\) \(= \(E \(P x\)\) \(P \(E x\)\)\)\)\)/
+  );
+});
+
+test('flow equivalence under commute law references emit and hash', () => {
+  const smt = emitFlowEquivalence(
+    'emit-metric |> hash',
+    'hash |> emit-metric',
+    ['commute:emit-metric-with-pure']
+  );
+  assert.ok(smt.includes('(assert (not (= outA outB)))'));
+  assert.match(
+    smt,
+    /\(assert \(forall \(\(x Val\)\) \(= \(E \(H x\)\) \(H \(E x\)\)\)\)\)/
+  );
+});
+
+test('emissions are deterministic', () => {
+  const a1 = emitLaw('idempotent:hash');
+  const a2 = emitLaw('idempotent:hash');
+  assert.equal(a1, a2);
+
+  const e1 = emitFlowEquivalence(
+    'serialize |> deserialize',
+    'serialize |> deserialize',
+    ['inverse:serialize-deserialize']
+  );
+  const e2 = emitFlowEquivalence(
+    'serialize |> deserialize',
+    'serialize |> deserialize',
+    ['inverse:serialize-deserialize']
+  );
+  assert.equal(e1, e2);
+});


### PR DESCRIPTION
## Summary
- add an SMT law emitter that covers idempotent, inverse, and commute axioms alongside flow-equivalence assertions
- expose a CLI to render SMT obligations for individual laws or flow comparisons
- document the workflow for generating law files and cover the emitter with deterministic unit tests

## Testing
- pnpm run a0
- pnpm run a1
- node --test tests/smt-laws.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf565443cc83209c96349ab3b0b5d1