### PR TITLE
Add pilot minimal flow and runner

### DIFF
--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -1,0 +1,29 @@
+# Pilot L0 Flow Sketch
+
+This pilot sketch walks through a minimal replay → exec → ledger sequence using the existing TF primitives.
+
+```
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}
+```
+
+## Stages
+
+- **Replay** — `emit-metric` announces the replay start (`pilot.replay.start`).
+- **Exec** — `publish` forwards an `orders` topic message for key `o-1` and records the dispatch via `emit-metric` (`pilot.exec.sent`).
+- **Ledger** — `write-object` records the fill result under `res://ledger/pilot`, followed by a final `emit-metric` (`pilot.ledger.write`).
+
+## How to Run
+
+```
+node scripts/pilot-min.mjs
+cat out/0.4/pilot-l0/status.json
+cat out/0.4/pilot-l0/summary.json
+```
+
+The capability guard needs `Network.Out`, `Storage.Write`, `Observability`, and `Pure`, with writes allowed under `res://ledger/`.

--- a/examples/flows/pilot_min.tf
+++ b/examples/flows/pilot_min.tf
@@ -1,0 +1,7 @@
+seq{
+  emit-metric(name="pilot.replay.start");
+  publish(topic="orders", key="o-1", payload="{\"sym\":\"ABC\",\"side\":\"buy\",\"qty\":1}");
+  emit-metric(name="pilot.exec.sent");
+  write-object(uri="res://ledger/pilot", key="o-1", value="filled");
+  emit-metric(name="pilot.ledger.write")
+}

--- a/scripts/pilot-min.mjs
+++ b/scripts/pilot-min.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dir, '..', 'out', '0.4', 'pilot-l0');
+mkdirSync(outDir, { recursive: true });
+
+// 1) Parse, check, canon, manifest
+const irPath    = join(outDir, 'pilot_min.ir.json');
+const canonPath = join(outDir, 'pilot_min.canon.json');
+const manPath   = join(outDir, 'pilot_min.manifest.json');
+
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'parse', 'examples/flows/pilot_min.tf', '-o', irPath]);
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'canon', 'examples/flows/pilot_min.tf', '-o', canonPath]);
+sh('node', ['packages/tf-compose/bin/tf-manifest.mjs', 'examples/flows/pilot_min.tf', '-o', manPath]);
+
+const manifest = JSON.parse(readFileSync(manPath, 'utf8'));
+const fixUri = (entry) => {
+  if (!entry || typeof entry !== 'object') return entry;
+  if (typeof entry.uri === 'string' && entry.uri.startsWith('res://ledger/')) return entry;
+  return { ...entry, uri: 'res://ledger/pilot/:<key>' };
+};
+if (Array.isArray(manifest.footprints)) {
+  manifest.footprints = manifest.footprints.map(fixUri);
+}
+if (manifest.footprints_rw && Array.isArray(manifest.footprints_rw.writes)) {
+  manifest.footprints_rw = {
+    ...manifest.footprints_rw,
+    writes: manifest.footprints_rw.writes.map(fixUri),
+  };
+}
+writeFileSync(manPath, JSON.stringify(manifest, null, 2) + '\n');
+
+// 2) Generate TS + caps
+const genDir = join(outDir, 'codegen-ts', 'pilot_min');
+mkdirSync(genDir, { recursive: true });
+sh('node', ['packages/tf-compose/bin/tf.mjs', 'emit', '--lang', 'ts', 'examples/flows/pilot_min.tf', '--out', genDir]);
+
+const runPath = join(genDir, 'run.mjs');
+const runSrc = readFileSync(runPath, 'utf8');
+const manifestLiteral = `const MANIFEST = ${JSON.stringify(manifest)};`;
+const updatedRun = runSrc.replace(/const MANIFEST = .*?;\n/s, `${manifestLiteral}\n`);
+if (updatedRun === runSrc) {
+  console.warn('pilot-min: unable to update manifest literal in run.mjs');
+} else {
+  writeFileSync(runPath, updatedRun);
+}
+
+const caps = {
+  effects: ['Network.Out', 'Storage.Write', 'Observability', 'Pure'],
+  allow_writes_prefixes: ['res://ledger/']
+};
+writeFileSync(join(genDir, 'caps.json'), JSON.stringify(caps) + '\n');
+
+// 3) Run with status + trace + summarize
+const statusPath = join(outDir, 'status.json');
+const tracePath = join(outDir, 'trace.jsonl');
+const summaryPath = join(outDir, 'summary.json');
+
+const env = { ...process.env, TF_STATUS_PATH: statusPath, TF_TRACE_PATH: tracePath };
+sh('node', [join(genDir, 'run.mjs'), '--caps', join(genDir, 'caps.json')], { env });
+
+const trace = readFileSync(tracePath, 'utf8');
+if (!trace.trim()) {
+  console.error('empty trace?');
+  process.exit(1);
+}
+const summary = spawnSync('node', ['packages/tf-l0-tools/trace-summary.mjs'], {
+  input: trace,
+  encoding: 'utf8'
+});
+if (summary.status !== 0) process.exit(summary.status ?? 1);
+writeFileSync(summaryPath, summary.stdout.endsWith('\n') ? summary.stdout : summary.stdout + '\n');
+
+console.log(`wrote status=${statusPath} trace=${tracePath} summary=${summaryPath}`);

--- a/tests/fixtures/caps-pilot.json
+++ b/tests/fixtures/caps-pilot.json
@@ -1,0 +1,4 @@
+{
+  "effects": ["Network.Out", "Storage.Write", "Observability", "Pure"],
+  "allow_writes_prefixes": ["res://ledger/"]
+}

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+test('pilot_min flow runs and summarizes', () => {
+  const r = spawnSync('node', ['scripts/pilot-min.mjs'], { stdio: 'inherit' });
+  assert.equal(r.status, 0);
+
+  const status = JSON.parse(readFileSync('out/0.4/pilot-l0/status.json', 'utf8'));
+  const summary = JSON.parse(readFileSync('out/0.4/pilot-l0/summary.json', 'utf8'));
+
+  assert.equal(status.ok, true);
+  assert.ok(status.ops >= 2);
+  assert.ok(Array.isArray(status.effects));
+  assert.ok(status.effects.includes('Network.Out'));
+  assert.ok(status.effects.includes('Storage.Write'));
+
+  assert.ok(summary.total >= 2);
+  assert.ok(summary.by_prim['tf:network/publish@1'] >= 1);
+});


### PR DESCRIPTION
## Summary
- Scope: pilot_min L0 sketch
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [ ] CI wiring + determinism re-run
  - [x] Documented and exercised the pilot minimal flow with status/trace artifacts

## Evidence (artifacts)
- [x] `out/0.4/pilot-l0/status.json`
- [x] `out/0.4/pilot-l0/summary.json`
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`

## Determinism & Seeds
- Repeats: 1
- Seeds: N/A
- Notes: Minimal pilot flow uses deterministic tf-compose outputs

## Tests & CI
- TS tests: passed 128 / failed 0
- Rust tests: passed 0 / failed 0 (not executed)
- CI jobs: not run (local)

## Implementation Notes
- ABI / paths unchanged? Y (example + scripts only)
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`

## Hurdles / Follow-ups
- Known gaps: Manifest heuristics still seed generic KV URI and require manual override in script
- Suggested next steps: Extend pilot coverage once DSL v1.1 features are available


------
https://chatgpt.com/codex/tasks/task_e_68d0249aa8748320a887a44c80b88f62