### PR TITLE
D1.2: add SMT property harness [work]

### DIFF
--- a/examples/flows/obs_pure_EP.tf
+++ b/examples/flows/obs_pure_EP.tf
@@ -1,0 +1,1 @@
+emit-metric(key="hits", value="1") |> hash

--- a/examples/flows/obs_pure_PE.tf
+++ b/examples/flows/obs_pure_PE.tf
@@ -1,0 +1,1 @@
+hash |> emit-metric(key="hits", value="1")

--- a/packages/tf-l0-proofs/src/smt-props.mjs
+++ b/packages/tf-l0-proofs/src/smt-props.mjs
@@ -1,0 +1,167 @@
+import { effectOf } from '../../tf-l0-check/src/effect-lattice.mjs';
+
+export function emitParWriteSafety(ir, opts = {}) {
+  const hasSameUri = hasParallelSameUriWrite(ir, opts.catalog || {});
+  const lines = [];
+  lines.push('(declare-sort URI 0)');
+  lines.push('(declare-fun InParSameURI () Bool)');
+  if (hasSameUri) {
+    lines.push('(assert InParSameURI)');
+  }
+  lines.push('(assert (not InParSameURI))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+export function emitCommutationEquiv(irSeqEP, irSeqPE, opts = {}) {
+  const catalog = opts.catalog || {};
+  const seqA = findSeqNode(irSeqEP);
+  const seqB = findSeqNode(irSeqPE);
+  const stepsA = extractSequenceSteps(seqA, catalog);
+  const stepsB = extractSequenceSteps(seqB, catalog);
+  const inputName = 'input';
+  const lines = [];
+  lines.push('(declare-sort Val 0)');
+  lines.push('(declare-fun E (Val) Val)');
+  lines.push('(declare-fun P (Val) Val)');
+  lines.push('(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))');
+  lines.push(`(declare-const ${inputName} Val)`);
+  lines.push(`(define-fun outA () Val ${composeSteps(stepsA, inputName)})`);
+  lines.push(`(define-fun outB () Val ${composeSteps(stepsB, inputName)})`);
+  lines.push('(assert (not (= outA outB)))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+function hasParallelSameUriWrite(ir, catalog) {
+  let found = false;
+  walk(ir, (node) => {
+    if (found || !node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node === 'Par' && Array.isArray(node.children)) {
+      const branchUris = node.children.map((child) => collectWriteUris(child, catalog));
+      for (let i = 0; i < branchUris.length && !found; i++) {
+        const left = branchUris[i];
+        if (left.size === 0) {
+          continue;
+        }
+        for (let j = i + 1; j < branchUris.length && !found; j++) {
+          const right = branchUris[j];
+          if (right.size === 0) {
+            continue;
+          }
+          for (const uri of left) {
+            if (right.has(uri)) {
+              found = true;
+              break;
+            }
+          }
+        }
+      }
+    }
+  });
+  return found;
+}
+
+function collectWriteUris(node, catalog) {
+  const uris = new Set();
+  const visit = (current) => {
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+    if (current.node === 'Prim' && isStorageWrite(current, catalog)) {
+      const uri = extractUri(current);
+      if (uri) {
+        uris.add(uri);
+      }
+    }
+    if (Array.isArray(current.children)) {
+      for (const child of current.children) {
+        visit(child);
+      }
+    }
+  };
+  visit(node);
+  return uris;
+}
+
+function isStorageWrite(node, catalog) {
+  const primId = typeof node?.prim === 'string' ? node.prim : '';
+  if (!primId) {
+    return false;
+  }
+  const family = effectOf(primId, catalog);
+  return family === 'Storage.Write';
+}
+
+function extractUri(node) {
+  const uri = node?.args?.uri;
+  return typeof uri === 'string' && uri.length > 0 ? uri : null;
+}
+
+function findSeqNode(ir) {
+  if (!ir || typeof ir !== 'object') {
+    return null;
+  }
+  if (ir.node === 'Seq') {
+    return ir;
+  }
+  if (Array.isArray(ir.children)) {
+    for (const child of ir.children) {
+      const found = findSeqNode(child);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+function extractSequenceSteps(seqNode, catalog) {
+  if (!seqNode || seqNode.node !== 'Seq' || !Array.isArray(seqNode.children)) {
+    throw new Error('Expected a Seq node with children');
+  }
+  const steps = [];
+  for (const child of seqNode.children) {
+    if (child && child.node === 'Prim') {
+      const symbol = effectSymbol(effectOf(child.prim, catalog));
+      steps.push(symbol);
+    }
+  }
+  if (steps.length !== 2) {
+    throw new Error('Commutation property expects a two-step sequence');
+  }
+  return steps;
+}
+
+function effectSymbol(family) {
+  switch (family) {
+    case 'Observability':
+      return 'E';
+    case 'Pure':
+      return 'P';
+    default:
+      throw new Error(`Unsupported effect family for commutation: ${family}`);
+  }
+}
+
+function composeSteps(steps, inputName) {
+  let expr = inputName;
+  for (const step of steps) {
+    expr = `(${step} ${expr})`;
+  }
+  return expr;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}

--- a/scripts/emit-smt-props.mjs
+++ b/scripts/emit-smt-props.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, extname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitParWriteSafety,
+  emitCommutationEquiv,
+} from '../packages/tf-l0-proofs/src/smt-props.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: { out: { type: 'string', short: 'o' } },
+    allowPositionals: true,
+  });
+
+  if (positionals.length < 2) {
+    usage();
+    process.exit(1);
+  }
+
+  const mode = positionals[0];
+  const inputs = positionals.slice(1);
+  const catalog = await loadCatalog();
+  let smt = '';
+
+  if (mode === 'par-safety') {
+    if (inputs.length !== 1) {
+      usage();
+      process.exit(1);
+    }
+    const ir = await loadIR(inputs[0]);
+    smt = emitParWriteSafety(ir, { catalog });
+  } else if (mode === 'commute') {
+    if (inputs.length !== 2) {
+      usage();
+      process.exit(1);
+    }
+    const irA = await loadIR(inputs[0]);
+    const irB = await loadIR(inputs[1]);
+    smt = emitCommutationEquiv(irA, irB, { catalog });
+  } else {
+    usage();
+    process.exit(1);
+  }
+
+  const outPath = resolve(values.out ?? defaultOut(mode, inputs));
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, smt, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage() {
+  process.stderr.write(
+    'Usage:\n' +
+      '  node scripts/emit-smt-props.mjs par-safety <flow.tf|flow.ir.json> [-o out/0.4/proofs/props/<name>.smt2]\n' +
+      '  node scripts/emit-smt-props.mjs commute <flowA.tf|flowA.ir.json> <flowB.tf|flowB.ir.json> [-o out/0.4/proofs/props/<name>.smt2]\n'
+  );
+}
+
+function defaultOut(mode, inputs) {
+  const first = inputs[0] ?? mode;
+  const base = basename(first);
+  const ext = extname(base);
+  const stem = ext ? base.slice(0, -ext.length) : base;
+  const suffix = mode === 'par-safety' ? 'par-safety' : 'commute';
+  return `out/0.4/proofs/props/${stem}.${suffix}.smt2`;
+}
+
+async function loadIR(inputPath) {
+  const resolved = resolve(inputPath);
+  if (resolved.endsWith('.tf')) {
+    const raw = await readFile(resolved, 'utf8');
+    return parseDSL(raw);
+  }
+  if (resolved.endsWith('.ir.json')) {
+    const raw = await readFile(resolved, 'utf8');
+    return JSON.parse(raw);
+  }
+  throw new Error(`Unsupported input format: ${inputPath}`);
+}
+
+async function loadCatalog() {
+  const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+  const raw = await readFile(catalogUrl, 'utf8');
+  return JSON.parse(raw);
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(String(err?.stack || err));
+  process.stderr.write('\n');
+  process.exit(1);
+});

--- a/tests/smt-props.test.mjs
+++ b/tests/smt-props.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitParWriteSafety,
+  emitCommutationEquiv,
+} from '../packages/tf-l0-proofs/src/smt-props.mjs';
+
+const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+const catalogPromise = readFile(catalogUrl, 'utf8').then((raw) => JSON.parse(raw));
+
+test('par write safety detects conflicting branch writes', async () => {
+  const catalog = await catalogPromise;
+  const ir = parseDSL(`authorize{
+    par{
+      write-object(uri="res://kv/x", key="a", value="1");
+      write-object(uri="res://kv/x", key="b", value="2")
+    }
+  }`);
+  const smt = emitParWriteSafety(ir, { catalog });
+  assert.ok(smt.includes('(declare-sort URI 0)'), 'declares URI sort');
+  assert.ok(smt.includes('(assert InParSameURI)'), 'asserts detected conflict');
+  assert.ok(smt.includes('(assert (not InParSameURI))'), 'includes safety axiom');
+  assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
+});
+
+test('par write safety omits conflict assertion when URIs differ', async () => {
+  const catalog = await catalogPromise;
+  const ir = parseDSL(`authorize{
+    par{
+      write-object(uri="res://kv/a", key="a", value="1");
+      write-object(uri="res://kv/b", key="b", value="2")
+    }
+  }`);
+  const smt = emitParWriteSafety(ir, { catalog });
+  assert.ok(!smt.includes('(assert InParSameURI)'), 'no conflict assertion for safe flow');
+  assert.ok(smt.includes('(assert (not InParSameURI))'), 'still encodes safety axiom');
+  assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
+});
+
+test('observability/pure commutation emits disequality proof obligation', async () => {
+  const catalog = await catalogPromise;
+  const seqEP = parseDSL('emit-metric(key="hits", value="1") |> hash');
+  const seqPE = parseDSL('hash |> emit-metric(key="hits", value="1")');
+  const smt = emitCommutationEquiv(seqEP, seqPE, { catalog });
+  assert.ok(smt.includes('(declare-sort Val 0)'), 'declares Val sort');
+  assert.ok(smt.includes('(declare-fun E (Val) Val)'), 'declares E');
+  assert.ok(smt.includes('(declare-fun P (Val) Val)'), 'declares P');
+  assert.ok(
+    smt.includes('(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))'),
+    'includes commutation law'
+  );
+  assert.ok(smt.includes('(define-fun outA () Val (P (E input)))'), 'encodes EP sequence');
+  assert.ok(smt.includes('(define-fun outB () Val (E (P input)))'), 'encodes PE sequence');
+  assert.ok(smt.includes('(assert (not (= outA outB)))'), 'asserts disequality');
+  assert.ok(/\(check-sat\)\s*$/.test(smt), 'ends with check-sat');
+});
+
+test('property emitters are deterministic', async () => {
+  const catalog = await catalogPromise;
+  const seqEP = parseDSL('emit-metric(key="hits", value="1") |> hash');
+  const seqPE = parseDSL('hash |> emit-metric(key="hits", value="1")');
+  const parFlow = parseDSL(`authorize{
+    par{
+      write-object(uri="res://kv/x", key="a", value="1");
+      write-object(uri="res://kv/x", key="b", value="2")
+    }
+  }`);
+  const parFirst = emitParWriteSafety(parFlow, { catalog });
+  const parSecond = emitParWriteSafety(parFlow, { catalog });
+  assert.equal(parFirst, parSecond, 'par safety emitter is deterministic');
+  const commuteFirst = emitCommutationEquiv(seqEP, seqPE, { catalog });
+  const commuteSecond = emitCommutationEquiv(seqEP, seqPE, { catalog });
+  assert.equal(commuteFirst, commuteSecond, 'commutation emitter is deterministic');
+});


### PR DESCRIPTION
## Summary
- add dedicated SMT property emitter covering parallel write safety detection
- emit commutation equivalence obligations and expose both via a CLI helper
- add focused tests and sample flows to validate the generated SMT text

## Testing
- pnpm -w -r build *(fails: adapter-legal-ts build requires unavailable deps in the container)*
- pnpm -w -r test *(fails: vitest workspace target depends on missing deps)*
- node --test tests/smt-props.test.mjs


------
https://chatgpt.com/codex/tasks/task_e_68d0185fd51c8320af93cef0039d6e91