### PR TITLE
Add trace schema, writer support, and validator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out
 # Summarize traces
 cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
+### Trace files (T3)
+- Set `TF_TRACE_PATH=...` to append JSONL records while running generated flows.
+- Each entry includes `ts`, `prim_id`, `args`, `region`, and `effect`.
+- Validate with `cat trace.jsonl | node scripts/validate-trace.mjs`.
+- Failures exit non-zero and print a summary of the first invalid lines.
+
 ### Example App: Order Publish
 ```bash
 node scripts/app-order-publish.mjs

--- a/schemas/trace.v0.4.schema.json
+++ b/schemas/trace.v0.4.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.tf-lang.com/trace.v0.4.schema.json",
+  "title": "TF Trace v0.4 record",
+  "type": "object",
+  "required": ["ts", "prim_id", "args", "region", "effect"],
+  "properties": {
+    "ts": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "prim_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "args": {
+      "type": "object"
+    },
+    "region": {
+      "type": "string"
+    },
+    "effect": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/validate-trace.mjs
+++ b/scripts/validate-trace.mjs
@@ -1,0 +1,63 @@
+import { createInterface } from 'node:readline';
+import { stdin, stdout } from 'node:process';
+import { readFile } from 'node:fs/promises';
+import Ajv from 'ajv/dist/2020.js';
+
+const schemaUrl = new URL('../schemas/trace.v0.4.schema.json', import.meta.url);
+const schema = JSON.parse(await readFile(schemaUrl, 'utf8'));
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+const validate = ajv.compile(schema);
+
+const rl = createInterface({
+  input: stdin,
+  crlfDelay: Infinity,
+});
+
+let total = 0;
+let invalid = 0;
+let lineNumber = 0;
+const examples = [];
+
+for await (const line of rl) {
+  lineNumber += 1;
+  if (!line.trim()) continue;
+  total += 1;
+
+  let record;
+  try {
+    record = JSON.parse(line);
+  } catch (err) {
+    invalid += 1;
+    if (examples.length < 3) {
+      examples.push({ line: lineNumber, error: `invalid JSON: ${err.message}` });
+    }
+    continue;
+  }
+
+  if (!validate(record)) {
+    invalid += 1;
+    const firstError = validate.errors?.[0];
+    let message = 'invalid record';
+    if (firstError) {
+      if (firstError.keyword === 'required' && firstError.params?.missingProperty) {
+        message = `${firstError.params.missingProperty} is required`;
+      } else if (typeof firstError.message === 'string') {
+        message = firstError.message;
+      } else {
+        message = ajv.errorsText([firstError]);
+      }
+    }
+    if (examples.length < 3) {
+      examples.push({ line: lineNumber, error: message });
+    }
+  }
+}
+
+const ok = invalid === 0;
+const summary = ok
+  ? { ok: true, total, invalid: 0 }
+  : { ok: false, total, invalid, examples };
+
+stdout.write(`${JSON.stringify(summary)}\n`);
+process.exitCode = ok ? 0 : 1;

--- a/tests/trace-schema.test.mjs
+++ b/tests/trace-schema.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const tfCli = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+const validatorCli = fileURLToPath(new URL('../scripts/validate-trace.mjs', import.meta.url));
+const publishOutDir = fileURLToPath(new URL('../out/0.4/codegen-ts/run_publish', import.meta.url));
+const runScript = path.join(publishOutDir, 'run.mjs');
+const tracePath = fileURLToPath(new URL('../out/0.4/traces/publish.jsonl', import.meta.url));
+
+function runNode(args, { input, env, cwd } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+test('trace writer emits JSONL and validator enforces schema', async () => {
+  await fs.rm(publishOutDir, { recursive: true, force: true });
+  await fs.rm(tracePath, { force: true });
+  await fs.mkdir(path.dirname(tracePath), { recursive: true });
+
+  const emitResult = await runNode([
+    tfCli,
+    'emit',
+    '--lang',
+    'ts',
+    fileURLToPath(new URL('../examples/flows/run_publish.tf', import.meta.url)),
+    '--out',
+    publishOutDir,
+  ]);
+  assert.equal(emitResult.code, 0, emitResult.stderr);
+
+  const capsPath = path.join(os.tmpdir(), `tf-trace-caps-${process.pid}.json`);
+  await fs.writeFile(
+    capsPath,
+    JSON.stringify({ effects: ['Network.Out', 'Pure', 'Observability'], allow_writes_prefixes: [] }),
+    'utf8',
+  );
+
+  const runResult = await runNode([runScript, '--caps', capsPath], {
+    env: { TF_TRACE_PATH: tracePath },
+  });
+  assert.equal(runResult.code, 0, runResult.stderr);
+
+  const traceContent = await fs.readFile(tracePath, 'utf8');
+  const records = traceContent
+    .trim()
+    .split('\n')
+    .filter((line) => line);
+  assert.ok(records.length >= 1, 'expected at least one trace record');
+
+  const validResult = await runNode([validatorCli], {
+    input: traceContent,
+    cwd: repoRoot,
+  });
+  assert.equal(validResult.code, 0, validResult.stderr);
+  const summary = JSON.parse(validResult.stdout.trim());
+  assert.deepEqual(summary, { ok: true, total: records.length, invalid: 0 });
+
+  const invalidLine = `${JSON.stringify({ ts: Date.now(), args: {}, effect: 'Storage.Write', region: '' })}\n`;
+  const invalidResult = await runNode([validatorCli], {
+    input: invalidLine,
+    cwd: repoRoot,
+  });
+  assert.equal(invalidResult.code, 1, invalidResult.stderr);
+  const invalidSummary = JSON.parse(invalidResult.stdout.trim());
+  assert.equal(invalidSummary.ok, false);
+  assert.equal(invalidSummary.total, 1);
+  assert.equal(invalidSummary.invalid, 1);
+  assert.ok(Array.isArray(invalidSummary.examples));
+  assert.ok(invalidSummary.examples.length >= 1);
+  assert.equal(invalidSummary.examples[0].line, 1);
+  assert.equal(invalidSummary.examples[0].error, 'prim_id is required');
+});


### PR DESCRIPTION
## Summary
- add the v0.4 JSON schema for trace records and wire the runner to emit ordered fields to stdout and optional files
- provide an Ajv-based CLI to validate trace JSONL streams against the schema
- cover the flow by generating and running publish traces, validating good/bad samples, and documenting the workflow

## Testing
- pnpm run a0
- pnpm run a1
- pnpm -w -r build
- pnpm run tf -- emit --lang ts examples/flows/run_publish.tf --out out/0.4/codegen-ts/run_publish
- TF_TRACE_PATH=out/0.4/traces/publish.jsonl node out/0.4/codegen-ts/run_publish/run.mjs --caps /tmp/caps2.json
- cat out/0.4/traces/publish.jsonl | node scripts/validate-trace.mjs
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68cf563bd540832094f56b9e2a6dcfc6