### PR TITLE
Add SMT law emitter and CLI

### DIFF
--- a/docs/l0-proofs.md
+++ b/docs/l0-proofs.md
@@ -1,0 +1,23 @@
+# L0 Proofs
+
+## Law obligations
+
+We emit SMT-LIB obligations for the algebraic laws that back our small-model
+proofs. Use `scripts/emit-smt-laws.mjs` to write the axioms for a law or check
+that two flows are equivalent under a set of laws:
+
+```bash
+node scripts/emit-smt-laws.mjs --law idempotent:hash \
+  -o out/0.4/proofs/laws/idempotent_hash.smt2
+
+node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf \
+  examples/flows/info_roundtrip.tf \
+  --laws idempotent:hash,inverse:serialize-deserialize \
+  -o out/0.4/proofs/laws/roundtrip_equiv.smt2
+```
+
+These emitters are deterministic and live alongside the general SMT generator
+in [`packages/tf-l0-proofs/src/smt-laws.mjs`](../packages/tf-l0-proofs/src/smt-laws.mjs)
+and the Alloy tooling in [`packages/tf-l0-proofs/src/alloy.mjs`](../packages/tf-l0-proofs/src/alloy.mjs).
+CI does not run any solvers; generated SMT is reviewed as a human/audit
+artifact.

--- a/packages/tf-l0-proofs/src/smt-laws.mjs
+++ b/packages/tf-l0-proofs/src/smt-laws.mjs
@@ -1,0 +1,241 @@
+const LAW_DEFINITIONS = new Map([
+  [
+    'idempotent:hash',
+    {
+      sorts: ['(declare-sort Val 0)'],
+      decls: ['(declare-fun H (Val) Val)'],
+      axioms: ['(assert (forall ((x Val)) (= (H (H x)) (H x))))']
+    }
+  ],
+  [
+    'inverse:serialize-deserialize',
+    {
+      sorts: ['(declare-sort Val 0)', '(declare-sort Bytes 0)'],
+      decls: ['(declare-fun S (Val) Bytes)', '(declare-fun D (Bytes) Val)'],
+      axioms: ['(assert (forall ((v Val)) (= (D (S v)) v)))']
+    }
+  ],
+  [
+    'commute:emit-metric-with-pure',
+    {
+      sorts: ['(declare-sort Val 0)'],
+      decls: ['(declare-fun E (Val) Val)', '(declare-fun H (Val) Val)'],
+      axioms: ['(assert (forall ((x Val)) (= (E (H x)) (H (E x)))))']
+    }
+  ]
+]);
+
+const SORT_DECLS = new Map([
+  ['Val', '(declare-sort Val 0)'],
+  ['Bytes', '(declare-sort Bytes 0)']
+]);
+
+const PRIM_DEFS = new Map([
+  [
+    'hash',
+    {
+      symbol: 'H',
+      domain: ['Val'],
+      range: 'Val'
+    }
+  ],
+  [
+    'serialize',
+    {
+      symbol: 'S',
+      domain: ['Val'],
+      range: 'Bytes'
+    }
+  ],
+  [
+    'deserialize',
+    {
+      symbol: 'D',
+      domain: ['Bytes'],
+      range: 'Val'
+    }
+  ],
+  [
+    'emit-metric',
+    {
+      symbol: 'E',
+      domain: ['Val'],
+      range: 'Val'
+    }
+  ]
+]);
+
+export function emitLaw(law, opts = {}) {
+  const definition = LAW_DEFINITIONS.get(law);
+  if (!definition) {
+    throw new Error(`unknown law: ${law}`);
+  }
+  const lines = [];
+  pushAllUnique(lines, definition.sorts);
+  pushAllUnique(lines, definition.decls);
+  pushAllUnique(lines, definition.axioms);
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+export function emitFlowEquivalence(irA, irB, lawSet = []) {
+  const context = createContext();
+  const laws = Array.isArray(lawSet) ? lawSet : [];
+  for (const law of laws) {
+    const definition = LAW_DEFINITIONS.get(law);
+    if (!definition) {
+      throw new Error(`unknown law: ${law}`);
+    }
+    for (const sortDecl of definition.sorts || []) {
+      context.addSort(sortDecl);
+    }
+    for (const decl of definition.decls || []) {
+      context.addDecl(decl);
+    }
+    for (const axiom of definition.axioms || []) {
+      context.addAxiom(axiom);
+    }
+  }
+
+  context.ensureSort('Val');
+  const inputSymbol = 'x';
+  context.addDeclaration(`(declare-const ${inputSymbol} Val)`);
+
+  const outA = evaluateFlow(irA, inputSymbol, 'Val', context);
+  const outB = evaluateFlow(irB, inputSymbol, 'Val', context);
+
+  if (outA.sort !== outB.sort) {
+    throw new Error(`flow outputs have different sorts: ${outA.sort} vs ${outB.sort}`);
+  }
+
+  const lines = [];
+  lines.push(...context.sorts);
+  lines.push(...context.functionDecls);
+  lines.push(...context.additionalDecls);
+  lines.push(...context.axioms);
+  lines.push(`(define-fun outA () ${outA.sort} ${outA.term})`);
+  lines.push(`(define-fun outB () ${outB.sort} ${outB.term})`);
+  lines.push('(assert (not (= outA outB)))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+function createContext() {
+  return {
+    sorts: [],
+    functionDecls: [],
+    additionalDecls: [],
+    axioms: [],
+    seenSorts: new Set(),
+    seenDecls: new Set(),
+    seenAdditional: new Set(),
+    seenAxioms: new Set(),
+    unknownSymbols: new Map(),
+    ensureSort(name) {
+      const decl = SORT_DECLS.get(name);
+      if (!decl) {
+        throw new Error(`unknown sort: ${name}`);
+      }
+      this.addSort(decl);
+    },
+    addSort(decl) {
+      if (!this.seenSorts.has(decl)) {
+        this.seenSorts.add(decl);
+        this.sorts.push(decl);
+      }
+    },
+    addDecl(decl) {
+      if (!this.seenDecls.has(decl)) {
+        this.seenDecls.add(decl);
+        this.functionDecls.push(decl);
+      }
+    },
+    addDeclaration(decl) {
+      if (!this.seenAdditional.has(decl)) {
+        this.seenAdditional.add(decl);
+        this.additionalDecls.push(decl);
+      }
+    },
+    addAxiom(axiom) {
+      if (!this.seenAxioms.has(axiom)) {
+        this.seenAxioms.add(axiom);
+        this.axioms.push(axiom);
+      }
+    },
+    resolvePrim(name) {
+      const key = typeof name === 'string' ? name.toLowerCase() : '';
+      if (!key) {
+        throw new Error('invalid primitive name');
+      }
+      if (PRIM_DEFS.has(key)) {
+        const def = PRIM_DEFS.get(key);
+        this.ensureSort(def.range);
+        for (const sort of def.domain) {
+          this.ensureSort(sort);
+        }
+        this.addDecl(
+          `(declare-fun ${def.symbol} (${def.domain.join(' ')}) ${def.range})`
+        );
+        return def;
+      }
+      if (!this.unknownSymbols.has(key)) {
+        const symbol = `F_${key.replace(/[^A-Za-z0-9]/g, '_') || 'prim'}`;
+        this.unknownSymbols.set(key, symbol);
+      }
+      const symbol = this.unknownSymbols.get(key);
+      this.ensureSort('Val');
+      const decl = `(declare-fun ${symbol} (Val) Val)`;
+      this.addDecl(decl);
+      return { symbol, domain: ['Val'], range: 'Val' };
+    }
+  };
+}
+
+function evaluateFlow(ir, inputTerm, inputSort, context) {
+  const primitives = collectPrimitives(ir);
+  let term = inputTerm;
+  let sort = inputSort;
+  for (const primName of primitives) {
+    const def = context.resolvePrim(primName);
+    if (def.domain.length !== 1) {
+      throw new Error(`unsupported arity for ${primName}`);
+    }
+    const expectedSort = def.domain[0];
+    if (sort !== expectedSort) {
+      throw new Error(`sort mismatch for ${primName}: expected ${expectedSort}, got ${sort}`);
+    }
+    term = `(${def.symbol} ${term})`;
+    sort = def.range;
+  }
+  return { term, sort };
+}
+
+function collectPrimitives(node) {
+  const acc = [];
+  walk(node, (current) => {
+    if (current?.node === 'Prim' && typeof current.prim === 'string') {
+      acc.push(current.prim);
+    }
+  });
+  return acc;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}
+
+function pushAllUnique(target, values = []) {
+  for (const value of values) {
+    if (!target.includes(value)) {
+      target.push(value);
+    }
+  }
+}

--- a/scripts/emit-smt-laws.mjs
+++ b/scripts/emit-smt-laws.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, extname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitLaw,
+  emitFlowEquivalence
+} from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      law: { type: 'string' },
+      equiv: { type: 'boolean' },
+      laws: { type: 'string' },
+      out: { type: 'string', short: 'o' }
+    },
+    allowPositionals: true
+  });
+
+  const modeLaw = typeof values.law === 'string';
+  const modeEquiv = Boolean(values.equiv);
+
+  if (modeLaw === modeEquiv) {
+    usage();
+    process.exit(1);
+  }
+
+  if (modeLaw) {
+    const outArg = values.out ?? defaultLawOut(values.law);
+    const outPath = resolve(outArg);
+    await mkdir(dirname(outPath), { recursive: true });
+    const smt = emitLaw(values.law);
+    await writeFile(outPath, smt, 'utf8');
+    process.stdout.write(`wrote ${outPath}\n`);
+    return;
+  }
+
+  if (positionals.length !== 2) {
+    usage();
+    process.exit(1);
+  }
+
+  const [flowAPath, flowBPath] = positionals.map((p) => resolve(p));
+  const [srcA, srcB] = await Promise.all([
+    readFile(flowAPath, 'utf8'),
+    readFile(flowBPath, 'utf8')
+  ]);
+  const [irA, irB] = [parseDSL(srcA), parseDSL(srcB)];
+  const lawSet = parseLaws(values.laws);
+  const smt = emitFlowEquivalence(irA, irB, lawSet);
+  const outArg = values.out ?? defaultEquivOut(flowAPath, flowBPath);
+  const outPath = resolve(outArg);
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, smt, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage() {
+  process.stderr.write(
+    'Usage:\n' +
+      '  node scripts/emit-smt-laws.mjs --law <law> -o <out.smt2>\n' +
+      '  node scripts/emit-smt-laws.mjs --equiv <flowA.tf> <flowB.tf> --laws <law1,law2> -o <out.smt2>\n'
+  );
+}
+
+function defaultLawOut(law) {
+  const stem = (law || 'law').replace(/[^A-Za-z0-9]+/g, '_');
+  return `out/0.4/proofs/laws/${stem}.smt2`;
+}
+
+function defaultEquivOut(flowAPath, flowBPath) {
+  const left = stemFromPath(flowAPath);
+  const right = stemFromPath(flowBPath);
+  return `out/0.4/proofs/laws/${left}_vs_${right}.smt2`;
+}
+
+function stemFromPath(path) {
+  const base = basename(path);
+  const ext = extname(base);
+  return ext ? base.slice(0, -ext.length) : base;
+}
+
+function parseLaws(value) {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((law) => law.trim())
+    .filter((law) => law.length > 0);
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(String(err?.stack || err));
+  process.stderr.write('\n');
+  process.exit(1);
+});

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitLaw,
+  emitFlowEquivalence
+} from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+test('law axioms emit expected forall assertions', () => {
+  const idempotent = emitLaw('idempotent:hash');
+  assert.ok(
+    idempotent.includes('(forall ((x Val)) (= (H (H x)) (H x)))'),
+    'idempotent law should assert H idempotency'
+  );
+  assert.ok(/\(check-sat\)\s*$/.test(idempotent), 'idempotent law ends with check-sat');
+
+  const inverse = emitLaw('inverse:serialize-deserialize');
+  assert.ok(
+    inverse.includes('(forall ((v Val)) (= (D (S v)) v))'),
+    'inverse law should assert deserialize(serialize(v)) = v'
+  );
+  assert.ok(/\(check-sat\)\s*$/.test(inverse), 'inverse law ends with check-sat');
+
+  const commute = emitLaw('commute:emit-metric-with-pure');
+  assert.ok(
+    commute.includes('(forall ((x Val)) (= (E (H x)) (H (E x))))'),
+    'commute law should assert emit/hash commutativity'
+  );
+  assert.ok(/\(check-sat\)\s*$/.test(commute), 'commute law ends with check-sat');
+});
+
+test('flow equivalence encodes witness with commute axiom', () => {
+  const left = parseDSL('emit-metric |> hash');
+  const right = parseDSL('hash |> emit-metric');
+  const smt = emitFlowEquivalence(left, right, ['commute:emit-metric-with-pure']);
+  assert.ok(
+    smt.includes('(assert (not (= outA outB)))'),
+    'equivalence should negate equality for solver check'
+  );
+  assert.ok(
+    smt.includes('(forall ((x Val)) (= (E (H x)) (H (E x))))'),
+    'commute axiom should mention both E and H'
+  );
+});
+
+test('emission is deterministic', () => {
+  const lawFirst = emitLaw('inverse:serialize-deserialize');
+  const lawSecond = emitLaw('inverse:serialize-deserialize');
+  assert.equal(lawFirst, lawSecond, 'law emission should be deterministic');
+
+  const ir = parseDSL('hash |> hash');
+  const first = emitFlowEquivalence(ir, ir, ['idempotent:hash']);
+  const second = emitFlowEquivalence(ir, ir, ['idempotent:hash']);
+  assert.equal(first, second, 'flow equivalence emission should be deterministic');
+});


### PR DESCRIPTION
## Summary
- add an SMT-LIB law emitter covering idempotent, inverse, and commute axioms
- provide a CLI to emit individual laws or flow equivalence obligations
- document the law workflow and add deterministic unit tests

## Testing
- node --test tests/smt-laws.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf565443cc83209c96349ab3b0b5d1