### PR TITLE
B2.2: lattice-guided normalization [default]

### DIFF
--- a/docs/l0-effects-lattice.md
+++ b/docs/l0-effects-lattice.md
@@ -60,9 +60,10 @@ The L0 canonicalizer now performs a local "bubble sort" guided by the lattice.
 Two adjacent primitives swap only when the lattice proves that the effects
 commute in both directions. When a swap is allowed, the pass uses a stable
 precedence (`Pure`, `Observability`, `Network.Out`, …) and the primitive ID as a
-tie-breaker so repeated normalizations are deterministic. Region boundaries are
-treated as barriers, and non-primitive nodes are left untouched, which keeps the
-pass purely local.
+tie-breaker so repeated normalizations are deterministic. Normalization uses a
+local (adjacent) swap based on symmetric commutation and a fixed effect
+precedence. We do not reorder across region boundaries. Non-primitive nodes are
+left untouched, which keeps the pass purely local.
 
 ## Parallel safety
 

--- a/docs/l0-effects-lattice.md
+++ b/docs/l0-effects-lattice.md
@@ -37,10 +37,9 @@ predecessor inside a sequential composition. The rules are asymmetric because
 commutation is evaluated relative to a previous effect family:
 
 - `Pure` commutes with everything.
-- `Observability` only commutes with `Pure` and other `Observability` nodes.
-- `Network.Out` commutes with `Pure` and `Observability` nodes. The reverse is
-  *not* assumed; an observability action followed by a network write stays in
-  place until we have a proof obligation describing that swap.
+- `Observability` commutes with `Pure`, other `Observability` nodes, and
+  `Network.Out` effects.
+- `Network.Out` commutes with `Pure` and `Observability` nodes.
 - `Storage.Write` never commutes with another `Storage.Write` without a
   disjointness proof.
 - All other pairs are considered non-commuting for now.
@@ -54,6 +53,16 @@ left across its predecessor.
 The checker simply annotates `Seq` children with a `commutes_with_prev` boolean
 so that future normalization passes can inspect the lattice decision without
 reordering anything yet.
+
+## Using the lattice in normalization
+
+The L0 canonicalizer now performs a local "bubble sort" guided by the lattice.
+Two adjacent primitives swap only when the lattice proves that the effects
+commute in both directions. When a swap is allowed, the pass uses a stable
+precedence (`Pure`, `Observability`, `Network.Out`, …) and the primitive ID as a
+tie-breaker so repeated normalizations are deterministic. Region boundaries are
+treated as barriers, and non-primitive nodes are left untouched, which keeps the
+pass purely local.
 
 ## Parallel safety
 

--- a/packages/tf-l0-check/src/effect-lattice.mjs
+++ b/packages/tf-l0-check/src/effect-lattice.mjs
@@ -14,6 +14,19 @@ export const CANONICAL_EFFECT_FAMILIES = Object.freeze([
   'UI'
 ]);
 
+export const EFFECT_PRECEDENCE = [
+  'Pure',
+  'Observability',
+  'Network.Out',
+  'Storage.Read',
+  'Storage.Write',
+  'Crypto',
+  'Policy',
+  'Infra',
+  'Time',
+  'UI'
+];
+
 const FAMILY_ALIASES = Object.freeze({
   'Time.Read': 'Time',
   'Time.Wait': 'Time',
@@ -104,7 +117,7 @@ export function canCommute(prevFamily, nextFamily) {
   }
 
   if (prev === 'Observability') {
-    return next === 'Observability';
+    return next === 'Observability' || next === 'Network.Out';
   }
 
   if (prev === 'Network.Out') {
@@ -112,6 +125,16 @@ export function canCommute(prevFamily, nextFamily) {
   }
 
   return false;
+}
+
+export function effectRank(family) {
+  const normalized = normalizeFamily(family);
+  const idx = EFFECT_PRECEDENCE.indexOf(normalized);
+  return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
+}
+
+export function commuteSymmetric(familyA, familyB) {
+  return canCommute(familyA, familyB) && canCommute(familyB, familyA);
 }
 
 export function parSafe(famA, famB, ctx = {}) {

--- a/packages/tf-l0-ir/src/normalize-commute.mjs
+++ b/packages/tf-l0-ir/src/normalize-commute.mjs
@@ -1,0 +1,107 @@
+import { effectOf, effectRank, commuteSymmetric } from '../../tf-l0-check/src/effect-lattice.mjs';
+
+export function normalizeByCommutation(ir, catalog) {
+  return visit(ir, catalog ?? {});
+}
+
+function visit(node, catalog) {
+  if (!node || typeof node !== 'object') {
+    return node;
+  }
+
+  if (node.node === 'Seq') {
+    const originalChildren = Array.isArray(node.children) ? node.children : [];
+    let changed = false;
+    const normalizedChildren = originalChildren.map((child) => {
+      const next = visit(child, catalog);
+      if (next !== child) {
+        changed = true;
+      }
+      return next;
+    });
+    const { nodes: reordered, changed: reorderedChanged } = reorderSequentialChildren(normalizedChildren, catalog);
+    if (reorderedChanged) {
+      changed = true;
+    }
+    if (!changed && !reorderedChanged) {
+      return node;
+    }
+    const resultChildren = reorderedChanged ? reordered : normalizedChildren;
+    return { ...node, children: resultChildren };
+  }
+
+  if (node.node === 'Par' || node.node === 'Region') {
+    const originalChildren = Array.isArray(node.children) ? node.children : [];
+    let changed = false;
+    const normalizedChildren = originalChildren.map((child) => {
+      const next = visit(child, catalog);
+      if (next !== child) {
+        changed = true;
+      }
+      return next;
+    });
+    if (!changed) {
+      return node;
+    }
+    return { ...node, children: normalizedChildren };
+  }
+
+  if (Array.isArray(node.children)) {
+    const originalChildren = node.children;
+    let changed = false;
+    const normalizedChildren = originalChildren.map((child) => {
+      const next = visit(child, catalog);
+      if (next !== child) {
+        changed = true;
+      }
+      return next;
+    });
+    if (!changed) {
+      return node;
+    }
+    return { ...node, children: normalizedChildren };
+  }
+
+  return node;
+}
+
+function reorderSequentialChildren(children, catalog) {
+  const nodes = children.slice();
+  let anySwapped = false;
+  if (nodes.length < 2) {
+    return { nodes, changed: false };
+  }
+
+  let passSwapped = false;
+  do {
+    passSwapped = false;
+    for (let i = 0; i < nodes.length - 1; i++) {
+      const a = nodes[i];
+      const b = nodes[i + 1];
+      if (!isPrim(a) || !isPrim(b)) {
+        continue;
+      }
+      const famA = effectOf(a.prim, catalog);
+      const famB = effectOf(b.prim, catalog);
+      if (!commuteSymmetric(famA, famB)) {
+        continue;
+      }
+      const rankA = effectRank(famA);
+      const rankB = effectRank(famB);
+      const primA = typeof a.prim === 'string' ? a.prim : '';
+      const primB = typeof b.prim === 'string' ? b.prim : '';
+      if (rankB < rankA || (rankB === rankA && primB < primA)) {
+        nodes[i] = b;
+        nodes[i + 1] = a;
+        passSwapped = true;
+        anySwapped = true;
+      }
+    }
+  } while (passSwapped);
+
+  return { nodes, changed: anySwapped };
+}
+
+function isPrim(node) {
+  return node && typeof node === 'object' && node.node === 'Prim' && typeof node.prim === 'string';
+}

--- a/packages/tf-l0-ir/src/normalize.mjs
+++ b/packages/tf-l0-ir/src/normalize.mjs
@@ -1,12 +1,15 @@
+import { normalizeByCommutation } from './normalize-commute.mjs';
+
 const KNOWN_PURE_PRIMS = new Set(['hash', 'serialize', 'deserialize']);
 
-export function canon(ir, laws = {}) {
-  const ctx = buildLawContext(laws);
-  return normalizeNode(ir, ctx);
+export function canon(ir, options = {}) {
+  const ctx = buildLawContext(options);
+  const normalized = normalizeNode(ir, ctx);
+  return normalizeByCommutation(normalized, options.catalog);
 }
 
-export function normalize(ir, laws = {}) {
-  return canon(ir, laws);
+export function normalize(ir, options = {}) {
+  return canon(ir, options);
 }
 
 function normalizeNode(ir, ctx) {

--- a/scripts/normalize-commute.mjs
+++ b/scripts/normalize-commute.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { normalize } from '../packages/tf-l0-ir/src/normalize.mjs';
 import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { canonicalize } from '../packages/tf-l0-ir/src/hash.mjs';
 
 function usage() {
   console.error('Usage: node scripts/normalize-commute.mjs <flow.tf|flow.ir.json> -o <output.ir.json>');
@@ -49,7 +50,7 @@ async function main() {
   const { input, output } = parseArgs(process.argv.slice(2));
   const ir = await loadIR(input);
   const normalized = normalize(ir);
-  const serialized = JSON.stringify(normalized, null, 2) + '\n';
+  const serialized = canonicalize(normalized) + '\n';
   await mkdir(path.dirname(output), { recursive: true });
   await writeFile(output, serialized, 'utf8');
 }

--- a/scripts/normalize-commute.mjs
+++ b/scripts/normalize-commute.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { normalize } from '../packages/tf-l0-ir/src/normalize.mjs';
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+
+function usage() {
+  console.error('Usage: node scripts/normalize-commute.mjs <flow.tf|flow.ir.json> -o <output.ir.json>');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  let input = null;
+  let output = null;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '-o') {
+      const next = argv[++i];
+      if (!next) {
+        usage();
+      }
+      output = next;
+    } else if (!input) {
+      input = arg;
+    } else {
+      usage();
+    }
+  }
+  if (!input || !output) {
+    usage();
+  }
+  return { input, output };
+}
+
+async function loadIR(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  if (filePath.endsWith('.ir.json')) {
+    return JSON.parse(raw);
+  }
+  if (filePath.endsWith('.tf')) {
+    return parseDSL(raw);
+  }
+  console.error('Input must be a .tf or .ir.json file');
+  process.exit(2);
+}
+
+async function main() {
+  const { input, output } = parseArgs(process.argv.slice(2));
+  const ir = await loadIR(input);
+  const normalized = normalize(ir);
+  const serialized = JSON.stringify(normalized, null, 2) + '\n';
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, serialized, 'utf8');
+}
+
+await main();

--- a/tests/effect-lattice.test.mjs
+++ b/tests/effect-lattice.test.mjs
@@ -38,8 +38,8 @@ test('Observability does not commute with Storage.Write', () => {
   assert.equal(canCommute('Observability', 'Storage.Write'), false);
 });
 
-test('Observability does not commute with Network.Out', () => {
-  assert.equal(canCommute('Observability', 'Network.Out'), false);
+test('Observability commutes with Network.Out', () => {
+  assert.equal(canCommute('Observability', 'Network.Out'), true);
 });
 
 // Network.Out commutation cases

--- a/tests/normalize-commute.test.mjs
+++ b/tests/normalize-commute.test.mjs
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { normalize } = await import('../packages/tf-l0-ir/src/normalize.mjs');
+
+function prim(id) {
+  return { node: 'Prim', prim: id };
+}
+
+function seq(children) {
+  return { node: 'Seq', children };
+}
+
+test('Pure stays ordered before Observability', () => {
+  const input = seq([
+    prim('tf:pure/identity@1'),
+    prim('tf:observability/emit-metric@1')
+  ]);
+  const output = normalize(input);
+  assert.deepEqual(output, input);
+});
+
+test('Observability bubbles ahead of Pure neighbor', () => {
+  const input = seq([
+    prim('tf:observability/emit-metric@1'),
+    prim('tf:pure/identity@1')
+  ]);
+  const expected = seq([
+    prim('tf:pure/identity@1'),
+    prim('tf:observability/emit-metric@1')
+  ]);
+  const output = normalize(input);
+  assert.deepEqual(output, expected);
+});
+
+test('Network.Out settles after Observability when commuting', () => {
+  const forward = seq([
+    prim('tf:observability/emit-metric@1'),
+    prim('tf:network/publish@1')
+  ]);
+  const reverse = seq([
+    prim('tf:network/publish@1'),
+    prim('tf:observability/emit-metric@1')
+  ]);
+  const expected = normalize(forward);
+  assert.deepEqual(expected, seq([
+    prim('tf:observability/emit-metric@1'),
+    prim('tf:network/publish@1')
+  ]));
+  const reordered = normalize(reverse);
+  assert.deepEqual(reordered, expected);
+});
+
+test('Storage.Write remains a barrier for reordering', () => {
+  const input = seq([
+    prim('tf:storage/write-object@1'),
+    prim('tf:observability/emit-metric@1')
+  ]);
+  const output = normalize(input);
+  assert.deepEqual(output, input);
+});
+
+test('Region boundary prevents commuting across', () => {
+  const input = {
+    node: 'Seq',
+    children: [
+      {
+        node: 'Region',
+        children: [prim('tf:observability/emit-metric@1')]
+      },
+      prim('tf:network/publish@1')
+    ]
+  };
+  const output = normalize(input);
+  assert.deepEqual(output, input);
+});
+
+test('Normalization is stable under repeated application', () => {
+  const input = seq([
+    prim('tf:network/publish@1'),
+    prim('tf:observability/emit-metric@1'),
+    prim('tf:pure/identity@1')
+  ]);
+  const once = normalize(input);
+  const twice = normalize(once);
+  assert.deepEqual(once, twice);
+  assert.equal(JSON.stringify(once), JSON.stringify(twice));
+});


### PR DESCRIPTION
## Summary
- expose effect precedence, symmetric observability/network commutation, and ranking helpers from the lattice for reuse in normalization
- add a lattice-guided local commutation pass to the normalizer and wire it into the CLI plus a helper script
- document the pass and add focused tests covering commuting pairs, barriers, and fixpoint stability

## Testing
- `pnpm -w -r build`
- `pnpm -w -r test` *(fails: existing rust codegen scaffold assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d01850b8a48320b1f5352d90ac3c00