### PR TITLE
B2.2: Add local commutation normalization pass

### DIFF
--- a/packages/tf-l0-check/src/effect-lattice.mjs
+++ b/packages/tf-l0-check/src/effect-lattice.mjs
@@ -14,6 +14,19 @@ export const CANONICAL_EFFECT_FAMILIES = Object.freeze([
   'UI'
 ]);
 
+export const EFFECT_PRECEDENCE = Object.freeze([
+  'Pure',
+  'Observability',
+  'Network.Out',
+  'Storage.Read',
+  'Storage.Write',
+  'Crypto',
+  'Policy',
+  'Infra',
+  'Time',
+  'UI'
+]);
+
 const FAMILY_ALIASES = Object.freeze({
   'Time.Read': 'Time',
   'Time.Wait': 'Time',
@@ -71,6 +84,12 @@ export function normalizeFamily(family) {
   return 'Pure';
 }
 
+export function effectRank(family) {
+  const normalized = normalizeFamily(family);
+  const index = EFFECT_PRECEDENCE.indexOf(normalized);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
 export function effectOf(primId, catalog = {}) {
   const primitives = Array.isArray(catalog.primitives) ? catalog.primitives : [];
   const name = nameFromId(primId).toLowerCase();
@@ -104,7 +123,7 @@ export function canCommute(prevFamily, nextFamily) {
   }
 
   if (prev === 'Observability') {
-    return next === 'Observability';
+    return next === 'Observability' || next === 'Network.Out';
   }
 
   if (prev === 'Network.Out') {
@@ -112,6 +131,10 @@ export function canCommute(prevFamily, nextFamily) {
   }
 
   return false;
+}
+
+export function commuteSymmetric(familyA, familyB) {
+  return canCommute(familyA, familyB) && canCommute(familyB, familyA);
 }
 
 export function parSafe(famA, famB, ctx = {}) {

--- a/packages/tf-l0-ir/src/normalize-commute.mjs
+++ b/packages/tf-l0-ir/src/normalize-commute.mjs
@@ -1,0 +1,142 @@
+import { effectOf, effectRank, commuteSymmetric } from '../../tf-l0-check/src/effect-lattice.mjs';
+
+export function normalizeByCommutation(ir, catalog = {}) {
+  const { node } = visit(ir, catalog);
+  return node;
+}
+
+function visit(node, catalog) {
+  if (!node || typeof node !== 'object') {
+    return { node, changed: false };
+  }
+
+  if (node.node === 'Seq') {
+    const children = Array.isArray(node.children) ? node.children : [];
+    let childChanged = false;
+    const normalizedChildren = [];
+
+    for (const child of children) {
+      const result = visit(child, catalog);
+      normalizedChildren.push(result.node);
+      if (result.changed) {
+        childChanged = true;
+      }
+    }
+
+    const { nodes: reorderedChildren, changed: reorderChanged } = reorderSeq(normalizedChildren, catalog);
+
+    if (!childChanged && !reorderChanged) {
+      return { node, changed: false };
+    }
+
+    const finalChildren = reorderChanged ? reorderedChildren : normalizedChildren;
+    return { node: { ...node, children: finalChildren }, changed: true };
+  }
+
+  if (node.node === 'Par' || node.node === 'Region') {
+    const children = Array.isArray(node.children) ? node.children : [];
+    let changed = false;
+    const nextChildren = [];
+
+    for (const child of children) {
+      const result = visit(child, catalog);
+      nextChildren.push(result.node);
+      if (result.changed) {
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return { node, changed: false };
+    }
+
+    return { node: { ...node, children: nextChildren }, changed: true };
+  }
+
+  if (Array.isArray(node.children)) {
+    let changed = false;
+    const nextChildren = [];
+
+    for (const child of node.children) {
+      const result = visit(child, catalog);
+      nextChildren.push(result.node);
+      if (result.changed) {
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return { node, changed: false };
+    }
+
+    return { node: { ...node, children: nextChildren }, changed: true };
+  }
+
+  return { node, changed: false };
+}
+
+function reorderSeq(children, catalog) {
+  if (!Array.isArray(children) || children.length < 2) {
+    return { nodes: children, changed: false };
+  }
+
+  const nodes = children.slice();
+  let changed = false;
+
+  while (true) {
+    let swapped = false;
+    for (let i = 0; i < nodes.length - 1; i += 1) {
+      const left = nodes[i];
+      const right = nodes[i + 1];
+
+      if (!isPrim(left) || !isPrim(right)) {
+        continue;
+      }
+
+      const leftFamily = effectOf(left.prim, catalog);
+      const rightFamily = effectOf(right.prim, catalog);
+
+      if (!commuteSymmetric(leftFamily, rightFamily)) {
+        continue;
+      }
+
+      const leftRank = effectRank(leftFamily);
+      const rightRank = effectRank(rightFamily);
+
+      if (!shouldSwap(left, right, leftRank, rightRank)) {
+        continue;
+      }
+
+      nodes[i] = right;
+      nodes[i + 1] = left;
+      swapped = true;
+      changed = true;
+    }
+
+    if (!swapped) {
+      break;
+    }
+  }
+
+  return { nodes: changed ? nodes : children, changed };
+}
+
+function shouldSwap(leftNode, rightNode, leftRank, rightRank) {
+  if (rightRank < leftRank) {
+    return true;
+  }
+
+  if (rightRank === leftRank) {
+    return comparePrimIds(rightNode.prim, leftNode.prim) < 0;
+  }
+
+  return false;
+}
+
+function comparePrimIds(a, b) {
+  return String(a ?? '').localeCompare(String(b ?? ''));
+}
+
+function isPrim(node) {
+  return Boolean(node && node.node === 'Prim');
+}

--- a/packages/tf-l0-ir/src/normalize.mjs
+++ b/packages/tf-l0-ir/src/normalize.mjs
@@ -1,8 +1,12 @@
+import { normalizeByCommutation } from './normalize-commute.mjs';
+
 const KNOWN_PURE_PRIMS = new Set(['hash', 'serialize', 'deserialize']);
 
 export function canon(ir, laws = {}) {
   const ctx = buildLawContext(laws);
-  return normalizeNode(ir, ctx);
+  const normalized = normalizeNode(ir, ctx);
+  const catalog = extractCatalog(laws);
+  return normalizeByCommutation(normalized, catalog);
 }
 
 export function normalize(ir, laws = {}) {
@@ -227,4 +231,17 @@ function isPurePrim(node, ctx) {
   if (!name) return false;
   if (ctx?.pure?.has(name)) return true;
   return KNOWN_PURE_PRIMS.has(name);
+}
+
+function extractCatalog(lawsSpec) {
+  if (
+    lawsSpec &&
+    typeof lawsSpec === 'object' &&
+    !Array.isArray(lawsSpec) &&
+    lawsSpec.catalog &&
+    typeof lawsSpec.catalog === 'object'
+  ) {
+    return lawsSpec.catalog;
+  }
+  return {};
 }

--- a/scripts/normalize-commute.mjs
+++ b/scripts/normalize-commute.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import process from 'node:process';
+
+import { normalize } from '../packages/tf-l0-ir/src/normalize.mjs';
+import { canonicalize } from '../packages/tf-l0-ir/src/hash.mjs';
+
+async function main(argv) {
+  const cliArgs = argv.slice(2);
+  const { values, positionals } = parseArgs({
+    args: cliArgs,
+    options: {
+      o: { type: 'string' }
+    },
+    allowPositionals: true
+  });
+
+  if (positionals.length !== 1) {
+    throw new Error('Usage: node scripts/normalize-commute.mjs <flow.tf|flow.ir.json> -o <output.ir.json>');
+  }
+
+  const outputPath = values.o;
+  if (typeof outputPath !== 'string' || outputPath.length === 0) {
+    throw new Error('Usage: node scripts/normalize-commute.mjs <flow.tf|flow.ir.json> -o <output.ir.json>');
+  }
+
+  const inputPath = path.resolve(process.cwd(), positionals[0]);
+  const resolvedOutput = path.resolve(process.cwd(), outputPath);
+
+  const ir = await loadIR(inputPath);
+  const normalized = normalize(ir);
+
+  await mkdir(path.dirname(resolvedOutput), { recursive: true });
+  await writeFile(resolvedOutput, `${canonicalize(normalized)}\n`, 'utf8');
+}
+
+async function loadIR(filePath) {
+  if (filePath.endsWith('.tf')) {
+    const source = await readFile(filePath, 'utf8');
+    const { parseDSL } = await import('../packages/tf-compose/src/parser.mjs');
+    return parseDSL(source);
+  }
+
+  if (filePath.endsWith('.ir.json')) {
+    const contents = await readFile(filePath, 'utf8');
+    return JSON.parse(contents);
+  }
+
+  throw new Error('Input must end with .tf or .ir.json');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main(process.argv).catch((err) => {
+    const message = err && typeof err.message === 'string' ? err.message : String(err);
+    console.error(message);
+    process.exitCode = 1;
+  });
+}

--- a/tests/normalize-commute.test.mjs
+++ b/tests/normalize-commute.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalize } from '../packages/tf-l0-ir/src/normalize.mjs';
+import { canonicalize } from '../packages/tf-l0-ir/src/hash.mjs';
+
+const PURE = 'tf:information/hash@1';
+const OBS = 'tf:observability/emit-metric@1';
+const NET = 'tf:network/publish@1';
+const WRITE = 'tf:storage/write-object@1';
+
+function makePrim(prim) {
+  return { node: 'Prim', prim };
+}
+
+function makeSeq(children) {
+  return { node: 'Seq', children };
+}
+
+function primOrder(node) {
+  if (!node || node.node !== 'Seq') {
+    return [];
+  }
+  return (node.children ?? [])
+    .filter((child) => child?.node === 'Prim')
+    .map((child) => child.prim);
+}
+
+test('Pure and Observability remain in canonical order', () => {
+  const ordered = makeSeq([makePrim(PURE), makePrim(OBS)]);
+  const normalizedOrdered = normalize(ordered);
+  assert.deepEqual(primOrder(normalizedOrdered), [PURE, OBS]);
+
+  const reversed = makeSeq([makePrim(OBS), makePrim(PURE)]);
+  const normalizedReversed = normalize(reversed);
+  assert.deepEqual(primOrder(normalizedReversed), [PURE, OBS]);
+});
+
+test('Observability bubbles left of Network.Out when commuting', () => {
+  const reversed = makeSeq([makePrim(NET), makePrim(OBS)]);
+  const normalized = normalize(reversed);
+  assert.deepEqual(primOrder(normalized), [OBS, NET]);
+});
+
+test('Storage.Write remains a barrier for Observability', () => {
+  const seq = makeSeq([makePrim(WRITE), makePrim(OBS)]);
+  const normalized = normalize(seq);
+  assert.deepEqual(primOrder(normalized), [WRITE, OBS]);
+});
+
+test('Region boundaries prevent commuting across the region', () => {
+  const region = { node: 'Region', children: [makePrim(OBS)] };
+  const seq = makeSeq([region, makePrim(NET)]);
+  const normalized = normalize(seq);
+
+  assert.equal(normalized.node, 'Seq');
+  const children = normalized.children ?? [];
+  assert.equal(children.length, 2);
+  assert.equal(children[0].node, 'Region');
+  assert.equal(children[1].node, 'Prim');
+  assert.equal(children[1].prim, NET);
+  const regionChildren = children[0].children ?? [];
+  assert.equal(regionChildren.length, 1);
+  assert.equal(regionChildren[0].prim, OBS);
+});
+
+test('Normalization with commutation is a fixpoint', () => {
+  const seq = makeSeq([
+    makePrim(NET),
+    makePrim(OBS),
+    makePrim(PURE),
+    makePrim(NET),
+    makePrim(OBS)
+  ]);
+  const first = normalize(seq);
+  const second = normalize(first);
+  assert.equal(canonicalize(first), canonicalize(second));
+});


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

> Fill all sections. CI will fail if required headings are missing.

## Summary
- Scope: B2.2
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [ ] CI wiring + determinism re‑run
- Notes: Added an effect-precedence-guided local commutation pass to the L0 normalizer plus supporting tools/tests.

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`

## Determinism & Seeds
- Repeats: 0
- Seeds: N/A
- Notes: Not a stochastic workflow; no new nondeterministic steps introduced.

## Tests & CI
- TS tests: `pnpm -w -r test` (fails: upstream workspace packages `tf-plan-enum` / `tf-plan-scaffold` vitest suite) and `pnpm run test:l0` (fails: existing `tests/codegen-rs.test.mjs` assertion)
- Rust tests: N/A
- CI jobs: Not run locally

## Implementation Notes
- ABI / paths unchanged? Y
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`, Rust panic‑free

## Hurdles / Follow-ups
- Known gaps: Workspace build currently blocked by missing `claims-core-ts` dependency when running `pnpm -w -r build`.
- Suggested next steps: Address failing workspace packages/tests or run filtered builds when focusing on L0 layer.


------
https://chatgpt.com/codex/tasks/task_e_68d01850b8a48320b1f5352d90ac3c00