### PR TITLE
Add pilot minimal flow pipeline

### DIFF
--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -1,0 +1,28 @@
+# Pilot L0 Flow
+
+This pilot sketch uses existing DSL primitives to illustrate a minimal replay → execution → ledger write pipeline.
+
+## Flow overview
+
+The flow defined in `examples/flows/pilot_min.tf` emits a start metric, publishes an order message, records an execution metric, writes a ledger entry, and finishes with a ledger metric. It only uses string and numeric arguments to stay within the minimal DSL surface.
+
+## Running the pilot
+
+```sh
+node scripts/pilot-min.mjs
+cat out/0.4/pilot-l0/status.json
+cat out/0.4/pilot-l0/summary.json
+```
+
+The runner script creates IR, canonical form, and manifest artifacts, generates TypeScript code, produces capability gates, and executes the generated flow. Status and trace data are written under `out/0.4/pilot-l0/`.
+
+## Capabilities
+
+Execution requires the following capabilities:
+
+- `Network.Out`
+- `Storage.Write`
+- `Observability`
+- `Pure`
+
+Writes are allowed for resources prefixed by `res://ledger/` and `res://kv/`.

--- a/examples/flows/pilot_min.tf
+++ b/examples/flows/pilot_min.tf
@@ -1,0 +1,7 @@
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}

--- a/scripts/pilot-min.mjs
+++ b/scripts/pilot-min.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dir, '..', 'out', '0.4', 'pilot-l0');
+mkdirSync(outDir, { recursive: true });
+
+// 1) Parse, check, canon, manifest
+const irPath    = join(outDir, 'pilot_min.ir.json');
+const canonPath = join(outDir, 'pilot_min.canon.json');
+const manPath   = join(outDir, 'pilot_min.manifest.json');
+
+function sh(cmd, args, opts={}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+sh('node', ['packages/tf-compose/bin/tf.mjs','parse','examples/flows/pilot_min.tf','-o', irPath]);
+sh('node', ['packages/tf-compose/bin/tf.mjs','canon','examples/flows/pilot_min.tf','-o', canonPath]);
+sh('node', ['packages/tf-compose/bin/tf-manifest.mjs','examples/flows/pilot_min.tf','-o', manPath]);
+
+// 2) Generate TS + caps
+const genDir = join(outDir, 'codegen-ts', 'pilot_min');
+mkdirSync(genDir, { recursive: true });
+sh('node', ['packages/tf-compose/bin/tf.mjs','emit','--lang','ts','examples/flows/pilot_min.tf','--out', genDir]);
+
+const caps = {
+  effects: ['Network.Out','Storage.Write','Observability','Pure'],
+  allow_writes_prefixes: ['res://ledger/','res://kv/']
+};
+writeFileSync(join(genDir,'caps.json'), JSON.stringify(caps) + '\n');
+
+// 3) Run with status + trace + summarize
+const statusPath = join(outDir, 'status.json');
+const tracePath  = join(outDir, 'trace.jsonl');
+const summaryPath= join(outDir, 'summary.json');
+
+const env = { ...process.env, TF_STATUS_PATH: statusPath, TF_TRACE_PATH: tracePath };
+sh('node', [join(genDir,'run.mjs'),'--caps', join(genDir,'caps.json')], { env });
+
+const trace = readFileSync(tracePath, 'utf8');
+if (!trace.trim()) {
+  console.error('empty trace?'); process.exit(1);
+}
+const summary = spawnSync('node', ['packages/tf-l0-tools/trace-summary.mjs'], {
+  input: trace, encoding: 'utf8'
+});
+if (summary.status !== 0) process.exit(summary.status ?? 1);
+writeFileSync(summaryPath, summary.stdout.endsWith('\n') ? summary.stdout : summary.stdout + '\n');
+
+console.log(`wrote status=${statusPath} trace=${tracePath} summary=${summaryPath}`);

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+test('pilot_min flow runs and summarizes', () => {
+  const r = spawnSync('node', ['scripts/pilot-min.mjs'], { stdio: 'inherit' });
+  assert.equal(r.status, 0);
+
+  const status = JSON.parse(readFileSync('out/0.4/pilot-l0/status.json','utf8'));
+  const summary= JSON.parse(readFileSync('out/0.4/pilot-l0/summary.json','utf8'));
+
+  assert.equal(status.ok, true);
+  assert.ok(status.ops >= 2);
+  assert.ok(Array.isArray(status.effects));
+  // At least these effects should appear
+  assert.ok(status.effects.includes('Network.Out'));
+  assert.ok(status.effects.includes('Storage.Write'));
+
+  // Summary sanity
+  assert.ok(summary.total >= 2);
+  assert.ok(summary.by_prim['tf:network/publish@1'] >= 1);
+});


### PR DESCRIPTION
## Summary
- add a minimal pilot flow that exercises metric, publish, and ledger primitives
- add a runner that generates IR, TypeScript, and capability artifacts then executes under caps
- document and test the pilot flow end-to-end

## Testing
- pnpm -w -r build
- pnpm -w -r test
- node scripts/pilot-min.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d0249aa8748320a887a44c80b88f62