### PR TITLE
Add L0 type system helpers and demo CLI

### DIFF
--- a/packages/tf-l0-spec/spec/signatures.demo.json
+++ b/packages/tf-l0-spec/spec/signatures.demo.json
@@ -1,0 +1,56 @@
+{
+  "tf:information/hash@1": {
+    "input": {"refined": ["string", "digest_sha256"]},
+    "output": {"refined": ["string", "digest_sha256"]}
+  },
+  "tf:observability/emit-metric@1": {
+    "input": {"unit": true},
+    "output": {"unit": true}
+  },
+  "tf:network/publish@1": {
+    "input": {
+      "object": {
+        "required": {
+          "topic": {"string": true},
+          "key": {"string": true},
+          "payload": {"string": true}
+        }
+      }
+    },
+    "output": {"unit": true}
+  },
+  "tf:resource/write-object@1": {
+    "input": {
+      "object": {
+        "required": {
+          "uri": {"refined": ["string", "uri"]},
+          "key": {"string": true},
+          "value": {"string": true}
+        },
+        "optional": {
+          "idempotency_key": {"refined": ["string", "idempotency_key"]}
+        }
+      }
+    },
+    "output": {
+      "object": {
+        "required": {
+          "status": {"string": true}
+        }
+      }
+    }
+  },
+  "tf:resource/compare-and-swap@1": {
+    "input": {
+      "object": {
+        "required": {
+          "uri": {"refined": ["string", "uri"]},
+          "key": {"string": true},
+          "expect": {"string": true},
+          "update": {"string": true}
+        }
+      }
+    },
+    "output": {"bool": true}
+  }
+}

--- a/packages/tf-l0-types/README.md
+++ b/packages/tf-l0-types/README.md
@@ -1,0 +1,3 @@
+# @tf-lang/tf-l0-types
+
+Minimal helpers for expressing TF L0 demo types. Provides constructors for the primitive vocabulary, a stable JSON codec, and a conservative unifier used by the examples and smoke tests.

--- a/packages/tf-l0-types/package.json
+++ b/packages/tf-l0-types/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@tf-lang/tf-l0-types",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/types.mjs"
+  }
+}

--- a/packages/tf-l0-types/src/types.mjs
+++ b/packages/tf-l0-types/src/types.mjs
@@ -1,0 +1,420 @@
+const BASE_KINDS = new Set([
+  "int",
+  "float",
+  "string",
+  "bool",
+  "bytes",
+  "unit",
+  "any"
+]);
+
+const REFINEMENT_TAGS = new Set([
+  "timestamp_ms",
+  "uri",
+  "digest_sha256",
+  "symbol",
+  "idempotency_key"
+]);
+
+function createBase(kind, refinements = []) {
+  if (!BASE_KINDS.has(kind)) {
+    throw new Error(`unknown base kind: ${kind}`);
+  }
+  if (kind === "any" && refinements.length > 0) {
+    throw new Error("cannot refine 'any'");
+  }
+  const unique = Array.from(new Set(refinements));
+  unique.sort();
+  return {
+    kind: "base",
+    name: kind,
+    refinements: unique
+  };
+}
+
+function cloneBase(type) {
+  return createBase(type.name, type.refinements ?? []);
+}
+
+function baseFactory(kind) {
+  return () => createBase(kind);
+}
+
+export const int = baseFactory("int");
+export const float = baseFactory("float");
+export const string = baseFactory("string");
+export const bool = baseFactory("bool");
+export const bytes = baseFactory("bytes");
+export const unit = baseFactory("unit");
+export const any = baseFactory("any");
+
+export function kind(name) {
+  return createBase(name);
+}
+
+export function refined(type, tag) {
+  if (!REFINEMENT_TAGS.has(tag)) {
+    throw new Error(`unknown refinement tag: ${tag}`);
+  }
+  const normalized = normalize(type);
+  if (normalized.kind !== "base") {
+    throw new Error("refinements are only supported on base kinds");
+  }
+  const tags = new Set(normalized.refinements);
+  tags.add(tag);
+  return createBase(normalized.name, Array.from(tags));
+}
+
+export function array(type) {
+  return {
+    kind: "array",
+    element: normalize(type)
+  };
+}
+
+export function option(type) {
+  return {
+    kind: "option",
+    inner: normalize(type)
+  };
+}
+
+function normalizeField(key, descriptor) {
+  let optional = false;
+  let cleanKey = key;
+  if (cleanKey.endsWith("?")) {
+    optional = true;
+    cleanKey = cleanKey.slice(0, -1);
+  }
+
+  let typeDescriptor = descriptor;
+  if (descriptor && typeof descriptor === "object" && "type" in descriptor) {
+    typeDescriptor = descriptor.type;
+    if (descriptor.optional !== undefined) {
+      optional = Boolean(descriptor.optional);
+    }
+  }
+
+  return {
+    key: cleanKey,
+    optional,
+    type: normalize(typeDescriptor)
+  };
+}
+
+function makeObjectFromFields(fields) {
+  const mapped = fields.map((field) => ({
+    key: field.key,
+    optional: Boolean(field.optional),
+    type: normalize(field.type)
+  }));
+  mapped.sort((a, b) => a.key.localeCompare(b.key));
+  return {
+    kind: "object",
+    fields: mapped
+  };
+}
+
+export function object(shape) {
+  if (!shape || typeof shape !== "object" || Array.isArray(shape)) {
+    throw new Error("object() expects a plain object shape");
+  }
+  const entries = Object.entries(shape).map(([key, descriptor]) =>
+    normalizeField(key, descriptor)
+  );
+  const seen = new Set();
+  for (const field of entries) {
+    if (seen.has(field.key)) {
+      throw new Error(`duplicate field '${field.key}' in object shape`);
+    }
+    seen.add(field.key);
+  }
+  return makeObjectFromFields(entries);
+}
+
+function flattenUnion(types) {
+  const queue = [];
+  for (const candidate of types) {
+    const normalized = normalize(candidate);
+    if (normalized.kind === "union") {
+      queue.push(...normalized.variants);
+    } else {
+      queue.push(normalized);
+    }
+  }
+  const lookup = new Map();
+  for (const variant of queue) {
+    const key = canonicalStringify(toJSON(variant));
+    lookup.set(key, variant);
+  }
+  const sortedKeys = Array.from(lookup.keys()).sort();
+  return sortedKeys.map((key) => lookup.get(key));
+}
+
+export function union(...types) {
+  if (types.length === 0) {
+    throw new Error("union() requires at least one type");
+  }
+  const variants = flattenUnion(types);
+  if (variants.length === 1) {
+    return variants[0];
+  }
+  return {
+    kind: "union",
+    variants
+  };
+}
+
+export function normalize(type) {
+  if (!type || typeof type !== "object") {
+    throw new Error("invalid type descriptor");
+  }
+  switch (type.kind) {
+    case "base":
+      return cloneBase(type);
+    case "array":
+      return array(type.element);
+    case "option":
+      return option(type.inner);
+    case "object":
+      return makeObjectFromFields(type.fields ?? []);
+    case "union":
+      return union(...(type.variants ?? []));
+    default:
+      throw new Error(`unsupported type descriptor: ${JSON.stringify(type)}`);
+  }
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalize(entry));
+  }
+  if (value && typeof value === "object") {
+    const result = {};
+    const keys = Object.keys(value).sort();
+    for (const key of keys) {
+      result[key] = canonicalize(value[key]);
+    }
+    return result;
+  }
+  return value;
+}
+
+export function canonicalStringify(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function toJSON(type) {
+  const normalized = normalize(type);
+  switch (normalized.kind) {
+    case "base": {
+      if (normalized.refinements.length === 0) {
+        return { [normalized.name]: true };
+      }
+      const baseToken = normalized.name;
+      if (normalized.refinements.length === 1) {
+        return { refined: [baseToken, normalized.refinements[0]] };
+      }
+      return { refined: [baseToken, [...normalized.refinements]] };
+    }
+    case "array":
+      return { array: toJSON(normalized.element) };
+    case "option":
+      return { option: toJSON(normalized.inner) };
+    case "object": {
+      const required = {};
+      const optional = {};
+      for (const field of normalized.fields) {
+        const container = field.optional ? optional : required;
+        container[field.key] = toJSON(field.type);
+      }
+      const payload = {};
+      const requiredKeys = Object.keys(required);
+      const optionalKeys = Object.keys(optional);
+      if (requiredKeys.length > 0) {
+        requiredKeys.sort();
+        const obj = {};
+        for (const key of requiredKeys) {
+          obj[key] = required[key];
+        }
+        payload.required = obj;
+      }
+      if (optionalKeys.length > 0) {
+        optionalKeys.sort();
+        const obj = {};
+        for (const key of optionalKeys) {
+          obj[key] = optional[key];
+        }
+        payload.optional = obj;
+      }
+      return { object: payload };
+    }
+    case "union":
+      return {
+        union: normalized.variants.map((variant) => toJSON(variant))
+      };
+    default:
+      throw new Error(`cannot convert to JSON: ${JSON.stringify(normalized)}`);
+  }
+}
+
+export function fromJSON(json) {
+  if (!json || typeof json !== "object" || Array.isArray(json)) {
+    throw new Error("fromJSON expects an object");
+  }
+  if ("refined" in json) {
+    const [baseToken, refinementSpec] = json.refined;
+    const baseType = typeof baseToken === "string" ? kind(baseToken) : fromJSON(baseToken);
+    const tags = Array.isArray(refinementSpec)
+      ? refinementSpec
+      : [refinementSpec];
+    return tags.reduce((acc, tag) => refined(acc, tag), baseType);
+  }
+  if ("array" in json) {
+    return array(fromJSON(json.array));
+  }
+  if ("option" in json) {
+    return option(fromJSON(json.option));
+  }
+  if ("object" in json) {
+    const payload = json.object;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("object payload must be an object");
+    }
+    const shape = {};
+    if (payload.required) {
+      for (const [key, value] of Object.entries(payload.required)) {
+        shape[key] = fromJSON(value);
+      }
+    }
+    if (payload.optional) {
+      for (const [key, value] of Object.entries(payload.optional)) {
+        shape[`${key}?`] = fromJSON(value);
+      }
+    }
+    return object(shape);
+  }
+  if ("union" in json) {
+    const variants = json.union.map((variant) => fromJSON(variant));
+    return union(...variants);
+  }
+  const entries = Object.entries(json);
+  if (entries.length === 1) {
+    const [key, value] = entries[0];
+    if (value === true && BASE_KINDS.has(key)) {
+      return kind(key);
+    }
+  }
+  throw new Error(`unsupported JSON payload: ${JSON.stringify(json)}`);
+}
+
+function cloneObjectFields(fields) {
+  return fields.map((field) => ({
+    key: field.key,
+    optional: field.optional,
+    type: normalize(field.type)
+  }));
+}
+
+function makeObjectType(fields) {
+  return makeObjectFromFields(cloneObjectFields(fields));
+}
+
+function isAny(type) {
+  return type.kind === "base" && type.name === "any";
+}
+
+function kindMismatchReason(a, b) {
+  if (a.kind === "object" || b.kind === "object") {
+    return "shape_mismatch";
+  }
+  return "kind_mismatch";
+}
+
+export function unify(left, right) {
+  const a = normalize(left);
+  const b = normalize(right);
+
+  if (isAny(a)) {
+    return { ok: true, type: b };
+  }
+  if (isAny(b)) {
+    return { ok: true, type: a };
+  }
+
+  if (a.kind === "union" || b.kind === "union") {
+    const variants = [];
+    if (a.kind === "union") variants.push(...a.variants);
+    else variants.push(a);
+    if (b.kind === "union") variants.push(...b.variants);
+    else variants.push(b);
+    return { ok: true, type: union(...variants) };
+  }
+
+  if (a.kind !== b.kind) {
+    return { ok: false, reason: kindMismatchReason(a, b) };
+  }
+
+  switch (a.kind) {
+    case "base": {
+      if (a.name !== b.name) {
+        return { ok: false, reason: "kind_mismatch" };
+      }
+      const leftTags = a.refinements;
+      const rightTags = b.refinements;
+      if (leftTags.length === 0 && rightTags.length === 0) {
+        return { ok: true, type: createBase(a.name) };
+      }
+      if (leftTags.length === 0 || rightTags.length === 0) {
+        return { ok: false, reason: "refinement_mismatch" };
+      }
+      const intersection = leftTags.filter((tag) => rightTags.includes(tag));
+      if (intersection.length === 0) {
+        return { ok: false, reason: "refinement_mismatch" };
+      }
+      return { ok: true, type: createBase(a.name, intersection) };
+    }
+    case "array": {
+      const inner = unify(a.element, b.element);
+      if (!inner.ok) {
+        return inner;
+      }
+      return { ok: true, type: array(inner.type) };
+    }
+    case "option": {
+      const inner = unify(a.inner, b.inner);
+      if (!inner.ok) {
+        return inner;
+      }
+      return { ok: true, type: option(inner.type) };
+    }
+    case "object": {
+      if (a.fields.length !== b.fields.length) {
+        return { ok: false, reason: "shape_mismatch" };
+      }
+      const merged = [];
+      for (let i = 0; i < a.fields.length; i += 1) {
+        const leftField = a.fields[i];
+        const rightField = b.fields[i];
+        if (leftField.key !== rightField.key || leftField.optional !== rightField.optional) {
+          return { ok: false, reason: "shape_mismatch" };
+        }
+        const fieldResult = unify(leftField.type, rightField.type);
+        if (!fieldResult.ok) {
+          return fieldResult;
+        }
+        merged.push({
+          key: leftField.key,
+          optional: leftField.optional,
+          type: fieldResult.type
+        });
+      }
+      return { ok: true, type: makeObjectType(merged) };
+    }
+    default:
+      throw new Error(`unhandled kind: ${a.kind}`);
+  }
+}
+
+export const refinements = Object.freeze(Array.from(REFINEMENT_TAGS));
+export const baseKinds = Object.freeze(Array.from(BASE_KINDS));

--- a/scripts/types-demo.mjs
+++ b/scripts/types-demo.mjs
@@ -1,0 +1,80 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { fromJSON, toJSON, unify, canonicalStringify } from "../packages/tf-l0-types/src/types.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const specPath = resolve(here, "../packages/tf-l0-spec/spec/signatures.demo.json");
+const outputPath = resolve(here, "../out/0.4/check/types-demo.json");
+
+async function loadSpec(path) {
+  const raw = await readFile(path, "utf8");
+  const data = JSON.parse(raw);
+  const entries = Object.entries(data);
+  return entries.reduce((acc, [id, payload]) => {
+    acc[id] = {
+      input: fromJSON(payload.input),
+      output: fromJSON(payload.output)
+    };
+    return acc;
+  }, {});
+}
+
+function requireSignature(signatures, id) {
+  const signature = signatures[id];
+  if (!signature) {
+    throw new Error(`missing signature for ${id}`);
+  }
+  return signature;
+}
+
+function evaluateChain(signatures, chain) {
+  const label = chain.join("|>");
+  if (chain.length === 1) {
+    const signature = requireSignature(signatures, chain[0]);
+    return { chain: label, ok: true, type: toJSON(signature.output) };
+  }
+  let last = null;
+  for (let i = 0; i < chain.length - 1; i += 1) {
+    const current = requireSignature(signatures, chain[i]);
+    const next = requireSignature(signatures, chain[i + 1]);
+    const verdict = unify(current.output, next.input);
+    if (!verdict.ok) {
+      return { chain: label, ok: false, reason: verdict.reason };
+    }
+    last = verdict.type;
+  }
+  const payload = { chain: label, ok: true };
+  if (last) {
+    payload.type = toJSON(last);
+  }
+  return payload;
+}
+
+async function main() {
+  const signatures = await loadSpec(specPath);
+  const chains = [
+    ["tf:information/hash@1", "tf:information/hash@1"],
+    ["tf:network/publish@1", "tf:observability/emit-metric@1"],
+    ["tf:resource/write-object@1", "tf:information/hash@1"]
+  ];
+
+  const cases = chains.map((chain) => evaluateChain(signatures, chain));
+  const summary = cases.reduce(
+    (acc, entry) => {
+      if (entry.ok) acc.ok += 1;
+      else acc.fail += 1;
+      return acc;
+    },
+    { ok: 0, fail: 0 }
+  );
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${canonicalStringify({ cases, summary })}\n`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tests/types-unify.test.mjs
+++ b/tests/types-unify.test.mjs
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  any,
+  array,
+  bytes,
+  object,
+  option,
+  refined,
+  string,
+  toJSON,
+  canonicalStringify,
+  unify
+} from "../packages/tf-l0-types/src/types.mjs";
+
+function assertDeterministic(left, right) {
+  const first = unify(left, right);
+  const second = unify(left, right);
+  assert.deepStrictEqual(first, second, "unify results should be deterministic");
+  if (first.ok) {
+    const jsonFirst = canonicalStringify(toJSON(first.type));
+    const jsonSecond = canonicalStringify(toJSON(second.type));
+    assert.strictEqual(jsonFirst, jsonSecond, "canonical JSON should be stable");
+  }
+  return first;
+}
+
+function assertCommutative(left, right) {
+  const forward = unify(left, right);
+  const backward = unify(right, left);
+  assert.deepStrictEqual(forward, backward, "unify should be commutative");
+  return forward;
+}
+
+test("refined hash type is stable", () => {
+  const digest = refined(string(), "digest_sha256");
+  const commutative = assertCommutative(digest, digest);
+  assert.ok(commutative.ok, "refined string hashes should unify");
+  const deterministic = assertDeterministic(digest, digest);
+  assert.ok(deterministic.ok, "deterministic unify should succeed");
+});
+
+test("option(string) merges", () => {
+  const left = option(string());
+  const right = option(string());
+  const result = assertCommutative(left, right);
+  assert.ok(result.ok, "option(string) should unify");
+  const json = canonicalStringify(toJSON(result.type));
+  const again = canonicalStringify(toJSON(assertDeterministic(left, right).type));
+  assert.strictEqual(json, again, "option unify should be stable");
+});
+
+test("any unifies with structured types", () => {
+  const payload = array(string());
+  const result = unify(any(), payload);
+  assert.ok(result.ok, "any should unify with arrays");
+  const json = canonicalStringify(toJSON(result.type));
+  const expected = canonicalStringify(toJSON(payload));
+  assert.strictEqual(json, expected, "any should return the other type");
+});
+
+test("bytes and string stay distinct", () => {
+  const verdict = unify(bytes(), string());
+  assert.deepStrictEqual(verdict, { ok: false, reason: "kind_mismatch" });
+});
+
+test("object shapes require matching fields", () => {
+  const base = object({ topic: string(), key: string() });
+  const missing = object({ topic: string() });
+  const verdict = unify(base, missing);
+  assert.deepStrictEqual(verdict, { ok: false, reason: "shape_mismatch" });
+});
+
+test("refinement mismatch fails", () => {
+  const refinedUri = refined(string(), "uri");
+  const plain = string();
+  const verdict = unify(refinedUri, plain);
+  assert.deepStrictEqual(verdict, { ok: false, reason: "refinement_mismatch" });
+});


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

> Fill all sections. CI will fail if required headings are missing.

## Summary
- Scope: tf-l0 types demo helpers
- Key outcomes in this PR:
  - Added a minimal tf-l0 type vocabulary with canonical JSON codec and conservative unifier.
  - Added a deterministic CLI that emits demo chain compatibility reports.
  - Added regression tests for unifier commutativity and determinism.
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [ ] CI wiring + determinism re-run

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`

## Determinism & Seeds
- Repeats: 1
- Seeds: n/a
- Notes: `node scripts/types-demo.mjs` writes deterministic JSON via canonical codec.

## Tests & CI
- TS tests: passed 91 / failed 1 (workspace failure in tests/codegen-rs.test.mjs unrelated to this change)
- Rust tests: passed 0 / failed 0 (not run)
- CI jobs: not run (local testing only)

## Implementation Notes
- ABI / paths unchanged? Y (new helpers only)
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`, Rust panic‑free

## Hurdles / Follow-ups
- Known gaps: Workspace test suite currently fails on existing rust scaffold assertion.
- Suggested next steps: Investigate failing rust scaffold test separately from this change.


------
https://chatgpt.com/codex/tasks/task_e_68d008c69ca483208920b877ee5995c7