### PR TITLE
Add type vocabulary, unifier, and demo CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "a1": "node packages/tf-l0-spec/scripts/build-catalog.mjs && node packages/tf-l0-spec/scripts/derive-effects.mjs && node packages/tf-l0-spec/scripts/build-laws.mjs && node packages/tf-l0-spec/scripts/finalize-a1.mjs",
     "a1:summary": "node scripts/effects-summary.mjs",
     "a1:all": "pnpm run a1 && pnpm run a1:summary",
+    "a4:demo": "node scripts/types-demo.mjs && cat out/0.4/check/types-demo.json | node -e \"process.stdout.write(require('fs').readFileSync(0,'utf8'))\"",
     "proofs:laws:axioms": "node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2 && node scripts/emit-smt-laws.mjs --law inverse:serialize-deserialize -o out/0.4/proofs/laws/inverse_roundtrip.smt2 && node scripts/emit-smt-laws.mjs --law commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute.smt2",
     "proofs:laws:equiv": "node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2",
     "tf": "node packages/tf-compose/bin/tf.mjs",

--- a/packages/tf-l0-spec/spec/signatures.demo.json
+++ b/packages/tf-l0-spec/spec/signatures.demo.json
@@ -1,0 +1,45 @@
+{
+  "tf:information/hash@1": {
+    "input": {"any": true},
+    "output": {"refined": ["string", "digest_sha256"]}
+  },
+  "tf:observability/emit-metric@1": {
+    "input": {"unit": true},
+    "output": {"unit": true}
+  },
+  "tf:network/publish@1": {
+    "input": {
+      "object": {
+        "key": {"string": true},
+        "payload": {"string": true},
+        "topic": {"string": true}
+      }
+    },
+    "output": {"unit": true}
+  },
+  "tf:resource/write-object@1": {
+    "input": {
+      "object": {
+        "idempotency_key?": {"refined": ["string", "idempotency_key"]},
+        "key": {"string": true},
+        "uri": {"refined": ["string", "uri"]},
+        "value": {"string": true}
+      }
+    },
+    "output": {"unit": true}
+  },
+  "tf:resource/read-object@1": {
+    "input": {
+      "object": {
+        "key": {"string": true},
+        "uri": {"refined": ["string", "uri"]}
+      }
+    },
+    "output": {
+      "object": {
+        "key": {"string": true},
+        "value": {"string": true}
+      }
+    }
+  }
+}

--- a/packages/tf-l0-types/README.md
+++ b/packages/tf-l0-types/README.md
@@ -1,0 +1,3 @@
+# tf-l0-types
+
+Minimal type vocabulary and unifier utilities used in tests and demos.

--- a/packages/tf-l0-types/package.json
+++ b/packages/tf-l0-types/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tf-lang/tf-l0-types",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/types.mjs",
+  "exports": {
+    ".": "./src/types.mjs"
+  },
+  "scripts": {
+    "build": "node -e \"process.exit(0)\""
+  }
+}

--- a/packages/tf-l0-types/src/types.mjs
+++ b/packages/tf-l0-types/src/types.mjs
@@ -1,0 +1,394 @@
+import assert from 'node:assert/strict';
+
+const BASE_KINDS = new Set(['int', 'float', 'string', 'bool', 'bytes', 'unit', 'any']);
+const REFINEMENT_TAGS = new Set([
+  'timestamp_ms',
+  'uri',
+  'digest_sha256',
+  'symbol',
+  'idempotency_key'
+]);
+
+function normalizeRefinements(refinements = []) {
+  const tags = Array.from(new Set(refinements));
+  tags.forEach((tag) => {
+    if (!REFINEMENT_TAGS.has(tag)) {
+      throw new Error(`unknown refinement tag: ${tag}`);
+    }
+  });
+  tags.sort();
+  return tags;
+}
+
+function baseKind(kind, refinements = []) {
+  if (!BASE_KINDS.has(kind)) {
+    throw new Error(`unknown kind: ${kind}`);
+  }
+  const normalRefinements = normalizeRefinements(refinements);
+  return freezeType({ kind, refinements: normalRefinements });
+}
+
+function freezeType(type) {
+  switch (type.kind) {
+    case 'array':
+      return Object.freeze({ kind: 'array', items: type.items });
+    case 'option':
+      return Object.freeze({ kind: 'option', inner: type.inner });
+    case 'object': {
+      const frozenFields = {};
+      for (const [name, field] of Object.entries(type.fields)) {
+        frozenFields[name] = Object.freeze({ type: field.type, optional: field.optional });
+      }
+      return Object.freeze({ kind: 'object', fields: Object.freeze(frozenFields) });
+    }
+    case 'union': {
+      const variants = type.variants.slice();
+      Object.freeze(variants);
+      return Object.freeze({ kind: 'union', variants });
+    }
+    default: {
+      if (!BASE_KINDS.has(type.kind)) {
+        throw new Error(`cannot freeze unknown kind: ${type.kind}`);
+      }
+      return Object.freeze({ kind: type.kind, refinements: type.refinements.slice() });
+    }
+  }
+}
+
+export const int = baseKind('int');
+export const float = baseKind('float');
+export const string = baseKind('string');
+export const bool = baseKind('bool');
+export const bytes = baseKind('bytes');
+export const unit = baseKind('unit');
+export const any = baseKind('any');
+
+function assertType(value) {
+  assert.ok(value && typeof value === 'object', 'expected type object');
+  assert.ok(typeof value.kind === 'string', 'type missing kind');
+}
+
+function cloneBase(type) {
+  return { kind: type.kind, refinements: type.refinements.slice() };
+}
+
+function makeObject(fieldsMap) {
+  const normal = {};
+  for (const [name, field] of Object.entries(fieldsMap)) {
+    assertType(field.type);
+    normal[name] = { type: field.type, optional: Boolean(field.optional) };
+  }
+  return freezeType({ kind: 'object', fields: normal });
+}
+
+export function array(inner) {
+  assertType(inner);
+  return freezeType({ kind: 'array', items: inner });
+}
+
+export function option(inner) {
+  assertType(inner);
+  return freezeType({ kind: 'option', inner });
+}
+
+export function object(shape) {
+  if (!shape || typeof shape !== 'object') {
+    throw new Error('object shape must be an object');
+  }
+  const fields = {};
+  for (const [rawKey, descriptor] of Object.entries(shape)) {
+    let key = rawKey;
+    let optional = false;
+    if (key.endsWith('?')) {
+      optional = true;
+      key = key.slice(0, -1);
+    }
+    if (!key) {
+      throw new Error('empty field name');
+    }
+    if (fields[key]) {
+      throw new Error(`duplicate field: ${key}`);
+    }
+    let typeDescriptor = descriptor;
+    if (descriptor && typeof descriptor === 'object' && 'type' in descriptor) {
+      typeDescriptor = descriptor.type;
+      if ('optional' in descriptor) {
+        optional = Boolean(descriptor.optional);
+      }
+    }
+    assertType(typeDescriptor);
+    fields[key] = { type: typeDescriptor, optional };
+  }
+  return makeObject(fields);
+}
+
+function dedupeAndSortTypes(types) {
+  const map = new Map();
+  for (const type of types) {
+    assertType(type);
+    const key = canonicalTypeKey(type);
+    if (!map.has(key)) {
+      map.set(key, type);
+    }
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([, type]) => type);
+}
+
+function makeUnionType(types) {
+  const variants = dedupeAndSortTypes(types);
+  if (variants.length === 0) {
+    throw new Error('union requires at least one variant');
+  }
+  if (variants.length === 1) {
+    return variants[0];
+  }
+  return freezeType({ kind: 'union', variants });
+}
+
+export function union(...types) {
+  const all = [];
+  for (const type of types) {
+    assertType(type);
+    if (type.kind === 'union') {
+      all.push(...type.variants);
+    } else {
+      all.push(type);
+    }
+  }
+  return makeUnionType(all);
+}
+
+export function refined(type, tag) {
+  assertType(type);
+  if (!REFINEMENT_TAGS.has(tag)) {
+    throw new Error(`unknown refinement tag: ${tag}`);
+  }
+  if (!BASE_KINDS.has(type.kind)) {
+    throw new Error('refined() only supports base kinds');
+  }
+  if (type.kind === 'any') {
+    throw new Error('cannot refine "any"');
+  }
+  const base = cloneBase(type);
+  const tags = new Set(base.refinements);
+  tags.add(tag);
+  return freezeType({ kind: base.kind, refinements: normalizeRefinements(Array.from(tags)) });
+}
+
+function fail(reason) {
+  return { ok: false, reason };
+}
+
+function baseUnify(a, b) {
+  const shared = a.refinements.filter((tag) => b.refinements.includes(tag));
+  if (shared.length === 0 && (a.refinements.length > 0 || b.refinements.length > 0)) {
+    return fail('refinement_mismatch');
+  }
+  return { ok: true, type: baseKind(a.kind, shared) };
+}
+
+function unifyArrays(a, b) {
+  const inner = unify(a.items, b.items);
+  if (!inner.ok) {
+    return inner;
+  }
+  return { ok: true, type: array(inner.type) };
+}
+
+function unifyOptions(a, b) {
+  const inner = unify(a.inner, b.inner);
+  if (!inner.ok) {
+    return inner;
+  }
+  return { ok: true, type: option(inner.type) };
+}
+
+function unifyObjects(a, b) {
+  const sharedKeys = Object.keys(a.fields).filter((key) => key in b.fields);
+  if (sharedKeys.length === 0) {
+    return fail('shape_mismatch');
+  }
+  for (const [name, field] of Object.entries(a.fields)) {
+    if (!(name in b.fields) && !field.optional) {
+      return fail('shape_mismatch');
+    }
+  }
+  for (const [name, field] of Object.entries(b.fields)) {
+    if (!(name in a.fields) && !field.optional) {
+      return fail('shape_mismatch');
+    }
+  }
+  const resultFields = {};
+  for (const name of sharedKeys.sort()) {
+    const unified = unify(a.fields[name].type, b.fields[name].type);
+    if (!unified.ok) {
+      return unified;
+    }
+    resultFields[name] = {
+      type: unified.type,
+      optional: a.fields[name].optional && b.fields[name].optional,
+    };
+  }
+  return { ok: true, type: makeObject(resultFields) };
+}
+
+function unifyUnions(a, b) {
+  const left = a.kind === 'union' ? a.variants : [a];
+  const right = b.kind === 'union' ? b.variants : [b];
+  const results = [];
+  for (const variantA of left) {
+    for (const variantB of right) {
+      const unified = unify(variantA, variantB);
+      if (unified.ok) {
+        results.push(unified.type);
+      }
+    }
+  }
+  if (results.length === 0) {
+    return fail('union_mismatch');
+  }
+  const combined = makeUnionType(results);
+  return { ok: true, type: combined };
+}
+
+export function unify(a, b) {
+  assertType(a);
+  assertType(b);
+  if (a.kind === 'any') {
+    return { ok: true, type: b };
+  }
+  if (b.kind === 'any') {
+    return { ok: true, type: a };
+  }
+  if (a.kind === 'union' || b.kind === 'union') {
+    return unifyUnions(a, b);
+  }
+  if (a.kind !== b.kind) {
+    return fail('kind_mismatch');
+  }
+  switch (a.kind) {
+    case 'array':
+      return unifyArrays(a, b);
+    case 'option':
+      return unifyOptions(a, b);
+    case 'object':
+      return unifyObjects(a, b);
+    default:
+      return baseUnify(a, b);
+  }
+}
+
+function canonicalTypeKey(type) {
+  return canonicalStringify(toJSON(type));
+}
+
+export function toJSON(type) {
+  assertType(type);
+  if (type.kind === 'union') {
+    return { union: type.variants.map((variant) => toJSON(variant)) };
+  }
+  if (type.kind === 'array') {
+    return { array: toJSON(type.items) };
+  }
+  if (type.kind === 'option') {
+    return { option: toJSON(type.inner) };
+  }
+  if (type.kind === 'object') {
+    const entries = Object.entries(type.fields)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([name, field]) => {
+        const key = field.optional ? `${name}?` : name;
+        return [key, toJSON(field.type)];
+      });
+    const shape = {};
+    for (const [key, value] of entries) {
+      shape[key] = value;
+    }
+    return { object: shape };
+  }
+  if (type.refinements.length > 0) {
+    return { refined: [type.kind, ...type.refinements] };
+  }
+  return { [type.kind]: true };
+}
+
+export function fromJSON(json) {
+  const payload = typeof json === 'string' ? JSON.parse(json) : json;
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('fromJSON expects an object or JSON string');
+  }
+  const keys = Object.keys(payload);
+  if (keys.length !== 1) {
+    throw new Error('type JSON must contain exactly one top-level key');
+  }
+  const [key] = keys;
+  switch (key) {
+    case 'union': {
+      const list = payload.union;
+      if (!Array.isArray(list) || list.length === 0) {
+        throw new Error('union expects non-empty array');
+      }
+      const variants = list.map((item) => fromJSON(item));
+      return makeUnionType(variants);
+    }
+    case 'array':
+      return array(fromJSON(payload.array));
+    case 'option':
+      return option(fromJSON(payload.option));
+    case 'object': {
+      const shape = payload.object;
+      if (!shape || typeof shape !== 'object') {
+        throw new Error('object expects shape object');
+      }
+      const fields = {};
+      for (const [rawKey, value] of Object.entries(shape)) {
+        let optional = false;
+        let name = rawKey;
+        if (name.endsWith('?')) {
+          optional = true;
+          name = name.slice(0, -1);
+        }
+        fields[name] = { type: fromJSON(value), optional };
+      }
+      return makeObject(fields);
+    }
+    case 'refined': {
+      const list = payload.refined;
+      if (!Array.isArray(list) || list.length < 2) {
+        throw new Error('refined expects [base, ...tags]');
+      }
+      const [base, ...tags] = list;
+      return baseKind(base, tags);
+    }
+    default: {
+      if (!payload[key]) {
+        throw new Error(`invalid type descriptor for ${key}`);
+      }
+      return baseKind(key);
+    }
+  }
+}
+
+export function canonicalStringify(value) {
+  return canonicalize(value);
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalize(v)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    const parts = keys.map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`);
+    return `{${parts.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function writeJSON(type) {
+  return canonicalStringify(toJSON(type));
+}
+
+export const refinements = Array.from(REFINEMENT_TAGS).sort();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.9(@types/node@24.3.1)(jsdom@24.1.3)
 
+  packages/tf-l0-types: {}
+
   packages/tf-lang-l0-ts:
     dependencies:
       '@noble/hashes':

--- a/scripts/types-demo.mjs
+++ b/scripts/types-demo.mjs
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { fromJSON, toJSON, unify, canonicalStringify } from '../packages/tf-l0-types/src/types.mjs';
+import { fromJSON, toJSON, unify, toCanonicalJSON } from '../packages/tf-l0-types/src/types.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -59,6 +59,8 @@ const cases = chains.map((chain) => {
   return { chain: label, ok: false, reason: verdict.reason };
 });
 
+cases.sort((a, b) => a.chain.localeCompare(b.chain));
+
 const summary = cases.reduce(
   (acc, entry) => {
     if (entry.ok) {
@@ -74,4 +76,4 @@ const summary = cases.reduce(
 const payload = { cases, summary };
 
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-fs.writeFileSync(outputPath, `${canonicalStringify(payload)}\n`);
+fs.writeFileSync(outputPath, `${toCanonicalJSON(payload)}\n`);

--- a/scripts/types-demo.mjs
+++ b/scripts/types-demo.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { fromJSON, toJSON, unify, canonicalStringify } from '../packages/tf-l0-types/src/types.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const specPath = path.resolve(__dirname, '../packages/tf-l0-spec/spec/signatures.demo.json');
+const outputPath = path.resolve(__dirname, '../out/0.4/check/types-demo.json');
+
+const specRaw = fs.readFileSync(specPath, 'utf8');
+const specData = JSON.parse(specRaw);
+
+const signatures = new Map();
+for (const [id, entry] of Object.entries(specData)) {
+  if (!entry.input || !entry.output) {
+    throw new Error(`signature for ${id} missing input/output`);
+  }
+  signatures.set(id, {
+    input: fromJSON(entry.input),
+    output: fromJSON(entry.output),
+  });
+}
+
+const chains = [
+  ['tf:information/hash@1', 'tf:information/hash@1'],
+  ['tf:network/publish@1', 'tf:observability/emit-metric@1'],
+  ['tf:resource/read-object@1', 'tf:network/publish@1']
+];
+
+function displayName(id) {
+  const afterColon = id.includes(':') ? id.split(':')[1] : id;
+  const beforeAt = afterColon.includes('@') ? afterColon.split('@')[0] : afterColon;
+  const parts = beforeAt.split('/');
+  return parts[parts.length - 1];
+}
+
+const cases = chains.map((chain) => {
+  const label = chain.map(displayName).join('|>');
+  let verdict = { ok: true, type: null, reason: null };
+  for (let i = 0; i < chain.length - 1; i += 1) {
+    const current = signatures.get(chain[i]);
+    const next = signatures.get(chain[i + 1]);
+    if (!current || !next) {
+      throw new Error(`unknown primitive in chain ${label}`);
+    }
+    const result = unify(current.output, next.input);
+    if (!result.ok) {
+      verdict = { ok: false, reason: result.reason, type: null };
+      break;
+    }
+    verdict = { ok: true, reason: null, type: result.type };
+  }
+  if (verdict.ok && verdict.type) {
+    return { chain: label, ok: true, type: toJSON(verdict.type) };
+  }
+  return { chain: label, ok: false, reason: verdict.reason };
+});
+
+const summary = cases.reduce(
+  (acc, entry) => {
+    if (entry.ok) {
+      acc.ok += 1;
+    } else {
+      acc.fail += 1;
+    }
+    return acc;
+  },
+  { ok: 0, fail: 0 }
+);
+
+const payload = { cases, summary };
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${canonicalStringify(payload)}\n`);

--- a/tests/types-unify.test.mjs
+++ b/tests/types-unify.test.mjs
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  any,
+  array,
+  bytes,
+  object,
+  option,
+  refined,
+  string,
+  toJSON,
+  unify,
+  canonicalStringify
+} from '../packages/tf-l0-types/src/types.mjs';
+
+test('unify is commutative and deterministic', () => {
+  const digest = refined(string, 'digest_sha256');
+  const first = unify(digest, digest);
+  const second = unify(digest, digest);
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  const keyA = canonicalStringify(toJSON(first.type));
+  const keyB = canonicalStringify(toJSON(second.type));
+  assert.equal(keyA, keyB);
+  const swapped = unify(digest, digest);
+  const keySwapped = canonicalStringify(toJSON(swapped.type));
+  assert.equal(keyA, keySwapped);
+});
+
+test('any unifies with bytes', () => {
+  const result = unify(any, bytes);
+  assert.equal(result.ok, true);
+  assert.equal(canonicalStringify(toJSON(result.type)), canonicalStringify(toJSON(bytes)));
+});
+
+test('option(string) unifies with itself', () => {
+  const left = option(string);
+  const right = option(string);
+  const result = unify(left, right);
+  assert.equal(result.ok, true);
+  assert.equal(canonicalStringify(toJSON(result.type)), canonicalStringify(toJSON(left)));
+});
+
+test('bytes and string do not unify', () => {
+  const result = unify(bytes, string);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'kind_mismatch');
+});
+
+test('object shapes require matching required keys', () => {
+  const source = object({ key: string, value: string });
+  const target = object({ key: string });
+  const result = unify(source, target);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'shape_mismatch');
+});
+
+test('refinement mismatch is detected', () => {
+  const uriString = refined(string, 'uri');
+  const plain = string;
+  const result = unify(uriString, plain);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'refinement_mismatch');
+});
+
+test('arrays unify element-wise', () => {
+  const left = array(refined(string, 'symbol'));
+  const right = array(refined(string, 'symbol'));
+  const result = unify(left, right);
+  assert.equal(result.ok, true);
+  assert.equal(canonicalStringify(toJSON(result.type)), canonicalStringify(toJSON(left)));
+});
+


### PR DESCRIPTION
## Summary
- add a tf-l0-types package with a minimal type vocabulary, JSON codec, and unifier helpers
- provide demo signatures plus a CLI that links primitive chains and emits canonical JSON artifacts
- exercise the new unifier with node:test coverage for positive and negative scenarios

## Testing
- pnpm -w -r build
- node scripts/types-demo.mjs
- cat out/0.4/check/types-demo.json | jq .
- pnpm -w -r test *(fails: known signing IR fixture assertion in tests/codegen-rs.test.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d008c69ca483208920b877ee5995c7