### PR TITLE
Add trace schema, writer, and validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out
 # Summarize traces
 cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
+### Trace files (T3)
+- Set `TF_TRACE_PATH=...` when running generated runners to capture JSONL traces.
+- Records emit `ts`, `prim_id`, `args`, `region`, and `effect` keys in stable order.
+- Validate captures with `cat trace.jsonl | node scripts/validate-trace.mjs`.
+- Schema lives at `schemas/trace.v0.4.schema.json` (JSON Schema Draft 2020-12).
+
 ### Example App: Order Publish
 ```bash
 node scripts/app-order-publish.mjs

--- a/schemas/trace.v0.4.schema.json
+++ b/schemas/trace.v0.4.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://transformers.dev/schemas/trace.v0.4.schema.json",
+  "title": "Transformers Trace v0.4 Record",
+  "type": "object",
+  "required": [
+    "ts",
+    "prim_id",
+    "args",
+    "region",
+    "effect"
+  ],
+  "properties": {
+    "ts": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "prim_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "args": {
+      "type": "object"
+    },
+    "region": {
+      "type": "string"
+    },
+    "effect": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/validate-trace.mjs
+++ b/scripts/validate-trace.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { stdin, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import Ajv from 'ajv/dist/2020.js';
+
+async function loadSchema() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const schemaPath = path.join(here, '../schemas/trace.v0.4.schema.json');
+  const raw = await readFile(schemaPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function formatError(error) {
+  if (!error) return 'Unknown validation error';
+  if (error.keyword === 'required' && typeof error.params?.missingProperty === 'string') {
+    return `${error.params.missingProperty} is required`;
+  }
+  const pathSegment = error.instancePath
+    ? error.instancePath.replace(/\//g, '.').replace(/^\./, '')
+    : '';
+  if (pathSegment) {
+    if (error.message) return `${pathSegment} ${error.message}`;
+    return `${pathSegment} ${error.keyword} validation failed`;
+  }
+  if (error.message) return error.message;
+  return `${error.keyword ?? 'schema'} validation failed`;
+}
+
+async function main() {
+  stdin.setEncoding('utf8');
+  const schema = await loadSchema();
+  const ajv = new Ajv({ strict: false, allErrors: true });
+  const validate = ajv.compile(schema);
+
+  const rl = createInterface({ input: stdin, crlfDelay: Infinity });
+
+  let total = 0;
+  let invalid = 0;
+  const examples = [];
+  let lineNo = 0;
+
+  for await (const line of rl) {
+    lineNo += 1;
+    if (!line.trim()) {
+      continue;
+    }
+    total += 1;
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (err) {
+      invalid += 1;
+      if (examples.length < 3) {
+        examples.push({ line: lineNo, error: err instanceof Error ? err.message : 'Invalid JSON' });
+      }
+      continue;
+    }
+
+    const ok = validate(record);
+    if (!ok) {
+      invalid += 1;
+      if (examples.length < 3) {
+        const message = formatError(validate.errors?.[0]);
+        examples.push({ line: lineNo, error: message });
+      }
+    }
+  }
+
+  const summary = invalid === 0
+    ? { ok: true, total, invalid: 0 }
+    : { ok: false, total, invalid, examples };
+
+  stdout.write(`${JSON.stringify(summary)}\n`);
+  if (invalid > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tests/trace-schema.test.mjs
+++ b/tests/trace-schema.test.mjs
@@ -1,0 +1,95 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const tfCliPath = fileURLToPath(new URL('../packages/tf-compose/bin/tf.mjs', import.meta.url));
+const flowPath = fileURLToPath(new URL('../examples/flows/run_publish.tf', import.meta.url));
+const runOutDir = fileURLToPath(new URL('../out/0.4/codegen-ts/run_publish', import.meta.url));
+const runnerPath = path.join(runOutDir, 'run.mjs');
+const tracesDir = fileURLToPath(new URL('../out/0.4/traces', import.meta.url));
+const tracePath = path.join(tracesDir, 'publish.jsonl');
+const validatorPath = fileURLToPath(new URL('../scripts/validate-trace.mjs', import.meta.url));
+
+function runNode(args, { input, env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+test('trace writer emits JSONL and validator enforces schema', async () => {
+  await fs.mkdir(path.dirname(runOutDir), { recursive: true });
+  await fs.mkdir(tracesDir, { recursive: true });
+  await fs.rm(runOutDir, { recursive: true, force: true });
+  await fs.rm(tracePath, { force: true });
+
+  const emitResult = await runNode([tfCliPath, 'emit', '--lang', 'ts', flowPath, '--out', runOutDir]);
+  assert.equal(emitResult.code, 0, emitResult.stderr);
+
+  const capsPath = '/tmp/caps2.json';
+  await fs.writeFile(
+    capsPath,
+    JSON.stringify({ effects: ['Network.Out', 'Pure', 'Observability'], allow_writes_prefixes: [] })
+  );
+
+  const runResult = await runNode(
+    [runnerPath, '--caps', capsPath],
+    { env: { TF_TRACE_PATH: tracePath } }
+  );
+  assert.equal(runResult.code, 0, runResult.stderr);
+  assert.ok(runResult.stdout.includes('prim_id'), 'expected stdout to include trace output');
+
+  const traceData = await fs.readFile(tracePath, 'utf8');
+  const traceLines = traceData.split('\n').filter((line) => line.trim().length > 0);
+  assert.ok(traceLines.length >= 1, 'expected at least one trace line');
+
+  const validResult = await runNode([validatorPath], { input: traceData });
+  assert.equal(validResult.code, 0, validResult.stderr);
+  const validSummary = JSON.parse(validResult.stdout.trim());
+  assert.equal(validSummary.ok, true);
+  assert.equal(validSummary.invalid, 0);
+  assert.ok(validSummary.total >= 1);
+
+  const tempDir = await fs.mkdtemp(path.join(tmpdir(), 'tf-trace-'));
+  const badTracePath = path.join(tempDir, 'bad.jsonl');
+  await fs.writeFile(badTracePath, '{"ts":1,"args":{},"region":"","effect":"Pure"}\n');
+  const badInput = await fs.readFile(badTracePath, 'utf8');
+  const invalidResult = await runNode([validatorPath], { input: badInput });
+  assert.equal(invalidResult.code, 1, invalidResult.stderr);
+  const invalidSummary = JSON.parse(invalidResult.stdout.trim());
+  assert.equal(invalidSummary.ok, false);
+  assert.equal(invalidSummary.total, 1);
+  assert.equal(invalidSummary.invalid, 1);
+  assert.ok(Array.isArray(invalidSummary.examples));
+  assert.ok(invalidSummary.examples.length >= 1);
+  assert.equal(invalidSummary.examples[0].line, 1);
+  assert.equal(invalidSummary.examples[0].error, 'prim_id is required');
+});


### PR DESCRIPTION
## Summary
- add a draft 2020-12 JSON schema for v0.4 trace records and document trace capture
- teach the generated TS runtime to optionally append trace JSONL to TF_TRACE_PATH while still logging
- add a JSONL validator CLI plus tests that cover successful and failing traces

## Testing
- pnpm run a0
- pnpm run a1
- pnpm -w -r build
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68cf563bd540832094f56b9e2a6dcfc6