### PR TITLE
Add trace schema, file writer, and validator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out
 # Summarize traces
 cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
+### Trace files (T3)
+- Set `TF_TRACE_PATH=path/to/file.jsonl` before running generated flows to append JSONL trace records.
+- Records still print to stdout, so interactive tooling continues to work.
+- Validate saved traces via `cat file.jsonl | node scripts/validate-trace.mjs`.
+- Schema lives at `schemas/trace.v0.4.schema.json` (Draft 2020-12) for integrations.
+
 ### Example App: Order Publish
 ```bash
 node scripts/app-order-publish.mjs

--- a/schemas/trace.v0.4.schema.json
+++ b/schemas/trace.v0.4.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tf-lang.io/schemas/trace.v0.4.schema.json",
+  "title": "TF Trace v0.4",
+  "type": "object",
+  "required": ["ts", "prim_id", "args", "region", "effect"],
+  "properties": {
+    "ts": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "prim_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "args": {
+      "type": "object"
+    },
+    "region": {
+      "type": "string"
+    },
+    "effect": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/validate-trace.mjs
+++ b/scripts/validate-trace.mjs
@@ -1,0 +1,71 @@
+import { createRequire } from 'node:module';
+import { createInterface } from 'node:readline';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const require = createRequire(import.meta.url);
+const schema = require('../schemas/trace.v0.4.schema.json');
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+const rl = createInterface({
+  input: process.stdin,
+  crlfDelay: Number.POSITIVE_INFINITY,
+});
+
+process.stdin.setEncoding('utf8');
+
+let total = 0;
+let invalid = 0;
+const examples = [];
+let lineNumber = 0;
+
+function addExample(line, error) {
+  if (examples.length < 3) {
+    examples.push({ line, error });
+  }
+}
+
+function describeError(error) {
+  if (!error) return 'invalid record';
+  if (error.keyword === 'required' && error.params && typeof error.params.missingProperty === 'string') {
+    return `${error.params.missingProperty} is required`;
+  }
+  if (typeof error.message === 'string' && error.message.length > 0) {
+    return error.message;
+  }
+  return 'invalid record';
+}
+
+(async () => {
+  for await (const raw of rl) {
+    lineNumber += 1;
+    if (!raw.trim()) {
+      continue;
+    }
+    total += 1;
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      invalid += 1;
+      addExample(lineNumber, 'invalid JSON');
+      continue;
+    }
+    if (!validate(parsed)) {
+      invalid += 1;
+      addExample(lineNumber, describeError(validate.errors && validate.errors[0]));
+    }
+  }
+
+  const summary = { ok: invalid === 0, total, invalid };
+  if (invalid > 0) {
+    summary.examples = examples;
+  }
+
+  if (invalid > 0) {
+    process.exitCode = 1;
+  }
+
+  process.stdout.write(JSON.stringify(summary) + '\n');
+})();

--- a/tests/trace-schema.test.mjs
+++ b/tests/trace-schema.test.mjs
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { promises as fs } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const tfCli = join(repoRoot, 'packages', 'tf-compose', 'bin', 'tf.mjs');
+const validatorScript = join(repoRoot, 'scripts', 'validate-trace.mjs');
+const runOutDir = join(repoRoot, 'out', '0.4', 'codegen-ts', 'run_publish');
+const traceDir = join(repoRoot, 'out', '0.4', 'traces');
+const tracePath = join(traceDir, 'publish.jsonl');
+
+function runNode(args, { cwd = repoRoot, env, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+test('trace writer emits JSONL and validator enforces schema', async () => {
+  await fs.mkdir(traceDir, { recursive: true });
+
+  const emit = await runNode([
+    tfCli,
+    'emit',
+    '--lang',
+    'ts',
+    join('examples', 'flows', 'run_publish.tf'),
+    '--out',
+    runOutDir,
+  ]);
+  assert.equal(emit.code, 0, emit.stderr);
+
+  const capsPath = join(traceDir, 'caps.json');
+  const caps = {
+    effects: ['Network.Out', 'Pure', 'Observability'],
+    allow_writes_prefixes: [],
+  };
+  await fs.writeFile(capsPath, JSON.stringify(caps));
+  await fs.rm(tracePath, { force: true });
+
+  const runnerPath = join(runOutDir, 'run.mjs');
+  const run = await runNode([runnerPath, '--caps', capsPath], {
+    env: { TF_TRACE_PATH: tracePath },
+  });
+  assert.equal(run.code, 0, run.stderr);
+
+  const traceContent = await fs.readFile(tracePath, 'utf8');
+  const traceLines = traceContent
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  assert.ok(traceLines.length >= 1, 'expected at least one trace line');
+
+  const valid = await runNode([validatorScript], { input: traceContent });
+  assert.equal(valid.code, 0, valid.stderr);
+  const validSummary = JSON.parse(valid.stdout.trim());
+  assert.equal(validSummary.ok, true);
+  assert.equal(validSummary.invalid, 0);
+  assert.ok(validSummary.total >= 1);
+
+  const invalidContent = '{"ts":1,"args":{},"region":"","effect":""}\n';
+  const invalid = await runNode([validatorScript], { input: invalidContent });
+  assert.equal(invalid.code, 1, invalid.stderr);
+  const invalidSummary = JSON.parse(invalid.stdout.trim());
+  assert.equal(invalidSummary.ok, false);
+  assert.equal(invalidSummary.invalid, 1);
+  assert.ok(Array.isArray(invalidSummary.examples));
+  assert.ok(invalidSummary.examples.length >= 1);
+  assert.equal(invalidSummary.examples[0].error, 'prim_id is required');
+});


### PR DESCRIPTION
## Summary
- add the draft 2020-12 JSON schema for T3 trace records
- extend the generated JS runner to tee trace events to TF_TRACE_PATH while keeping console output and closing the stream after runs
- introduce a trace validator CLI with schema-based checks and tests that cover writing and validating traces along with README docs

## Testing
- pnpm run a0
- pnpm run a1
- pnpm -w -r build
- pnpm run tf -- emit --lang ts examples/flows/run_publish.tf --out out/0.4/codegen-ts/run_publish
- TF_TRACE_PATH=out/0.4/traces/publish.jsonl node out/0.4/codegen-ts/run_publish/run.mjs --caps /tmp/caps2.json
- cat out/0.4/traces/publish.jsonl | node scripts/validate-trace.mjs
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68cf563bd540832094f56b9e2a6dcfc6