### PR TITLE
Add pilot minimal flow and runner

### DIFF
--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -1,0 +1,37 @@
+# Pilot L0 Flow
+
+This pilot flow sketches a minimal replay → exec → ledger sequence using only the existing DSL primitives. The `pilot_min` flow emits metrics to mark the replay start, publishes a single order message, records execution sent, writes a ledger entry, and records the ledger write.
+
+## Flow
+
+```
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}
+```
+
+## How to run
+
+```
+node scripts/pilot-min.mjs
+cat out/0.4/pilot-l0/status.json
+cat out/0.4/pilot-l0/summary.json
+```
+
+The generated artifacts also include the IR (`pilot_min.ir.json`), canonical form (`pilot_min.canon.json`), manifest (`pilot_min.manifest.json`), trace (`trace.jsonl`), and generated TypeScript (`out/0.4/pilot-l0/codegen-ts/pilot_min`).
+
+## Capability requirements
+
+The run requires the following capabilities:
+
+- `Network.Out`
+- `Storage.Write`
+- `Observability`
+- `Pure`
+
+Writes are allowed under the `res://ledger/` prefix. The generated manifest also declares a seed footprint under `res://kv/`, so
+the provided caps file permits both prefixes.

--- a/examples/flows/pilot_min.tf
+++ b/examples/flows/pilot_min.tf
@@ -1,0 +1,7 @@
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}

--- a/scripts/pilot-min.mjs
+++ b/scripts/pilot-min.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dir, '..', 'out', '0.4', 'pilot-l0');
+mkdirSync(outDir, { recursive: true });
+
+// 1) Parse, check, canon, manifest
+const irPath    = join(outDir, 'pilot_min.ir.json');
+const canonPath = join(outDir, 'pilot_min.canon.json');
+const manPath   = join(outDir, 'pilot_min.manifest.json');
+
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'parse', 'examples/flows/pilot_min.tf', '-o', irPath]);
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'canon', 'examples/flows/pilot_min.tf', '-o', canonPath]);
+sh('node', ['packages/tf-compose/bin/tf-manifest.mjs', 'examples/flows/pilot_min.tf', '-o', manPath]);
+
+// 2) Generate TS + caps
+const genDir = join(outDir, 'codegen-ts', 'pilot_min');
+mkdirSync(genDir, { recursive: true });
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'emit', '--lang', 'ts', 'examples/flows/pilot_min.tf', '--out', genDir]);
+
+const caps = {
+  effects: ['Network.Out', 'Storage.Write', 'Observability', 'Pure'],
+  allow_writes_prefixes: ['res://ledger/', 'res://kv/']
+};
+writeFileSync(join(genDir, 'caps.json'), JSON.stringify(caps) + '\n');
+
+// 3) Run with status + trace + summarize
+const statusPath = join(outDir, 'status.json');
+const tracePath = join(outDir, 'trace.jsonl');
+const summaryPath = join(outDir, 'summary.json');
+
+const env = { ...process.env, TF_STATUS_PATH: statusPath, TF_TRACE_PATH: tracePath };
+sh('node', [join(genDir, 'run.mjs'), '--caps', join(genDir, 'caps.json')], { env });
+
+const trace = readFileSync(tracePath, 'utf8');
+if (!trace.trim()) {
+  console.error('empty trace?');
+  process.exit(1);
+}
+const summary = spawnSync('node', ['packages/tf-l0-tools/trace-summary.mjs'], {
+  input: trace,
+  encoding: 'utf8'
+});
+if (summary.status !== 0) process.exit(summary.status ?? 1);
+writeFileSync(summaryPath, summary.stdout.endsWith('\n') ? summary.stdout : summary.stdout + '\n');
+
+console.log(`wrote status=${statusPath} trace=${tracePath} summary=${summaryPath}`);

--- a/tests/fixtures/caps-pilot.json
+++ b/tests/fixtures/caps-pilot.json
@@ -1,0 +1,4 @@
+{
+  "effects": ["Network.Out", "Storage.Write", "Observability", "Pure"],
+  "allow_writes_prefixes": ["res://ledger/", "res://kv/"]
+}

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+test('pilot_min flow runs and summarizes', () => {
+  const r = spawnSync('node', ['scripts/pilot-min.mjs'], { stdio: 'inherit' });
+  assert.equal(r.status, 0);
+
+  const status = JSON.parse(readFileSync('out/0.4/pilot-l0/status.json', 'utf8'));
+  const summary = JSON.parse(readFileSync('out/0.4/pilot-l0/summary.json', 'utf8'));
+
+  assert.equal(status.ok, true);
+  assert.ok(status.ops >= 2);
+  assert.ok(Array.isArray(status.effects));
+  // At least these effects should appear
+  assert.ok(status.effects.includes('Network.Out'));
+  assert.ok(status.effects.includes('Storage.Write'));
+
+  // Summary sanity
+  assert.ok(summary.total >= 2);
+  assert.ok(summary.by_prim['tf:network/publish@1'] >= 1);
+});


### PR DESCRIPTION
## Summary
- add a minimal pilot seq flow sketching replay, publish, ledger write metrics
- provide a runner script that emits IR/canon/manifest, codegens TS, runs under caps, and writes status/trace/summary
- document the flow and add an integration test and caps fixture

## Testing
- `pnpm -w -r build`
- `pnpm -w -r test`
- `node scripts/pilot-min.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68d0249aa8748320a887a44c80b88f62