### PR TITLE
Add SMT property emitters for par safety and commutation

### DIFF
--- a/packages/tf-l0-proofs/src/smt-props.mjs
+++ b/packages/tf-l0-proofs/src/smt-props.mjs
@@ -1,0 +1,194 @@
+import { effectOf } from '../../tf-l0-check/src/effect-lattice.mjs';
+
+export function emitParWriteSafety(ir, opts = {}) {
+  const catalog = normalizeCatalog(opts.catalog);
+  const hasConflict = detectParallelSameUriWrite(ir, catalog);
+  const lines = [];
+  lines.push('(declare-sort URI 0)');
+  lines.push('(declare-fun InParSameURI () Bool)');
+  if (hasConflict) {
+    lines.push('(assert InParSameURI)');
+  }
+  lines.push('(assert (not InParSameURI))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+export function emitCommutationEquiv(irSeqEP, irSeqPE, opts = {}) {
+  const catalog = normalizeCatalog(opts.catalog);
+  const outA = encodeSequence(irSeqEP, catalog, 'input');
+  const outB = encodeSequence(irSeqPE, catalog, 'input');
+  const lines = [];
+  lines.push('(declare-sort Val 0)');
+  lines.push('(declare-fun E (Val) Val)');
+  lines.push('(declare-fun P (Val) Val)');
+  lines.push('(declare-const input Val)');
+  lines.push('(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))');
+  lines.push(`(define-const outA Val ${outA})`);
+  lines.push(`(define-const outB Val ${outB})`);
+  lines.push('(assert (not (= outA outB)))');
+  lines.push('(check-sat)');
+  return lines.join('\n') + '\n';
+}
+
+function detectParallelSameUriWrite(node, catalog) {
+  let found = false;
+  walk(node, (current) => {
+    if (found || !current || typeof current !== 'object') {
+      return;
+    }
+    if (current.node === 'Par' && Array.isArray(current.children)) {
+      const branchUris = current.children.map((child) => collectWriteUris(child, catalog));
+      for (let i = 0; i < branchUris.length; i++) {
+        const left = branchUris[i];
+        if (left.length === 0) {
+          continue;
+        }
+        for (let j = i + 1; j < branchUris.length; j++) {
+          const right = branchUris[j];
+          if (right.length === 0) {
+            continue;
+          }
+          if (hasIntersection(left, right)) {
+            found = true;
+            return;
+          }
+        }
+      }
+    }
+  });
+  return found;
+}
+
+function collectWriteUris(node, catalog) {
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+  if (node.node === 'Prim') {
+    const primId = typeof node.prim === 'string' ? node.prim : null;
+    if (!primId) {
+      return [];
+    }
+    const family = effectOf(primId, catalog);
+    if (family !== 'Storage.Write') {
+      return [];
+    }
+    const uri = extractUri(node.args);
+    return uri ? [uri] : [];
+  }
+  if (!Array.isArray(node.children)) {
+    return [];
+  }
+  const uris = [];
+  for (const child of node.children) {
+    uris.push(...collectWriteUris(child, catalog));
+  }
+  return uniqueStrings(uris);
+}
+
+function encodeSequence(ir, catalog, seed) {
+  const prims = collectSequentialPrims(ir);
+  if (prims.length !== 2) {
+    throw new Error('Expected two-step sequence');
+  }
+  const ops = prims.map((prim) => mapPrimToOp(prim, catalog));
+  if (!containsBothOps(ops)) {
+    throw new Error('Expected sequence containing Observability and Pure effects');
+  }
+  return ops.reduce((acc, op) => `(${op} ${acc})`, seed);
+}
+
+function collectSequentialPrims(node) {
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+  if (node.node === 'Prim') {
+    return [node];
+  }
+  if (node.node === 'Par') {
+    throw new Error('Parallel nodes are not supported in commutation proofs');
+  }
+  const collected = [];
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      collected.push(...collectSequentialPrims(child));
+    }
+  }
+  return collected;
+}
+
+function mapPrimToOp(prim, catalog) {
+  const primId = typeof prim.prim === 'string' ? prim.prim : null;
+  if (!primId) {
+    throw new Error('Invalid primitive node');
+  }
+  const family = effectOf(primId, catalog);
+  if (family === 'Observability') {
+    return 'E';
+  }
+  if (family === 'Pure') {
+    return 'P';
+  }
+  throw new Error(`Unsupported effect family: ${family}`);
+}
+
+function containsBothOps(ops) {
+  const unique = new Set(ops);
+  return unique.has('E') && unique.has('P');
+}
+
+function extractUri(args) {
+  if (!args || typeof args !== 'object') {
+    return null;
+  }
+  const uri = args.uri;
+  if (typeof uri === 'string' && uri.length > 0) {
+    return uri;
+  }
+  return null;
+}
+
+function uniqueStrings(values) {
+  const result = [];
+  const seen = new Set();
+  for (const value of values) {
+    if (typeof value !== 'string' || value.length === 0) {
+      continue;
+    }
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function hasIntersection(a, b) {
+  const lookup = new Set(a);
+  for (const value of b) {
+    if (lookup.has(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      walk(child, visit);
+    }
+  }
+}
+
+function normalizeCatalog(raw) {
+  if (raw && typeof raw === 'object') {
+    return raw;
+  }
+  return { primitives: [] };
+}

--- a/scripts/emit-smt-props.mjs
+++ b/scripts/emit-smt-props.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitParWriteSafety, emitCommutationEquiv } from '../packages/tf-l0-proofs/src/smt-props.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      out: { type: 'string', short: 'o' },
+    },
+    allowPositionals: true,
+  });
+
+  if (positionals.length === 0) {
+    usage('missing command');
+    process.exit(2);
+  }
+
+  const command = positionals[0];
+  const inputs = positionals.slice(1);
+  const outPath = typeof values.out === 'string' ? resolve(values.out) : null;
+
+  if (!outPath) {
+    usage('missing --out <file>');
+    process.exit(2);
+  }
+
+  const catalog = await loadCatalog();
+
+  if (command === 'par-safety') {
+    if (inputs.length !== 1) {
+      usage('par-safety requires exactly one input');
+      process.exit(2);
+    }
+    const ir = await loadIR(inputs[0]);
+    const smt = emitParWriteSafety(ir, { catalog });
+    await writeOutput(outPath, smt);
+    process.stdout.write(`wrote ${outPath}\n`);
+    return;
+  }
+
+  if (command === 'commute') {
+    if (inputs.length !== 2) {
+      usage('commute requires two inputs');
+      process.exit(2);
+    }
+    const [left, right] = await Promise.all(inputs.map((entry) => loadIR(entry)));
+    const smt = emitCommutationEquiv(left, right, { catalog });
+    await writeOutput(outPath, smt);
+    process.stdout.write(`wrote ${outPath}\n`);
+    return;
+  }
+
+  usage(`unknown command: ${command}`);
+  process.exit(2);
+}
+
+async function loadIR(source) {
+  const resolved = resolve(source);
+  if (resolved.endsWith('.tf')) {
+    const raw = await readFile(resolved, 'utf8');
+    return parseDSL(raw);
+  }
+  if (resolved.endsWith('.ir.json')) {
+    const raw = await readFile(resolved, 'utf8');
+    return JSON.parse(raw);
+  }
+  throw new Error('unsupported input; expected .tf or .ir.json');
+}
+
+async function loadCatalog() {
+  try {
+    const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { primitives: [] };
+  }
+}
+
+async function writeOutput(filePath, content) {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, ensureTrailingNewline(content), 'utf8');
+}
+
+function ensureTrailingNewline(text) {
+  if (text.endsWith('\n')) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+function usage(message) {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.stderr.write(
+    'Usage:\n' +
+      '  node scripts/emit-smt-props.mjs par-safety <flow.tf|flow.ir.json> -o <out.smt2>\n' +
+      '  node scripts/emit-smt-props.mjs commute <seqEP> <seqPE> -o <out.smt2>\n'
+  );
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/tests/smt-props.test.mjs
+++ b/tests/smt-props.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import {
+  emitParWriteSafety,
+  emitCommutationEquiv,
+} from '../packages/tf-l0-proofs/src/smt-props.mjs';
+
+const catalog = await loadCatalog();
+
+test('par safety detects same-uri writes', () => {
+  const ir = parseDSL(
+    'par{ write-object(uri="res://kv/x", key="a", value="1"); write-object(uri="res://kv/x", key="b", value="2") }'
+  );
+  const smt = emitParWriteSafety(ir, { catalog });
+  assert.ok(smt.includes('(assert InParSameURI)'), 'conflict assertion present');
+  assert.ok(smt.includes('(assert (not InParSameURI))'), 'safety axiom asserted');
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'ends with check-sat');
+});
+
+test('par safety skips distinct URIs', () => {
+  const ir = parseDSL(
+    'par{ write-object(uri="res://kv/x", key="a", value="1"); write-object(uri="res://kv/y", key="b", value="2") }'
+  );
+  const smt = emitParWriteSafety(ir, { catalog });
+  assert.ok(!smt.includes('(assert InParSameURI)'), 'no same-URI assertion when safe');
+  assert.ok(smt.includes('(assert (not InParSameURI))'), 'safety axiom still asserted');
+});
+
+test('commutation equivalence encodes axioms and disequality', () => {
+  const seqEP = parseDSL('emit-metric(key="ok") |> hash');
+  const seqPE = parseDSL('hash |> emit-metric(key="ok")');
+  const smt = emitCommutationEquiv(seqEP, seqPE, { catalog });
+  assert.ok(/\(declare-sort\s+Val\s+0\)/.test(smt), 'declares Val sort');
+  assert.ok(/\(declare-fun\s+E\s+\(Val\)\s+Val\)/.test(smt), 'declares E function');
+  assert.ok(/\(declare-fun\s+P\s+\(Val\)\s+Val\)/.test(smt), 'declares P function');
+  assert.ok(
+    smt.includes('(assert (forall ((x Val)) (= (E (P x)) (P (E x)))))'),
+    'includes commutation law'
+  );
+  assert.ok(smt.includes('(assert (not (= outA outB)))'), 'asserts disequality');
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'ends with check-sat');
+});
+
+test('commutation emitter is deterministic', () => {
+  const seqEP = parseDSL('emit-metric(key="ok") |> hash');
+  const seqPE = parseDSL('hash |> emit-metric(key="ok")');
+  const first = emitCommutationEquiv(seqEP, seqPE, { catalog });
+  const second = emitCommutationEquiv(seqEP, seqPE, { catalog });
+  assert.equal(first, second);
+});
+
+test('par safety emitter is deterministic', () => {
+  const ir = parseDSL(
+    'par{ write-object(uri="res://kv/x", key="a", value="1"); write-object(uri="res://kv/y", key="b", value="2") }'
+  );
+  const first = emitParWriteSafety(ir, { catalog });
+  const second = emitParWriteSafety(ir, { catalog });
+  assert.equal(first, second);
+});
+
+async function loadCatalog() {
+  try {
+    const raw = await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { primitives: [] };
+  }
+}


### PR DESCRIPTION
## Summary
- add SMT property emitters covering parallel write safety and observability/pure commutation
- provide a CLI script for emitting the new property obligations
- exercise deterministic SMT output through targeted tests

## Testing
- `pnpm -w -r build` *(fails: TypeScript cannot find claims-core-ts during adapter-legal-ts build)*
- `pnpm -w -r test` *(fails: vitest run in @tf-lang/adapter-execution-ts exits 1)*
- `node --test tests/smt-props.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68d0185fd51c8320af93cef0039d6e91