### PR TITLE
Add L0 type vocabulary and demo CLI

### DIFF
--- a/packages/tf-l0-spec/spec/signatures.demo.json
+++ b/packages/tf-l0-spec/spec/signatures.demo.json
@@ -1,0 +1,71 @@
+{
+  "tf:information/hash@1": {
+    "input": { "any": true },
+    "output": { "refined": ["string", "digest_sha256"] }
+  },
+  "tf:data/serialize@1": {
+    "input": { "any": true },
+    "output": { "bytes": true }
+  },
+  "tf:data/deserialize@1": {
+    "input": { "bytes": true },
+    "output": { "any": true }
+  },
+  "tf:network/publish@1": {
+    "input": {
+      "object": {
+        "shape": [
+          { "key": "key", "type": { "string": true } },
+          { "key": "payload", "type": { "string": true } },
+          { "key": "topic", "type": { "string": true } }
+        ]
+      }
+    },
+    "output": { "unit": true }
+  },
+  "tf:observability/emit-metric@1": {
+    "input": { "unit": true },
+    "output": { "unit": true }
+  },
+  "tf:resource/write-object@1": {
+    "input": {
+      "object": {
+        "shape": [
+          { "key": "idempotency_key", "optional": true, "type": { "refined": ["string", "idempotency_key"] } },
+          { "key": "key", "type": { "string": true } },
+          { "key": "uri", "type": { "refined": ["string", "uri"] } },
+          { "key": "value", "type": { "string": true } }
+        ]
+      }
+    },
+    "output": {
+      "object": {
+        "shape": [
+          { "key": "etag", "type": { "refined": ["string", "digest_sha256"] } },
+          { "key": "key", "type": { "string": true } },
+          { "key": "uri", "type": { "refined": ["string", "uri"] } }
+        ]
+      }
+    }
+  },
+  "tf:resource/compare-and-swap@1": {
+    "input": {
+      "object": {
+        "shape": [
+          { "key": "expected", "type": { "option": { "string": true } } },
+          { "key": "key", "type": { "string": true } },
+          { "key": "uri", "type": { "refined": ["string", "uri"] } },
+          { "key": "value", "type": { "option": { "string": true } } }
+        ]
+      }
+    },
+    "output": {
+      "object": {
+        "shape": [
+          { "key": "key", "type": { "string": true } },
+          { "key": "uri", "type": { "refined": ["string", "uri"] } }
+        ]
+      }
+    }
+  }
+}

--- a/packages/tf-l0-types/README.md
+++ b/packages/tf-l0-types/README.md
@@ -1,0 +1,3 @@
+# tf-l0-types
+
+Minimal type constructors and a conservative unifier for L0 experiments.

--- a/packages/tf-l0-types/package.json
+++ b/packages/tf-l0-types/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@tf-lang/tf-l0-types",
+  "private": true,
+  "type": "module",
+  "main": "src/types.mjs",
+  "exports": {
+    ".": "./src/types.mjs"
+  },
+  "scripts": {
+    "build": "node -e \"process.exit(0)\""
+  }
+}

--- a/packages/tf-l0-types/src/types.mjs
+++ b/packages/tf-l0-types/src/types.mjs
@@ -1,0 +1,363 @@
+import assert from 'node:assert/strict';
+
+const BASE_KINDS = new Set(['int', 'float', 'string', 'bool', 'bytes', 'unit', 'any']);
+const REFINEMENT_TAGS = new Set(['timestamp_ms', 'uri', 'digest_sha256', 'symbol', 'idempotency_key']);
+
+function makeBase(name, refinements = []) {
+  assert(BASE_KINDS.has(name), `unknown base kind: ${name}`);
+  const tags = Array.from(new Set(refinements));
+  tags.sort();
+  return { kind: 'base', name, refinements: tags };
+}
+
+function cloneType(type) {
+  switch (type.kind) {
+    case 'base':
+      return makeBase(type.name, type.refinements);
+    case 'array':
+      return { kind: 'array', type: cloneType(type.type) };
+    case 'option':
+      return { kind: 'option', type: cloneType(type.type) };
+    case 'object': {
+      const entries = Object.entries(type.shape);
+      const shape = {};
+      for (const [key, field] of entries) {
+        shape[key] = { type: cloneType(field.type), optional: !!field.optional };
+      }
+      return { kind: 'object', shape };
+    }
+    case 'union':
+      return {
+        kind: 'union',
+        types: type.types.map((member) => cloneType(member)),
+      };
+    default:
+      throw new Error(`unknown type kind: ${type.kind}`);
+  }
+}
+
+function int() {
+  return makeBase('int');
+}
+
+function float() {
+  return makeBase('float');
+}
+
+function string() {
+  return makeBase('string');
+}
+
+function bool() {
+  return makeBase('bool');
+}
+
+function bytes() {
+  return makeBase('bytes');
+}
+
+function unit() {
+  return makeBase('unit');
+}
+
+function any() {
+  return makeBase('any');
+}
+
+function array(type) {
+  return { kind: 'array', type: cloneType(type) };
+}
+
+function option(type) {
+  return { kind: 'option', type: cloneType(type) };
+}
+
+function normalizeFieldSpec(spec) {
+  if (spec && typeof spec === 'object' && 'type' in spec) {
+    return { type: cloneType(spec.type), optional: !!spec.optional };
+  }
+  return { type: cloneType(spec), optional: false };
+}
+
+function object(shape) {
+  assert(shape && typeof shape === 'object' && !Array.isArray(shape), 'object shape must be an object');
+  const keys = Object.keys(shape).sort();
+  const normalized = {};
+  for (const key of keys) {
+    normalized[key] = normalizeFieldSpec(shape[key]);
+  }
+  return { kind: 'object', shape: normalized };
+}
+
+function flattenUnionArgs(args) {
+  const flat = [];
+  for (const entry of args) {
+    if (Array.isArray(entry)) {
+      flat.push(...flattenUnionArgs(entry));
+    } else if (entry && entry.kind === 'union') {
+      flat.push(...entry.types.map((t) => cloneType(t)));
+    } else if (entry) {
+      flat.push(cloneType(entry));
+    }
+  }
+  return flat;
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value).sort(([a], [b]) => a.localeCompare(b));
+    const out = {};
+    for (const [key, val] of entries) {
+      out[key] = canonicalize(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+function toJSON(type) {
+  switch (type.kind) {
+    case 'base': {
+      if (type.refinements.length === 0) {
+        return { [type.name]: true };
+      }
+      return { refined: [type.name, ...type.refinements] };
+    }
+    case 'array':
+      return { array: toJSON(type.type) };
+    case 'option':
+      return { option: toJSON(type.type) };
+    case 'object': {
+      const entries = Object.entries(type.shape).sort(([a], [b]) => a.localeCompare(b));
+      const shape = entries.map(([key, field]) => {
+        const item = { key, type: toJSON(field.type) };
+        if (field.optional) {
+          item.optional = true;
+        }
+        return item;
+      });
+      return { object: { shape } };
+    }
+    case 'union': {
+      const members = type.types.map((member) => canonicalize(toJSON(member)));
+      members.sort((a, b) => canonicalJSONStringify(a).localeCompare(canonicalJSONStringify(b)));
+      return { union: members };
+    }
+    default:
+      throw new Error(`cannot serialise type of kind: ${type.kind}`);
+  }
+}
+
+function canonicalJSONStringify(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalJSONStringifyType(type) {
+  return canonicalJSONStringify(toJSON(type));
+}
+
+function fromJSON(json) {
+  assert(json && typeof json === 'object' && !Array.isArray(json), 'type JSON must be an object');
+  const keys = Object.keys(json);
+  assert(keys.length === 1, 'type JSON must have exactly one key');
+  const key = keys[0];
+  switch (key) {
+    case 'int':
+    case 'float':
+    case 'string':
+    case 'bool':
+    case 'bytes':
+    case 'unit':
+    case 'any':
+      return makeBase(key);
+    case 'refined': {
+      const data = json.refined;
+      assert(Array.isArray(data) && data.length >= 2, 'refined expects [base, ...tags]');
+      const [baseName, ...tags] = data;
+      assert(typeof baseName === 'string', 'refined base must be a string kind name');
+      for (const tag of tags) {
+        assert(typeof tag === 'string', 'refinement tag must be a string');
+      }
+      return makeBase(baseName, tags);
+    }
+    case 'array':
+      return array(fromJSON(json.array));
+    case 'option':
+      return option(fromJSON(json.option));
+    case 'object': {
+      const shape = json.object?.shape;
+      assert(Array.isArray(shape), 'object.shape must be an array');
+      const entries = shape.map((item) => {
+        assert(item && typeof item === 'object', 'shape entries must be objects');
+        const { key: fieldKey, type: fieldType, optional = false } = item;
+        assert(typeof fieldKey === 'string', 'shape key must be a string');
+        return [fieldKey, { type: fromJSON(fieldType), optional: !!optional }];
+      });
+      const obj = {};
+      for (const [fieldKey, fieldSpec] of entries) {
+        obj[fieldKey] = fieldSpec;
+      }
+      return { kind: 'object', shape: obj };
+    }
+    case 'union': {
+      const members = json.union;
+      assert(Array.isArray(members) && members.length > 0, 'union must be a non-empty array');
+      const parsed = members.map((member) => fromJSON(member));
+      return union(parsed);
+    }
+    default:
+      throw new Error(`unknown type token: ${key}`);
+  }
+}
+
+function dedupeUnionMembers(members) {
+  const map = new Map();
+  for (const member of members) {
+    const key = canonicalJSONStringifyType(member);
+    if (!map.has(key)) {
+      map.set(key, member);
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    const sa = canonicalJSONStringifyType(a);
+    const sb = canonicalJSONStringifyType(b);
+    return sa.localeCompare(sb);
+  });
+}
+
+function union(...members) {
+  const flat = flattenUnionArgs(members);
+  assert(flat.length >= 1, 'union requires at least one member');
+  const deduped = dedupeUnionMembers(flat);
+  return { kind: 'union', types: deduped };
+}
+
+function refined(type, tag) {
+  assert(typeof tag === 'string', 'refinement tag must be a string');
+  assert(REFINEMENT_TAGS.has(tag), `unsupported refinement tag: ${tag}`);
+  const base = cloneType(type);
+  assert(base.kind === 'base', 'refined() currently supports base kinds only');
+  const existing = new Set(base.refinements);
+  existing.add(tag);
+  return makeBase(base.name, Array.from(existing));
+}
+
+function combineRefinements(name, a, b) {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size === 0 && setB.size === 0) {
+    return makeBase(name);
+  }
+  const intersection = Array.from(setA).filter((tag) => setB.has(tag));
+  if (intersection.length === 0) {
+    return null;
+  }
+  return makeBase(name, intersection);
+}
+
+function unify(a, b) {
+  const left = cloneType(a);
+  const right = cloneType(b);
+  if (left.kind === 'base' && left.name === 'any') {
+    return { ok: true, type: right };
+  }
+  if (right.kind === 'base' && right.name === 'any') {
+    return { ok: true, type: left };
+  }
+  if (left.kind === 'union' || right.kind === 'union') {
+    const members = [];
+    if (left.kind === 'union') {
+      members.push(...left.types);
+    } else {
+      members.push(left);
+    }
+    if (right.kind === 'union') {
+      members.push(...right.types);
+    } else {
+      members.push(right);
+    }
+    return { ok: true, type: union(members) };
+  }
+  if (left.kind !== right.kind) {
+    if (left.kind === 'object' || right.kind === 'object') {
+      return { ok: false, reason: 'shape_mismatch' };
+    }
+    if (left.kind === 'base' && right.kind === 'base' && (left.name === 'string' && right.name === 'bytes' || left.name === 'bytes' && right.name === 'string')) {
+      return { ok: false, reason: 'kind_mismatch' };
+    }
+    return { ok: false, reason: 'kind_mismatch' };
+  }
+  switch (left.kind) {
+    case 'base':
+      if (left.name !== right.name) {
+        return { ok: false, reason: 'kind_mismatch' };
+      }
+      if ((left.name === 'string' && right.name === 'bytes') || (left.name === 'bytes' && right.name === 'string')) {
+        return { ok: false, reason: 'kind_mismatch' };
+      }
+      const combined = combineRefinements(left.name, left.refinements, right.refinements);
+      if (!combined) {
+        return { ok: false, reason: 'refinement_mismatch' };
+      }
+      return { ok: true, type: combined };
+    case 'array': {
+      const unified = unify(left.type, right.type);
+      if (!unified.ok) {
+        return unified;
+      }
+      return { ok: true, type: array(unified.type) };
+    }
+    case 'option': {
+      const unified = unify(left.type, right.type);
+      if (!unified.ok) {
+        return unified;
+      }
+      return { ok: true, type: option(unified.type) };
+    }
+    case 'object': {
+      const keysLeft = Object.keys(left.shape);
+      const keysRight = Object.keys(right.shape);
+      const shared = keysLeft.filter((key) => keysRight.includes(key));
+      if (shared.length === 0) {
+        return { ok: false, reason: 'shape_mismatch' };
+      }
+      const resultShape = {};
+      for (const key of shared) {
+        const unified = unify(left.shape[key].type, right.shape[key].type);
+        if (!unified.ok) {
+          return unified;
+        }
+        resultShape[key] = {
+          type: unified.type,
+          optional: left.shape[key].optional || right.shape[key].optional,
+        };
+      }
+      return { ok: true, type: object(resultShape) };
+    }
+    default:
+      throw new Error(`unify not implemented for kind: ${left.kind}`);
+  }
+}
+
+export {
+  any,
+  array,
+  bool,
+  bytes,
+  canonicalJSONStringifyType,
+  float,
+  fromJSON,
+  int,
+  object,
+  option,
+  refined,
+  string,
+  toJSON,
+  union,
+  unit,
+  unify,
+};
+

--- a/scripts/types-demo.mjs
+++ b/scripts/types-demo.mjs
@@ -1,0 +1,117 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { fromJSON, toJSON, unify } from '../packages/tf-l0-types/src/types.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+const SPEC_PATH = path.join(ROOT, 'packages/tf-l0-spec/spec/signatures.demo.json');
+const OUT_PATH = path.join(ROOT, 'out/0.4/check/types-demo.json');
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value).sort(([a], [b]) => a.localeCompare(b));
+    const result = {};
+    for (const [key, val] of entries) {
+      result[key] = canonicalize(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+function stringify(value) {
+  return JSON.stringify(canonicalize(value), null, 2) + '\n';
+}
+
+const specRaw = await readFile(SPEC_PATH, 'utf8');
+const spec = JSON.parse(specRaw);
+
+const operations = new Map();
+for (const [id, entry] of Object.entries(spec)) {
+  operations.set(id, {
+    input: fromJSON(entry.input),
+    output: fromJSON(entry.output),
+  });
+}
+
+const labels = {
+  hash: 'tf:information/hash@1',
+  serialize: 'tf:data/serialize@1',
+  deserialize: 'tf:data/deserialize@1',
+  publish: 'tf:network/publish@1',
+  'emit-metric': 'tf:observability/emit-metric@1',
+  'write-object': 'tf:resource/write-object@1',
+  'compare-and-swap': 'tf:resource/compare-and-swap@1',
+};
+
+const chains = [
+  { name: 'hash|>hash', ops: ['hash', 'hash'] },
+  { name: 'publish|>emit-metric', ops: ['publish', 'emit-metric'] },
+  { name: 'write-object|>hash', ops: ['write-object', 'hash'] },
+];
+
+function evaluateChain(chain) {
+  const stages = chain.ops.map((label) => {
+    const id = labels[label];
+    if (!id) {
+      throw new Error(`unknown operation label: ${label}`);
+    }
+    const entry = operations.get(id);
+    if (!entry) {
+      throw new Error(`missing spec for ${id}`);
+    }
+    return { label, id, ...entry };
+  });
+
+  if (stages.length === 0) {
+    return { ok: false, reason: 'empty_chain' };
+  }
+
+  let currentType = stages[0].output;
+  for (let i = 1; i < stages.length; i += 1) {
+    const stage = stages[i];
+    const match = unify(currentType, stage.input);
+    if (!match.ok) {
+      return { ok: false, reason: match.reason };
+    }
+    const aligned = unify(match.type, stage.output);
+    if (!aligned.ok) {
+      return { ok: false, reason: aligned.reason };
+    }
+    currentType = stage.output;
+  }
+
+  return { ok: true, type: currentType };
+}
+
+const cases = chains.map((chain) => {
+  const verdict = evaluateChain(chain);
+  if (verdict.ok) {
+    return { chain: chain.name, ok: true, type: toJSON(verdict.type) };
+  }
+  return { chain: chain.name, ok: false, reason: verdict.reason };
+});
+
+const summary = cases.reduce(
+  (acc, entry) => {
+    if (entry.ok) {
+      acc.ok += 1;
+    } else {
+      acc.fail += 1;
+    }
+    return acc;
+  },
+  { ok: 0, fail: 0 },
+);
+
+await mkdir(path.dirname(OUT_PATH), { recursive: true });
+await writeFile(OUT_PATH, stringify({ cases, summary }));
+
+console.log(`wrote ${OUT_PATH}`);

--- a/tests/types-unify.test.mjs
+++ b/tests/types-unify.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const types = await import('../packages/tf-l0-types/src/types.mjs');
+
+const {
+  any,
+  array,
+  bool,
+  bytes,
+  canonicalJSONStringifyType,
+  object,
+  option,
+  refined,
+  string,
+  toJSON,
+  union,
+  unify,
+} = types;
+
+test('unify is commutative for arrays', () => {
+  const left = array(string());
+  const right = array(string());
+  const ab = unify(left, right);
+  const ba = unify(right, left);
+  assert.equal(ab.ok, true);
+  assert.equal(ba.ok, true);
+  assert.equal(canonicalJSONStringifyType(ab.type), canonicalJSONStringifyType(ba.type));
+});
+
+test('unify results are deterministic', () => {
+  const left = object({ foo: string(), bar: bool() });
+  const right = object({ foo: string(), baz: bool() });
+  const first = unify(left, right);
+  const second = unify(left, right);
+  assert.equal(first.ok, second.ok);
+  if (first.ok) {
+    assert.equal(canonicalJSONStringifyType(first.type), canonicalJSONStringifyType(second.type));
+  } else {
+    assert.equal(first.reason, second.reason);
+  }
+});
+
+test('hash after hash keeps digest refinement', () => {
+  const digest = refined(string(), 'digest_sha256');
+  const step = unify(digest, any());
+  assert.equal(step.ok, true);
+  const final = unify(step.type, digest);
+  assert.equal(final.ok, true);
+  assert.deepEqual(toJSON(final.type), { refined: ['string', 'digest_sha256'] });
+});
+
+test('option(string) with option(string) succeeds', () => {
+  const left = option(string());
+  const right = option(string());
+  const result = unify(left, right);
+  assert.equal(result.ok, true);
+  assert.deepEqual(toJSON(result.type), { option: { string: true } });
+});
+
+test('bytes do not unify with string', () => {
+  const result = unify(bytes(), string());
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'kind_mismatch');
+});
+
+test('object shapes must overlap', () => {
+  const left = object({ foo: string() });
+  const right = object({ bar: string() });
+  const result = unify(left, right);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'shape_mismatch');
+});
+
+test('refinement mismatch is reported', () => {
+  const refinedUri = refined(string(), 'uri');
+  const plain = string();
+  const result = unify(refinedUri, plain);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'refinement_mismatch');
+});
+
+test('union flattening is deterministic', () => {
+  const a = union(string(), bool());
+  const b = union(bool(), string());
+  const result = unify(a, b);
+  assert.equal(result.ok, true);
+  const expectedMembers = [{ bool: true }, { string: true }];
+  assert.deepEqual(toJSON(result.type), { union: expectedMembers });
+});


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

## Summary
- Scope: N/A
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [ ] CI wiring + determinism re-run
  - Added a minimal L0 type vocabulary module, conservative unifier, and deterministic demo CLI.

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`
- Additional outputs: `out/0.4/check/types-demo.json` (demo verdicts).

## Determinism & Seeds
- Repeats: N/A
- Seeds: N/A
- Notes: Type codec writes canonical JSON; CLI sorts keys before emitting demo results.

## Tests & CI
- TS tests: ran via `pnpm -w -r test`; JS suite has 93 pass / 1 fail (`tests/codegen-rs.test.mjs` expects signing IR fixture in current workspace).
- Rust tests: not run (N/A for this change).
- CI jobs: not run locally.

## Implementation Notes
- ABI / paths unchanged? Y (new module + CLI only).
- Runtime deps added? (**No**)
- Policy compliance: `.mjs` ESM modules, no deep imports, no `as any`.

## Hurdles / Follow-ups
- Known gaps: Workspace `pnpm -w -r test` still inherits existing `tests/codegen-rs.test.mjs` failure.
- Suggested next steps: Integrate the new unifier into upcoming checker work and extend demo coverage as new primitives appear.

------
https://chatgpt.com/codex/tasks/task_e_68d008c69ca483208920b877ee5995c7