### PR TITLE
Add deterministic pilot parity harness

### DIFF
--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -36,3 +36,21 @@ cat out/0.4/pilot-l0/summary.json
 ```
 
 The run produces IR, canonical form, manifest, generated TypeScript, capability manifest, execution status, trace, and a summarized view. Capability gating requires the following effects: `Network.Out`, `Storage.Write`, `Observability`, and `Pure`, with writes permitted under the `res://ledger/` prefix.
+
+## Parity harness
+
+A deterministic build harness is available via:
+
+```sh
+pnpm run pilot:build-run
+pnpm run pilot:manual
+pnpm run pilot:parity
+```
+
+The `pilot:build-run` script parses the flow, regenerates the TypeScript runner, executes it with a fixed clock, and materializes status, trace, summary, and digest artifacts under `out/0.4/pilot-l0/`. The `pilot:manual` script replays the same effects using the in-memory adapters to produce a minimal handwritten baseline. `pilot:parity` compares the generated and handwritten artifacts and fails fast when any digest diverges.
+
+To run the full loop in one go use:
+
+```sh
+pnpm run pilot:all
+```

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "graph:signing": "node scripts/graph-ir.mjs out/0.4/ir/signing.ir.json out/0.4/graphs/signing.dot",
     "contracts:baseline:capture": "node scripts/baseline-capture.mjs",
     "contracts:check-breaking": "node scripts/check-breaking.mjs",
+    "pilot:build-run": "node scripts/pilot-build-run.mjs",
+    "pilot:manual": "node scripts/pilot-handwritten.mjs",
+    "pilot:parity": "node scripts/pilot-parity.mjs",
+    "pilot:all": "pnpm run pilot:build-run && pnpm run pilot:manual && pnpm run pilot:parity",
     "policy:auth": "node packages/tf-compose/bin/tf-policy-auth.mjs",
     "policy:auth:samples": "node -e \"(async()=>{const {spawnSync}=require('node:child_process');const runs=[['ok','examples/flows/auth_ok.tf'],['wrong','examples/flows/auth_wrong_scope.tf'],['missing','examples/flows/auth_missing.tf']];for(const [label,file] of runs){const r=spawnSync('node',['packages/tf-compose/bin/tf-policy-auth.mjs','--','check',file],{stdio:'inherit'}); if(r.status!==0) console.error(`[auth smoke] ${label} -> nonzero (expected for wrong/missing)`);} process.exit(0)})();\""
   },

--- a/scripts/hash-jsonl.mjs
+++ b/scripts/hash-jsonl.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { basename, resolve } from 'node:path';
+
+export function canonicalize(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalize(entry));
+  }
+  const out = {};
+  for (const key of Object.keys(value).sort()) {
+    const next = canonicalize(value[key]);
+    if (next !== undefined) {
+      out[key] = next;
+    }
+  }
+  return out;
+}
+
+export function canonicalStringify(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function hashCanonicalString(text) {
+  const hash = createHash('sha256');
+  hash.update(text);
+  return `sha256:${hash.digest('hex')}`;
+}
+
+export function hashJsonText(text, { jsonl = false } = {}) {
+  if (!jsonl) {
+    const data = text.trim();
+    if (!data) {
+      return hashCanonicalString('');
+    }
+    const value = JSON.parse(data);
+    return hashCanonicalString(canonicalStringify(value));
+  }
+
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const canonical = lines.map((line) => {
+    const value = JSON.parse(line);
+    return canonicalStringify(value);
+  });
+  return hashCanonicalString(canonical.join('\n'));
+}
+
+export function hashJsonFile(path, opts = {}) {
+  const raw = readFileSync(path, 'utf8');
+  const jsonl = Object.prototype.hasOwnProperty.call(opts, 'jsonl') ? opts.jsonl : path.endsWith('.jsonl');
+  return hashJsonText(raw, { jsonl });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error(`usage: node ${basename(fileURLToPath(import.meta.url))} <file> [--jsonl]`);
+    process.exit(1);
+  }
+  const flags = new Set(args.slice(1));
+  const jsonl = flags.has('--jsonl');
+  const file = args[0];
+  try {
+    const digest = hashJsonFile(file, { jsonl });
+    console.log(digest);
+  } catch (err) {
+    console.error(err?.message ?? err);
+    process.exit(1);
+  }
+}

--- a/scripts/pilot-build-run.mjs
+++ b/scripts/pilot-build-run.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, readFileSync, rmSync, cpSync } from 'node:fs';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { canonicalize, canonicalStringify, hashJsonFile } from './hash-jsonl.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const workdir = process.env.TF_PILOT_WORKDIR;
+const outRoot = workdir
+  ? (isAbsolute(workdir) ? workdir : join(root, workdir))
+  : join(root, 'out', '0.4');
+const pilotDir = join(outRoot, 'pilot-l0');
+const codegenDir = join(pilotDir, 'codegen-ts', 'pilot_min');
+const goldenDir = join(pilotDir, 'golden');
+
+rmSync(pilotDir, { recursive: true, force: true });
+mkdirSync(codegenDir, { recursive: true });
+mkdirSync(goldenDir, { recursive: true });
+
+const tfCli = join(root, 'packages', 'tf-compose', 'bin', 'tf.mjs');
+const tfManifestCli = join(root, 'packages', 'tf-compose', 'bin', 'tf-manifest.mjs');
+const traceSummaryCli = join(root, 'packages', 'tf-l0-tools', 'trace-summary.mjs');
+const flowPath = join(root, 'examples', 'flows', 'pilot_min.tf');
+
+const irPath = join(pilotDir, 'pilot_min.ir.json');
+const canonPath = join(pilotDir, 'pilot_min.canon.json');
+const manifestPath = join(pilotDir, 'pilot_min.manifest.json');
+const statusPath = join(pilotDir, 'status.json');
+const tracePath = join(pilotDir, 'trace.jsonl');
+const summaryPath = join(pilotDir, 'summary.json');
+const digestsPath = join(pilotDir, 'digests.json');
+
+function sh(command, args, opts = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...opts });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function rewriteFootprints(list) {
+  if (!Array.isArray(list)) return [];
+  return list.map((entry) => {
+    if (!entry || typeof entry !== 'object') return entry;
+    if (typeof entry.uri === 'string' && entry.uri.startsWith('res://kv/')) {
+      const updated = { ...entry, uri: 'res://ledger/pilot' };
+      if (updated.notes === 'seed') updated.notes = 'pilot ledger write';
+      return updated;
+    }
+    return entry;
+  });
+}
+
+function rewriteManifest(path) {
+  const raw = readFileSync(path, 'utf8');
+  const manifest = JSON.parse(raw);
+  manifest.footprints = rewriteFootprints(manifest.footprints);
+  if (manifest.footprints_rw && Array.isArray(manifest.footprints_rw.writes)) {
+    manifest.footprints_rw = {
+      ...manifest.footprints_rw,
+      writes: rewriteFootprints(manifest.footprints_rw.writes),
+    };
+  }
+  writeFileSync(path, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+  return manifest;
+}
+
+function normalizeStatus(raw) {
+  const effects = Array.isArray(raw.effects) ? Array.from(new Set(raw.effects.filter((e) => typeof e === 'string'))).sort() : [];
+  const ops = Number.isFinite(raw.ops) ? raw.ops : 0;
+  const ok = raw.ok === true;
+  return { ok, ops, effects };
+}
+
+function normalizeTraceLine(record) {
+  const ordered = {
+    ts: Number(record.ts ?? 0),
+    prim_id: record.prim_id ?? '',
+    args: canonicalize(record.args ?? {}),
+    region: typeof record.region === 'string' ? record.region : '',
+    effect: typeof record.effect === 'string' ? record.effect : '',
+  };
+  return JSON.stringify(ordered);
+}
+
+function appendNodeOptions(env, modulePath) {
+  const existing = env.NODE_OPTIONS ? `${env.NODE_OPTIONS} ` : '';
+  const next = `${existing}--import=${pathToFileURL(modulePath).href}`.trim();
+  return { ...env, NODE_OPTIONS: next };
+}
+
+sh('node', [tfCli, 'parse', flowPath, '-o', irPath]);
+sh('node', [tfCli, 'canon', flowPath, '-o', canonPath]);
+sh('node', [tfManifestCli, flowPath, '-o', manifestPath]);
+const manifest = rewriteManifest(manifestPath);
+
+sh('node', [tfCli, 'emit', '--lang', 'ts', flowPath, '--out', codegenDir]);
+
+const runPath = join(codegenDir, 'run.mjs');
+const runSource = readFileSync(runPath, 'utf8');
+const marker = 'const MANIFEST = ';
+const idx = runSource.indexOf(marker);
+if (idx !== -1) {
+  const start = idx + marker.length;
+  const suffixIdx = runSource.indexOf(';\n', start);
+  if (suffixIdx !== -1) {
+    const prefix = runSource.slice(0, start);
+    const suffix = runSource.slice(suffixIdx);
+    const updated = `${prefix}${JSON.stringify(manifest)}${suffix}`;
+    writeFileSync(runPath, updated, 'utf8');
+  }
+}
+
+const caps = {
+  effects: ['Network.Out', 'Storage.Write', 'Observability', 'Pure'],
+  allow_writes_prefixes: ['res://ledger/'],
+};
+writeFileSync(join(codegenDir, 'caps.json'), JSON.stringify(caps, null, 2) + '\n', 'utf8');
+
+for (const target of [statusPath, tracePath, summaryPath]) {
+  rmSync(target, { force: true });
+}
+
+const env = appendNodeOptions(
+  {
+    ...process.env,
+    TF_STATUS_PATH: statusPath,
+    TF_TRACE_PATH: tracePath,
+  },
+  join(here, 'pilot-clock.mjs'),
+);
+
+sh('node', [runPath, '--caps', join(codegenDir, 'caps.json')], { env });
+
+const traceRaw = readFileSync(tracePath, 'utf8').trim();
+if (!traceRaw) {
+  console.error('pilot-build-run: empty trace output');
+  process.exit(1);
+}
+const traceLines = traceRaw.split(/\r?\n/).filter((line) => line.length > 0);
+const normalizedTrace = traceLines.map((line) => {
+  const parsed = JSON.parse(line);
+  return normalizeTraceLine(parsed);
+});
+writeFileSync(tracePath, normalizedTrace.join('\n') + '\n', 'utf8');
+
+const statusRaw = JSON.parse(readFileSync(statusPath, 'utf8'));
+const statusNorm = normalizeStatus(statusRaw);
+writeFileSync(statusPath, JSON.stringify(statusNorm, null, 2) + '\n', 'utf8');
+
+const summaryProc = spawnSync('node', [traceSummaryCli], {
+  input: normalizedTrace.join('\n') + '\n',
+  encoding: 'utf8',
+});
+if (summaryProc.status !== 0) {
+  process.exit(summaryProc.status ?? 1);
+}
+const summaryJson = JSON.parse(summaryProc.stdout);
+writeFileSync(summaryPath, canonicalStringify(summaryJson) + '\n', 'utf8');
+
+const digests = {
+  status: hashJsonFile(statusPath),
+  trace: hashJsonFile(tracePath, { jsonl: true }),
+  summary: hashJsonFile(summaryPath),
+  ir: hashJsonFile(irPath),
+  canon: hashJsonFile(canonPath),
+  manifest: hashJsonFile(manifestPath),
+};
+writeFileSync(digestsPath, canonicalStringify(digests) + '\n', 'utf8');
+
+cpSync(digestsPath, join(goldenDir, 'digests.json'));
+cpSync(statusPath, join(goldenDir, 'status.json'));
+cpSync(summaryPath, join(goldenDir, 'summary.json'));
+cpSync(tracePath, join(goldenDir, 'trace.jsonl'));
+
+console.log('pilot-build-run complete');

--- a/scripts/pilot-clock.mjs
+++ b/scripts/pilot-clock.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+const BASE_MS = 1700000000000;
+const STEP_NS = 1_000_000n; // 1ms
+const BASE_NS = BigInt(BASE_MS) * 1_000_000n;
+
+let state = { counter: -STEP_NS };
+
+function createClock() {
+  return {
+    nowNs() {
+      state.counter += STEP_NS;
+      return BASE_NS + state.counter;
+    },
+    reset() {
+      state.counter = -STEP_NS;
+    },
+    get __tf_pilot() {
+      return true;
+    }
+  };
+}
+
+export function installDeterministicClock() {
+  state.counter = -STEP_NS;
+  const clock = createClock();
+  globalThis.__tf_clock = clock;
+  return clock;
+}
+
+export function resetDeterministicClock() {
+  const clock = globalThis.__tf_clock;
+  if (clock && clock.__tf_pilot && typeof clock.reset === 'function') {
+    clock.reset();
+    return;
+  }
+  installDeterministicClock();
+}
+
+if (!globalThis.__tf_clock || !globalThis.__tf_clock.__tf_pilot) {
+  installDeterministicClock();
+}

--- a/scripts/pilot-handwritten.mjs
+++ b/scripts/pilot-handwritten.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import inmem from '../packages/tf-l0-codegen-ts/src/runtime/inmem.mjs';
+import { canonicalize, canonicalStringify } from './hash-jsonl.mjs';
+import { resetDeterministicClock } from './pilot-clock.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const workdir = process.env.TF_PILOT_WORKDIR;
+const outRoot = workdir
+  ? (isAbsolute(workdir) ? workdir : join(root, workdir))
+  : join(root, 'out', '0.4');
+const pilotDir = join(outRoot, 'pilot-l0');
+const manualDir = join(pilotDir, 'manual');
+const traceSummaryCli = join(root, 'packages', 'tf-l0-tools', 'trace-summary.mjs');
+
+mkdirSync(manualDir, { recursive: true });
+
+const statusPath = join(manualDir, 'status.json');
+const tracePath = join(manualDir, 'trace.jsonl');
+const summaryPath = join(manualDir, 'summary.json');
+
+for (const path of [statusPath, tracePath, summaryPath]) {
+  rmSync(path, { force: true });
+}
+
+process.env.TF_STATUS_PATH = statusPath;
+process.env.TF_TRACE_PATH = tracePath;
+
+resetDeterministicClock();
+if (typeof inmem.reset === 'function') {
+  inmem.reset();
+}
+
+const clock = globalThis.__tf_clock;
+if (!clock || typeof clock.nowNs !== 'function') {
+  console.error('pilot-handwritten: deterministic clock missing');
+  process.exit(1);
+}
+
+const records = [];
+let ops = 0;
+const effects = new Set();
+
+function nextTs() {
+  return Number(clock.nowNs() / 1_000_000n);
+}
+
+async function invoke(prim, args) {
+  const adapter = typeof inmem.getAdapter === 'function' ? inmem.getAdapter(prim) : inmem[prim];
+  if (typeof adapter !== 'function') {
+    throw new Error(`No adapter for primitive ${prim}`);
+  }
+  const ts = nextTs();
+  const primId = typeof inmem.canonicalPrim === 'function' ? inmem.canonicalPrim(prim) : prim;
+  const effect = typeof inmem.effectFor === 'function' ? inmem.effectFor(prim) : '';
+  if (effect) {
+    effects.add(effect);
+  }
+  const traceArgs = canonicalize(args ?? {});
+  records.push({ ts, prim_id: primId, args: traceArgs, region: '', effect: effect || '' });
+  ops += 1;
+  return adapter(args, inmem.state ?? {});
+}
+
+await invoke('emit-metric', { name: 'pilot.replay.start' });
+await invoke('publish', {
+  topic: 'orders',
+  key: 'o-1',
+  payload: '{"sym":"ABC","side":"buy","qty":1}',
+});
+await invoke('emit-metric', { name: 'pilot.exec.sent' });
+await invoke('write-object', {
+  uri: 'res://ledger/pilot',
+  key: 'o-1',
+  value: 'filled',
+});
+await invoke('emit-metric', { name: 'pilot.ledger.write' });
+
+const traceLines = records.map((record) => JSON.stringify(record));
+writeFileSync(tracePath, traceLines.join('\n') + '\n', 'utf8');
+
+const status = {
+  ok: true,
+  ops,
+  effects: Array.from(effects).sort(),
+};
+writeFileSync(statusPath, JSON.stringify(status, null, 2) + '\n', 'utf8');
+
+const summaryProc = spawnSync('node', [traceSummaryCli], {
+  input: traceLines.join('\n') + '\n',
+  encoding: 'utf8',
+});
+if (summaryProc.status !== 0) {
+  process.exit(summaryProc.status ?? 1);
+}
+const summaryJson = JSON.parse(summaryProc.stdout);
+writeFileSync(summaryPath, canonicalStringify(summaryJson) + '\n', 'utf8');
+
+console.log('pilot-handwritten complete');

--- a/scripts/pilot-parity.mjs
+++ b/scripts/pilot-parity.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { canonicalStringify, hashJsonFile } from './hash-jsonl.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const workdir = process.env.TF_PILOT_WORKDIR;
+const outRoot = workdir
+  ? (isAbsolute(workdir) ? workdir : join(root, workdir))
+  : join(root, 'out', '0.4');
+const pilotDir = join(outRoot, 'pilot-l0');
+const manualDir = join(pilotDir, 'manual');
+const parityDir = join(outRoot, 'parity');
+
+mkdirSync(parityDir, { recursive: true });
+
+const artifacts = [
+  { name: 'status', path: join(pilotDir, 'status.json'), manual: join(manualDir, 'status.json'), jsonl: false },
+  { name: 'trace', path: join(pilotDir, 'trace.jsonl'), manual: join(manualDir, 'trace.jsonl'), jsonl: true },
+  { name: 'summary', path: join(pilotDir, 'summary.json'), manual: join(manualDir, 'summary.json'), jsonl: false },
+];
+
+const generated = {};
+const manual = {};
+const diff = [];
+
+for (const artifact of artifacts) {
+  const gen = hashJsonFile(artifact.path, { jsonl: artifact.jsonl });
+  const man = hashJsonFile(artifact.manual, { jsonl: artifact.jsonl });
+  generated[artifact.name] = gen;
+  manual[artifact.name] = man;
+  if (gen !== man) {
+    diff.push({ artifact: artifact.name, generated: gen, manual: man });
+  }
+}
+
+const report = {
+  equal: diff.length === 0,
+  diff,
+  generated,
+  manual,
+};
+
+const reportPath = join(parityDir, 'report.json');
+writeFileSync(reportPath, canonicalStringify(report) + '\n', 'utf8');
+
+if (report.equal) {
+  console.log('pilot-parity: artifacts match');
+  process.exit(0);
+}
+
+console.error('pilot-parity: mismatch detected');
+process.exit(1);

--- a/tests/pilot-parity.test.mjs
+++ b/tests/pilot-parity.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { strict as assert } from 'node:assert';
+
+const workdir = 'out/0.4/pilot-parity-test';
+
+function runScript(name) {
+  const result = spawnSync('node', [name], {
+    stdio: 'inherit',
+    env: { ...process.env, TF_PILOT_WORKDIR: workdir },
+  });
+  assert.equal(result.status, 0, `${name} exited with ${result.status}`);
+}
+
+test('pilot pipeline matches handwritten runner', () => {
+  runScript('scripts/pilot-build-run.mjs');
+  runScript('scripts/pilot-handwritten.mjs');
+  runScript('scripts/pilot-parity.mjs');
+
+  const reportPath = join(workdir, 'parity', 'report.json');
+  const firstReport = readFileSync(reportPath, 'utf8');
+  const parsed = JSON.parse(firstReport);
+  assert.equal(parsed.equal, true, 'parity report should indicate equality');
+
+  runScript('scripts/pilot-parity.mjs');
+  const secondReport = readFileSync(reportPath, 'utf8');
+  assert.equal(secondReport, firstReport, 'parity report must be stable across runs');
+});


### PR DESCRIPTION
## Summary
- add a deterministic pilot build/run script that regenerates artifacts, normalizes outputs, and computes digests
- introduce a handwritten pilot runner, deterministic clock, hash utility, and a parity harness CLI/test
- wire new pilot scripts into package.json and document the parity workflow

## Testing
- pnpm -w -r build
- pnpm run pilot:all
- cat out/0.4/parity/report.json
- pnpm -w -r test *(fails: tests/codegen-rs.test.mjs expects signing IR fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68d0329a62348320acc0e63958192c68