### PR TITLE
Add SMT property emitters and tests

### DIFF
--- a/packages/tf-l0-proofs/src/smt-props.mjs
+++ b/packages/tf-l0-proofs/src/smt-props.mjs
@@ -1,0 +1,191 @@
+import { effectOf } from '../../tf-l0-check/src/effect-lattice.mjs';
+
+export function emitParWriteSafety(ir, opts = {}) {
+  const catalog = normalizeCatalog(opts.catalog);
+  const hasConflict = detectParallelWriteConflict(ir, catalog);
+  const lines = [];
+  lines.push('(declare-sort URI 0)');
+  lines.push('(declare-fun InParSameURI () Bool)');
+  if (hasConflict) {
+    lines.push('(assert InParSameURI)');
+  } else {
+    lines.push('(assert true)');
+  }
+  lines.push('(assert (not InParSameURI))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+export function emitCommutationEquiv(irSeqEP, irSeqPE, opts = {}) {
+  const catalog = normalizeCatalog(opts.catalog);
+  const analysisA = analyzeSequence(irSeqEP, catalog);
+  const analysisB = analyzeSequence(irSeqPE, catalog);
+
+  const lines = [];
+  lines.push('(declare-sort Val 0)');
+  lines.push('(declare-fun E (Val) Val)');
+  lines.push('(declare-fun P (Val) Val)');
+  lines.push('(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))');
+  lines.push('(declare-const x Val)');
+  lines.push(`(define-fun outA () Val ${applySequence(analysisA.steps, 'x')})`);
+  lines.push(`(define-fun outB () Val ${applySequence(analysisB.steps, 'x')})`);
+  lines.push('(assert (not (= outA outB)))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+function detectParallelWriteConflict(ir, catalog) {
+  let conflict = false;
+  walk(ir, (node) => {
+    if (conflict) {
+      return;
+    }
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.node === 'Par' && Array.isArray(node.children)) {
+      const branchUris = node.children.map((child) => collectWriteUris(child, catalog));
+      for (let i = 0; i < branchUris.length; i += 1) {
+        const set = new Set(branchUris[i]);
+        if (set.size === 0) {
+          continue;
+        }
+        for (let j = i + 1; j < branchUris.length; j += 1) {
+          for (const uri of branchUris[j]) {
+            if (set.has(uri)) {
+              conflict = true;
+              return;
+            }
+          }
+        }
+      }
+    }
+  });
+  return conflict;
+}
+
+function collectWriteUris(node, catalog) {
+  const uris = [];
+  walk(node, (current) => {
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+    if (current.node !== 'Prim') {
+      return;
+    }
+    const primId = selectPrimId(current);
+    const family = effectOf(primId, catalog);
+    if (family !== 'Storage.Write') {
+      return;
+    }
+    const uri = selectUri(current.args);
+    if (uri) {
+      uris.push(uri);
+    }
+  });
+  return dedupe(uris);
+}
+
+function analyzeSequence(ir, catalog) {
+  if (!ir || typeof ir !== 'object') {
+    throw new Error('Expected sequence IR object');
+  }
+  const steps = extractSequenceSteps(ir);
+  if (steps.length !== 2) {
+    throw new Error('Expected a two-step sequence');
+  }
+  const mapped = steps.map((node) => {
+    const primId = selectPrimId(node);
+    const family = effectOf(primId, catalog);
+    if (family === 'Observability') {
+      return 'E';
+    }
+    if (family === 'Pure') {
+      return 'P';
+    }
+    throw new Error(`Unsupported effect family: ${family}`);
+  });
+  return { steps: mapped };
+}
+
+function applySequence(symbols, inputName) {
+  let expr = inputName;
+  for (const symbol of symbols) {
+    expr = `(${symbol} ${expr})`;
+  }
+  return expr;
+}
+
+function extractSequenceSteps(ir) {
+  if (ir.node === 'Seq' && Array.isArray(ir.children)) {
+    return ir.children;
+  }
+  if (ir.node === 'Prim') {
+    return [ir];
+  }
+  throw new Error('Expected Seq node with children');
+}
+
+function selectUri(args = {}) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const keys = ['uri', 'resource_uri', 'bucket_uri'];
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function selectPrimId(node) {
+  if (!node || typeof node !== 'object') {
+    return '';
+  }
+  if (typeof node.prim_id === 'string' && node.prim_id.length > 0) {
+    return node.prim_id;
+  }
+  if (typeof node.prim === 'string' && node.prim.length > 0) {
+    return node.prim;
+  }
+  return '';
+}
+
+function walk(node, visitor) {
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      walk(entry, visitor);
+    }
+    return;
+  }
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visitor(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visitor);
+    }
+  }
+  if (node.args && typeof node.args === 'object') {
+    for (const value of Object.values(node.args)) {
+      walk(value, visitor);
+    }
+  }
+}
+
+function dedupe(values) {
+  return Array.from(new Set(values));
+}
+
+function normalizeCatalog(catalog) {
+  if (!catalog || typeof catalog !== 'object') {
+    return { primitives: [] };
+  }
+  if (!Array.isArray(catalog.primitives)) {
+    return { primitives: [] };
+  }
+  return catalog;
+}

--- a/scripts/emit-smt-props.mjs
+++ b/scripts/emit-smt-props.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitParWriteSafety,
+  emitCommutationEquiv,
+} from '../packages/tf-l0-proofs/src/smt-props.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      out: { type: 'string', short: 'o' },
+    },
+    allowPositionals: true,
+  });
+
+  const outPath = typeof values.out === 'string' ? resolve(values.out) : null;
+  if (!outPath) {
+    usage('missing --out <file>');
+    process.exit(2);
+  }
+
+  const [mode, ...rest] = positionals;
+  if (!mode) {
+    usage('missing mode');
+    process.exit(2);
+  }
+
+  if (mode === 'par-safety') {
+    if (rest.length !== 1) {
+      usage('par-safety requires exactly one input');
+      process.exit(2);
+    }
+    const ir = await loadIR(rest[0]);
+    const smt = emitParWriteSafety(ir);
+    await writeOutput(outPath, smt);
+    process.stdout.write(`wrote ${outPath}\n`);
+    return;
+  }
+
+  if (mode === 'commute') {
+    if (rest.length !== 2) {
+      usage('commute requires two inputs');
+      process.exit(2);
+    }
+    const [left, right] = await Promise.all(rest.map((entry) => loadIR(entry)));
+    const smt = emitCommutationEquiv(left, right);
+    await writeOutput(outPath, smt);
+    process.stdout.write(`wrote ${outPath}\n`);
+    return;
+  }
+
+  usage(`unknown mode: ${mode}`);
+  process.exit(2);
+}
+
+function usage(message) {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.stderr.write(
+    'Usage:\n' +
+      '  node scripts/emit-smt-props.mjs par-safety <input.tf|input.ir.json> -o <out.smt2>\n' +
+      '  node scripts/emit-smt-props.mjs commute <seqEP.tf|.ir.json> <seqPE.tf|.ir.json> -o <out.smt2>\n'
+  );
+}
+
+async function loadIR(source) {
+  const resolved = resolve(source);
+  const contents = await readFile(resolved, 'utf8');
+  if (resolved.endsWith('.tf')) {
+    return parseDSL(contents);
+  }
+  if (resolved.endsWith('.ir.json')) {
+    return JSON.parse(contents);
+  }
+  throw new Error('unsupported input; expected .tf or .ir.json');
+}
+
+async function writeOutput(filePath, content) {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, ensureTrailingNewline(content), 'utf8');
+}
+
+function ensureTrailingNewline(text) {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/tests/smt-props.test.mjs
+++ b/tests/smt-props.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitParWriteSafety,
+  emitCommutationEquiv,
+} from '../packages/tf-l0-proofs/src/smt-props.mjs';
+
+test('par write safety detects conflicting URIs', () => {
+  const ir = parseDSL(
+    'par{ write-object(uri="res://kv/x", value="1"); write-object(uri="res://kv/x", value="2") }'
+  );
+  const smt = emitParWriteSafety(ir);
+  assert.ok(smt.includes('(declare-sort URI 0)'));
+  assert.ok(smt.includes('(declare-fun InParSameURI () Bool)'));
+  assert.ok(smt.includes('(assert InParSameURI)'));
+  assert.ok(smt.includes('(assert (not InParSameURI))'));
+  assert.ok(smt.includes('(check-sat)'));
+
+  const again = emitParWriteSafety(ir);
+  assert.strictEqual(smt, again);
+});
+
+test('par write safety skips when URIs differ', () => {
+  const ir = parseDSL(
+    'par{ write-object(uri="res://kv/x", value="1"); write-object(uri="res://kv/y", value="2") }'
+  );
+  const smt = emitParWriteSafety(ir);
+  assert.ok(!smt.includes('(assert InParSameURI)'));
+  assert.ok(smt.includes('(assert (not InParSameURI))'));
+  assert.ok(smt.includes('(check-sat)'));
+});
+
+test('commutation equivalence emits law and disequality', () => {
+  const seqEP = parseDSL('emit-metric |> hash');
+  const seqPE = parseDSL('hash |> emit-metric');
+  const smt = emitCommutationEquiv(seqEP, seqPE);
+
+  assert.ok(smt.includes('(declare-sort Val 0)'));
+  assert.ok(smt.includes('(declare-fun E (Val) Val)'));
+  assert.ok(smt.includes('(declare-fun P (Val) Val)'));
+  assert.ok(smt.includes('(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))'));
+  assert.ok(smt.includes('(assert (not (= outA outB)))'));
+  assert.ok(smt.includes('(check-sat)'));
+
+  const again = emitCommutationEquiv(seqEP, seqPE);
+  assert.strictEqual(smt, again);
+});


### PR DESCRIPTION
## Summary
- add SMT emitters for parallel write safety and observability/pure commutation
- wire CLI entry point for generating the property obligations
- cover emitters with node:test cases for detection, commutation, and determinism


------
https://chatgpt.com/codex/tasks/task_e_68d0185fd51c8320af93cef0039d6e91