### PR TITLE
Formalize effect lattice helpers for L0 checker

### DIFF
--- a/docs/l0-effects-lattice.md
+++ b/docs/l0-effects-lattice.md
@@ -45,6 +45,12 @@ commutation is evaluated relative to a previous effect family:
   disjointness proof.
 - All other pairs are considered non-commuting for now.
 
+The helper is intentionally directional: `canCommute(prev, next)` answers the
+question “may the second node swap with the previous one?” rather than treating
+the pair symmetrically. This mirrors how the checker annotates sequential
+children—it records whether a future pass could safely bubble the current node
+left across its predecessor.
+
 The checker simply annotates `Seq` children with a `commutes_with_prev` boolean
 so that future normalization passes can inspect the lattice decision without
 reordering anything yet.

--- a/docs/l0-effects-lattice.md
+++ b/docs/l0-effects-lattice.md
@@ -1,0 +1,74 @@
+# L0 Effects Lattice
+
+The L0 checker uses a conservative lattice to describe the relationship between
+primitive effect families. The lattice is intentionally small: it only captures
+ordering information that we can justify today and treats everything else as
+incomparable until we prove otherwise.
+
+## Effect families
+
+Current families:
+
+- `Pure`
+- `Observability`
+- `Storage.Read`
+- `Storage.Write`
+- `Network.In`
+- `Network.Out`
+- `Crypto`
+- `Policy`
+- `Infra`
+- `Time`
+- `UI`
+
+Catalog entries may still use legacy variants such as `Time.Read` or
+`Time.Wait`; the lattice normalizes these aliases to the canonical families
+above.
+
+## Partial order and commutation
+
+The partial order (⊑) is used strictly as a bookkeeping tool for future
+normalization passes. Today the order only tracks a single relationship:
+`Pure ⊑ X` for every family `X`. No other pairs are related, which keeps all
+non-pure effects incomparable.
+
+The commutation table determines whether a node can be reordered with its
+predecessor inside a sequential composition. The rules are asymmetric because
+commutation is evaluated relative to a previous effect family:
+
+- `Pure` commutes with everything.
+- `Observability` only commutes with `Pure` and other `Observability` nodes.
+- `Network.Out` commutes with `Pure` and `Observability` nodes. The reverse is
+  *not* assumed; an observability action followed by a network write stays in
+  place until we have a proof obligation describing that swap.
+- `Storage.Write` never commutes with another `Storage.Write` without a
+  disjointness proof.
+- All other pairs are considered non-commuting for now.
+
+The checker simply annotates `Seq` children with a `commutes_with_prev` boolean
+so that future normalization passes can inspect the lattice decision without
+reordering anything yet.
+
+## Parallel safety
+
+The lattice also feeds parallel safety checks. Two `Storage.Write` branches are
+unsafe by default unless we can prove they write to disjoint URIs. The helper
+exposed to the checker delegates to the existing footprint conflict detector,
+so the behavior matches the previous implementation while giving us a single
+entry point to relax the rule when disjointness laws become available.
+
+All other effect combinations are treated as parallel-safe, which keeps the
+current behavior for non-write pairs intact. The exported helpers support an
+optional `disjoint(uriA, uriB)` predicate for future precision without changing
+callers.
+
+## Reporting and future work
+
+The lattice report script emits the commutation and parallel-safety matrices
+under `out/0.4/check/lattice-report.json`. The JSON output is deterministic so
+CI snapshots can track intentional changes when we revise the rules.
+
+Upcoming sprints will reuse these helpers inside the canonicalizer. By carrying
+`commutes_with_prev` annotations, we can gate normalization rewrites on the
+proven lattice rules and extend the table only when corresponding laws are
+formalized.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "a1": "node packages/tf-l0-spec/scripts/build-catalog.mjs && node packages/tf-l0-spec/scripts/derive-effects.mjs && node packages/tf-l0-spec/scripts/build-laws.mjs && node packages/tf-l0-spec/scripts/finalize-a1.mjs",
     "a1:summary": "node scripts/effects-summary.mjs",
     "a1:all": "pnpm run a1 && pnpm run a1:summary",
+    "a5:lattice-report": "node scripts/lattice-report.mjs && jq . out/0.4/check/lattice-report.json",
     "proofs:laws:axioms": "node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2 && node scripts/emit-smt-laws.mjs --law inverse:serialize-deserialize -o out/0.4/proofs/laws/inverse_roundtrip.smt2 && node scripts/emit-smt-laws.mjs --law commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute.smt2",
     "proofs:laws:equiv": "node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2",
     "tf": "node packages/tf-compose/bin/tf.mjs",

--- a/scripts/lattice-report.mjs
+++ b/scripts/lattice-report.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  EFFECT_FAMILIES,
+  canCommute,
+  parSafe
+} from '../packages/tf-l0-check/src/effect-lattice.mjs';
+
+export function buildLatticeReport() {
+  const commute = {};
+  const par = {};
+  for (const famA of EFFECT_FAMILIES) {
+    commute[famA] = {};
+    par[famA] = {};
+    for (const famB of EFFECT_FAMILIES) {
+      commute[famA][famB] = canCommute(famA, famB);
+      par[famA][famB] = parSafe(famA, famB);
+    }
+  }
+  return { commute, parSafe: par };
+}
+
+async function main() {
+  const outDir = 'out/0.4/check';
+  await mkdir(outDir, { recursive: true });
+  const report = buildLatticeReport();
+  await writeFile(
+    path.join(outDir, 'lattice-report.json'),
+    JSON.stringify(report, null, 2) + '\n',
+    'utf8'
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/lattice-report.mjs
+++ b/scripts/lattice-report.mjs
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
-  EFFECT_FAMILIES,
+  CANONICAL_EFFECT_FAMILIES,
   canCommute,
   parSafe
 } from '../packages/tf-l0-check/src/effect-lattice.mjs';
@@ -11,10 +11,10 @@ import {
 export function buildLatticeReport() {
   const commute = {};
   const par = {};
-  for (const famA of EFFECT_FAMILIES) {
+  for (const famA of CANONICAL_EFFECT_FAMILIES) {
     commute[famA] = {};
     par[famA] = {};
-    for (const famB of EFFECT_FAMILIES) {
+    for (const famB of CANONICAL_EFFECT_FAMILIES) {
       commute[famA][famB] = canCommute(famA, famB);
       par[famA][famB] = parSafe(famA, famB);
     }

--- a/tests/effect-lattice.test.mjs
+++ b/tests/effect-lattice.test.mjs
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  EFFECT_FAMILIES,
+  effectOf,
+  canCommute,
+  parSafe
+} from '../packages/tf-l0-check/src/effect-lattice.mjs';
+import { buildLatticeReport } from '../scripts/lattice-report.mjs';
+import { conflict } from '../packages/tf-l0-check/src/footprints.mjs';
+
+const catalog = JSON.parse(
+  await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8')
+);
+
+const emptyCatalog = { primitives: [] };
+
+// Pure commutes with a sampling of families
+const pureSamples = ['Observability', 'Storage.Write', 'Network.Out', 'Crypto', 'Policy', 'UI'];
+
+for (const fam of pureSamples) {
+  test(`Pure commutes with ${fam}`, () => {
+    assert.equal(canCommute('Pure', fam), true);
+  });
+}
+
+// Observability commutation cases
+test('Observability commutes with Pure', () => {
+  assert.equal(canCommute('Observability', 'Pure'), true);
+});
+
+test('Observability commutes with itself', () => {
+  assert.equal(canCommute('Observability', 'Observability'), true);
+});
+
+test('Observability does not commute with Storage.Write', () => {
+  assert.equal(canCommute('Observability', 'Storage.Write'), false);
+});
+
+test('Observability does not commute with Network.Out', () => {
+  assert.equal(canCommute('Observability', 'Network.Out'), false);
+});
+
+// Network.Out commutation cases
+test('Network.Out commutes with Observability', () => {
+  assert.equal(canCommute('Network.Out', 'Observability'), true);
+});
+
+test('Network.Out commutes with Pure', () => {
+  assert.equal(canCommute('Network.Out', 'Pure'), true);
+});
+
+test('Network.Out does not commute with Storage.Write', () => {
+  assert.equal(canCommute('Network.Out', 'Storage.Write'), false);
+});
+
+// Parallel safety checks
+const writeA = [{ uri: 'res://kv/a', mode: 'write' }];
+const writeB = [{ uri: 'res://kv/b', mode: 'write' }];
+const writeConflict = [{ uri: 'res://kv/shared', mode: 'write' }];
+
+test('Parallel Storage.Write with overlap is unsafe', () => {
+  assert.equal(
+    parSafe('Storage.Write', 'Storage.Write', {
+      conflict,
+      writesA: writeConflict,
+      writesB: writeConflict
+    }),
+    false
+  );
+});
+
+test('Parallel Storage.Write with disjoint URIs is safe', () => {
+  assert.equal(
+    parSafe('Storage.Write', 'Storage.Write', {
+      conflict,
+      writesA: writeA,
+      writesB: writeB
+    }),
+    true
+  );
+});
+
+test('Parallel Observability and Network.Out is safe', () => {
+  assert.equal(parSafe('Observability', 'Network.Out'), true);
+});
+
+// effectOf coverage
+test('effectOf prefers catalog effects', () => {
+  assert.equal(effectOf('tf:network/publish@1', catalog), 'Network.Out');
+});
+
+test('effectOf falls back to heuristics when missing', () => {
+  assert.equal(effectOf('tf:resource/read-object@1', emptyCatalog), 'Storage.Read');
+});
+
+test('effectOf returns Pure when unknown', () => {
+  assert.equal(effectOf('tf:unknown/thing@1', emptyCatalog), 'Pure');
+});
+
+// Lattice report determinism
+test('Lattice report matrix is deterministic', () => {
+  const first = buildLatticeReport();
+  const second = buildLatticeReport();
+  assert.deepEqual(first, second);
+  // ensure matrix covers declared families
+  for (const fam of EFFECT_FAMILIES) {
+    assert.ok(fam in first.commute);
+    assert.ok(fam in first.parSafe);
+  }
+});

--- a/tests/effect-lattice.test.mjs
+++ b/tests/effect-lattice.test.mjs
@@ -71,7 +71,12 @@ test('Parallel Storage.Write with overlap is unsafe', () => {
   );
 });
 
-test('Parallel Storage.Write with disjoint URIs is safe', () => {
+test('Parallel Observability and Network.Out is safe', () => {
+  assert.equal(parSafe('Observability', 'Network.Out'), true);
+});
+
+test('Parallel Storage.Write with provided disjoint predicate is safe', () => {
+  const alwaysDisjoint = () => true;
   assert.equal(
     parSafe('Storage.Write', 'Storage.Write', {
       conflict,
@@ -80,10 +85,14 @@ test('Parallel Storage.Write with disjoint URIs is safe', () => {
     }),
     true
   );
-});
-
-test('Parallel Observability and Network.Out is safe', () => {
-  assert.equal(parSafe('Observability', 'Network.Out'), true);
+  assert.equal(
+    parSafe('Storage.Write', 'Storage.Write', {
+      disjoint: alwaysDisjoint,
+      writesA: writeA,
+      writesB: writeB
+    }),
+    true
+  );
 });
 
 // effectOf coverage


### PR DESCRIPTION
## Summary
- add an effect lattice helper module with effectOf/canCommute/parSafe utilities and a JSON report script
- annotate sequential nodes with commutation metadata and reuse the lattice for Par safety checks
- document the conservative lattice and add focused effect lattice tests

## Testing
- pnpm -w -r build
- node scripts/lattice-report.mjs
- cat out/0.4/check/lattice-report.json | jq .
- pnpm -w -r test *(fails: existing rust codegen scaffold assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d008d3defc83208c50c5108c9d9142