### PR TITLE
Add L0 proof artifact workflow and docs

### DIFF
--- a/.github/workflows/l0-proofs.yml
+++ b/.github/workflows/l0-proofs.yml
@@ -1,21 +1,16 @@
-name: L0 proof artifacts
+name: L0 Proof Artifacts
 
 on:
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   emit:
-    name: Emit L0 proofs
     runs-on: ubuntu-latest
-    continue-on-error: true
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm + Node
-        uses: ./.github/actions/setup-pnpm
+      - uses: ./.github/actions/setup-pnpm
         with:
           node-version: '20'
           install: 'true'
@@ -24,25 +19,24 @@ jobs:
             pnpm-lock.yaml
             **/pnpm-lock.yaml
 
-      - name: Prepare catalogs (A0/A1)
+      - name: A0/A1 + build
         run: |
           pnpm run a0
           pnpm run a1
+          pnpm -w -r build
 
-      - name: Emit SMT encodings
+      - name: Emit proof artifacts
+        run: node scripts/proofs-emit-all.mjs
+
+      - name: List artifacts
         run: |
-          node scripts/emit-smt.mjs examples/flows/storage_conflict.tf -o out/0.4/proofs/storage_conflict.smt2
-          node scripts/emit-smt.mjs examples/flows/storage_ok.tf -o out/0.4/proofs/storage_ok.smt2
+          echo "::group::proof files"
+          find out/0.4/proofs -maxdepth 3 -type f -print
+          echo "::endgroup::"
 
-      - name: Emit Alloy models
-        run: |
-          node scripts/emit-alloy.mjs examples/flows/storage_conflict.tf -o out/0.4/proofs/storage_conflict.als
-          node scripts/emit-alloy.mjs examples/flows/storage_ok.tf -o out/0.4/proofs/storage_ok.als
-
-      - name: Upload artifacts
+      - name: Upload proof artifacts
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
           name: l0-proofs
           path: out/0.4/proofs/**
-          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "a1:all": "pnpm run a1 && pnpm run a1:summary",
     "a5:lattice-report": "node scripts/lattice-report.mjs && jq . out/0.4/check/lattice-report.json",
     "a4:demo": "node scripts/types-demo.mjs && cat out/0.4/check/types-demo.json | node -e \"process.stdout.write(require('fs').readFileSync(0,'utf8'))\"",
+    "proofs:emit": "node scripts/proofs-emit-all.mjs",
     "proofs:laws:axioms": "node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2 && node scripts/emit-smt-laws.mjs --law inverse:serialize-deserialize -o out/0.4/proofs/laws/inverse_roundtrip.smt2 && node scripts/emit-smt-laws.mjs --law commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute.smt2",
     "proofs:laws:equiv": "node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2",
     "tf": "node packages/tf-compose/bin/tf.mjs",

--- a/scripts/proofs-emit-all.mjs
+++ b/scripts/proofs-emit-all.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const root = join(__dir, '..');
+const out = join(root, 'out', '0.4', 'proofs');
+mkdirSync(out, { recursive: true });
+
+function sh(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', cwd: root, ...opts });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function emit(label, script, args) {
+  const target = join(out, label);
+  mkdirSync(dirname(target), { recursive: true });
+  sh('node', [script, ...args, '-o', target]);
+}
+
+emit('storage_conflict.als', 'scripts/emit-alloy.mjs', ['examples/flows/storage_conflict.tf']);
+emit('storage_ok.als', 'scripts/emit-alloy.mjs', ['examples/flows/storage_ok.tf']);
+
+emit('storage_conflict.smt2', 'scripts/emit-smt.mjs', ['examples/flows/storage_conflict.tf']);
+emit('storage_ok.smt2', 'scripts/emit-smt.mjs', ['examples/flows/storage_ok.tf']);
+
+emit('laws/idempotent_hash.smt2', 'scripts/emit-smt-laws.mjs', ['--law', 'idempotent:hash']);
+emit('laws/inverse_roundtrip.smt2', 'scripts/emit-smt-laws.mjs', ['--law', 'inverse:serialize-deserialize']);
+emit('laws/emit_commute.smt2', 'scripts/emit-smt-laws.mjs', ['--law', 'commute:emit-metric-with-pure']);
+
+emit('props/storage_conflict.smt2', 'scripts/emit-smt-props.mjs', ['par-safety', 'examples/flows/storage_conflict.tf']);
+emit('props/obs_pure_equiv.smt2', 'scripts/emit-smt-props.mjs', ['commute', 'examples/flows/obs_pure_EP.tf', 'examples/flows/obs_pure_PE.tf']);
+
+writeFileSync(
+  join(out, 'index.json'),
+  JSON.stringify(
+    {
+      generated: new Date(0).toISOString(),
+      files: [
+        'storage_conflict.als',
+        'storage_ok.als',
+        'storage_conflict.smt2',
+        'storage_ok.smt2',
+        'laws/idempotent_hash.smt2',
+        'laws/inverse_roundtrip.smt2',
+        'laws/emit_commute.smt2',
+        'props/storage_conflict.smt2',
+        'props/obs_pure_equiv.smt2'
+      ]
+    }
+  ) + '\n'
+);


### PR DESCRIPTION
## Summary
- add a PR workflow that builds the workspace and uploads deterministic proof artifacts
- create a helper script that emits Alloy, SMT structural, law, and property proofs with a stable index
- document the proof artifact layout, CI flow, and local generation steps

## Testing
- pnpm -w -r build
- node scripts/proofs-emit-all.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d024845ef083208965ca60cbc03162