### PR TITLE
Add pilot minimal flow and runner

### DIFF
--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -1,0 +1,31 @@
+# Pilot L0 Flow Sketch
+
+This pilot demonstrates a minimal replay → execution → ledger flow using only existing DSL primitives.
+
+## Flow
+
+```
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}
+```
+
+Stages:
+
+1. **Replay** — Start by emitting a metric signalling replay kickoff.
+2. **Execution** — Publish a simple order payload on the `orders` topic, followed by a metric confirming the send.
+3. **Ledger** — Write the fulfillment status to the ledger resource and emit a final metric capturing the ledger write.
+
+## How to run
+
+```sh
+node scripts/pilot-min.mjs
+cat out/0.4/pilot-l0/status.json
+cat out/0.4/pilot-l0/summary.json
+```
+
+The run produces IR, canonical form, manifest, generated TypeScript, capability manifest, execution status, trace, and a summarized view. Capability gating requires the following effects: `Network.Out`, `Storage.Write`, `Observability`, and `Pure`, with writes permitted under the `res://ledger/` and `res://kv/` prefixes.

--- a/examples/flows/pilot_min.tf
+++ b/examples/flows/pilot_min.tf
@@ -1,0 +1,7 @@
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}

--- a/scripts/pilot-min.mjs
+++ b/scripts/pilot-min.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dir, '..', 'out', '0.4', 'pilot-l0');
+mkdirSync(outDir, { recursive: true });
+
+// 1) Parse, check, canon, manifest
+const irPath = join(outDir, 'pilot_min.ir.json');
+const canonPath = join(outDir, 'pilot_min.canon.json');
+const manPath = join(outDir, 'pilot_min.manifest.json');
+
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'parse', 'examples/flows/pilot_min.tf', '-o', irPath]);
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'canon', 'examples/flows/pilot_min.tf', '-o', canonPath]);
+sh('node', ['packages/tf-compose/bin/tf-manifest.mjs', 'examples/flows/pilot_min.tf', '-o', manPath]);
+
+// 2) Generate TS + caps
+const genDir = join(outDir, 'codegen-ts', 'pilot_min');
+mkdirSync(genDir, { recursive: true });
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'emit', '--lang', 'ts', 'examples/flows/pilot_min.tf', '--out', genDir]);
+
+const caps = {
+  effects: ['Network.Out', 'Storage.Write', 'Observability', 'Pure'],
+  allow_writes_prefixes: ['res://ledger/', 'res://kv/']
+};
+writeFileSync(join(genDir, 'caps.json'), JSON.stringify(caps) + '\n');
+
+// 3) Run with status + trace + summarize
+const statusPath = join(outDir, 'status.json');
+const tracePath = join(outDir, 'trace.jsonl');
+const summaryPath = join(outDir, 'summary.json');
+
+const env = { ...process.env, TF_STATUS_PATH: statusPath, TF_TRACE_PATH: tracePath };
+sh('node', [join(genDir, 'run.mjs'), '--caps', join(genDir, 'caps.json')], { env });
+
+const trace = readFileSync(tracePath, 'utf8');
+if (!trace.trim()) {
+  console.error('empty trace?');
+  process.exit(1);
+}
+const summary = spawnSync('node', ['packages/tf-l0-tools/trace-summary.mjs'], {
+  input: trace,
+  encoding: 'utf8'
+});
+if (summary.status !== 0) process.exit(summary.status ?? 1);
+writeFileSync(summaryPath, summary.stdout.endsWith('\n') ? summary.stdout : summary.stdout + '\n');
+
+console.log(`wrote status=${statusPath} trace=${tracePath} summary=${summaryPath}`);

--- a/tests/fixtures/caps-pilot.json
+++ b/tests/fixtures/caps-pilot.json
@@ -1,0 +1,4 @@
+{
+  "effects": ["Network.Out", "Storage.Write", "Observability", "Pure"],
+  "allow_writes_prefixes": ["res://ledger/", "res://kv/"]
+}

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { strict as assert } from 'node:assert';
+
+test('pilot_min flow runs and summarizes', () => {
+  const r = spawnSync('node', ['scripts/pilot-min.mjs'], { stdio: 'inherit' });
+  assert.equal(r.status, 0);
+
+  const status = JSON.parse(readFileSync('out/0.4/pilot-l0/status.json', 'utf8'));
+  const summary = JSON.parse(readFileSync('out/0.4/pilot-l0/summary.json', 'utf8'));
+
+  assert.equal(status.ok, true);
+  assert.ok(status.ops >= 2);
+  assert.ok(Array.isArray(status.effects));
+  assert.ok(status.effects.includes('Network.Out'));
+  assert.ok(status.effects.includes('Storage.Write'));
+
+  assert.ok(summary.total >= 2);
+  assert.ok(summary.by_prim['tf:network/publish@1'] >= 1);
+});


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

> Fill all sections. CI will fail if required headings are missing.

## Summary
- Scope: pilot-l0
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [ ] CI wiring + determinism re-run
- Added a minimal replay → execution → ledger flow plus runner, docs, and tests for the pilot slice.

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`

## Determinism & Seeds
- Repeats: 1
- Seeds: N/A
- Notes: Pilot runner script emits stable IR, canon, manifest, status, trace, and summary artifacts.

## Tests & CI
- TS tests: passed 128 / failed 0 (`pnpm -w -r test`)
- Rust tests: not run (N/A)
- CI jobs: N/A (local execution only)

## Implementation Notes
- ABI / paths unchanged? Y (new flow, script, docs, fixture, and test only)
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`, Rust panic-free

## Hurdles / Follow-ups
- Known gaps: None identified
- Suggested next steps: Expand pilot coverage once additional DSL features are available

------
https://chatgpt.com/codex/tasks/task_e_68d0249aa8748320a887a44c80b88f62