### PR TITLE
C3.2/E4: Add provenance fingerprints to trace tooling

### DIFF
--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -36,3 +36,14 @@ cat out/0.4/pilot-l0/summary.json
 ```
 
 The run produces IR, canonical form, manifest, generated TypeScript, capability manifest, execution status, trace, and a summarized view. Capability gating requires the following effects: `Network.Out`, `Storage.Write`, `Observability`, and `Pure`, with writes permitted under the `res://ledger/` prefix.
+
+To capture provenance fingerprints in the status and trace, enable the gate and validate the output:
+
+```sh
+TF_PROVENANCE=1 node scripts/pilot-build-run.mjs
+node scripts/validate-trace.mjs --require-meta \
+  --ir "$(jq -r .provenance.ir_hash out/0.4/pilot-l0/status.json)" \
+  --manifest "$(jq -r .provenance.manifest_hash out/0.4/pilot-l0/status.json)" \
+  --catalog "$(jq -r .provenance.catalog_hash out/0.4/pilot-l0/status.json)" \
+  < out/0.4/pilot-l0/trace.jsonl
+```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "proofs:emit": "node scripts/proofs-emit-all.mjs",
     "proofs:laws:axioms": "node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2 && node scripts/emit-smt-laws.mjs --law inverse:serialize-deserialize -o out/0.4/proofs/laws/inverse_roundtrip.smt2 && node scripts/emit-smt-laws.mjs --law commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute.smt2",
     "proofs:laws:equiv": "node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2",
+    "pilot:build-run": "node scripts/pilot-build-run.mjs",
     "tf": "node packages/tf-compose/bin/tf.mjs",
     "codegen:rs:signing": "node scripts/generate-rs.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing",
     "trace:filter": "node packages/tf-l0-tools/trace-filter.mjs",

--- a/packages/tf-compose/bin/tf-verify-trace.mjs
+++ b/packages/tf-compose/bin/tf-verify-trace.mjs
@@ -4,7 +4,8 @@ import { parseArgs } from 'node:util';
 
 import { verifyTrace } from '../../tf-l0-tools/verify-trace.mjs';
 
-const usage = 'Usage: node packages/tf-compose/bin/tf-verify-trace.mjs --ir <file.ir.json> --trace <file.jsonl> [--manifest <manifest.json>] [--catalog <catalog.json>]';
+const usage =
+  'Usage: node packages/tf-compose/bin/tf-verify-trace.mjs --ir <file.ir.json> --trace <file.jsonl> [--manifest <manifest.json>] [--catalog <catalog.json>] [--status <status.json>] [--ir-hash <sha>] [--manifest-hash <sha>] [--catalog-hash <sha>]';
 
 async function main(argv) {
   const { values, positionals } = parseArgs({
@@ -14,6 +15,10 @@ async function main(argv) {
       trace: { type: 'string' },
       manifest: { type: 'string' },
       catalog: { type: 'string' },
+      status: { type: 'string' },
+      'ir-hash': { type: 'string' },
+      'manifest-hash': { type: 'string' },
+      'catalog-hash': { type: 'string' },
     },
     allowPositionals: true,
   });
@@ -37,6 +42,10 @@ async function main(argv) {
     tracePath: values.trace,
     manifestPath: values.manifest,
     catalogPath: values.catalog,
+    statusPath: values.status,
+    irHash: values['ir-hash'],
+    manifestHash: values['manifest-hash'],
+    catalogHash: values['catalog-hash'],
   });
 
   process.stdout.write(canonical + '\n');

--- a/packages/tf-l0-tools/trace-summary.mjs
+++ b/packages/tf-l0-tools/trace-summary.mjs
@@ -65,6 +65,8 @@ const lines = input.split(/\r?\n/);
 
 const primCounts = new Map();
 const effectCounts = new Map();
+const metaIrCounts = new Map();
+const metaManifestCounts = new Map();
 let total = 0;
 let warned = false;
 
@@ -80,6 +82,17 @@ for (const raw of lines) {
     if (parsed && typeof parsed.effect === 'string') {
       increment(effectCounts, parsed.effect);
     }
+    if (parsed && parsed.meta && typeof parsed.meta === 'object') {
+      const irHash = typeof parsed.meta.ir_hash === 'string' ? parsed.meta.ir_hash : null;
+      if (irHash) {
+        increment(metaIrCounts, irHash);
+      }
+      const manifestHash =
+        typeof parsed.meta.manifest_hash === 'string' ? parsed.meta.manifest_hash : null;
+      if (manifestHash) {
+        increment(metaManifestCounts, manifestHash);
+      }
+    }
   } catch (err) {
     if (!warned && !quiet) {
       console.warn('trace-summary: skipping malformed line');
@@ -93,6 +106,17 @@ const summary = {
   by_prim: selectTop(primCounts, topLimit),
   by_effect: selectTop(effectCounts, topLimit),
 };
+
+if (metaIrCounts.size > 0 || metaManifestCounts.size > 0) {
+  const byMeta = {};
+  if (metaIrCounts.size > 0) {
+    byMeta.ir_hash = selectTop(metaIrCounts, topLimit);
+  }
+  if (metaManifestCounts.size > 0) {
+    byMeta.manifest_hash = selectTop(metaManifestCounts, topLimit);
+  }
+  summary.by_meta = byMeta;
+}
 
 const canonical = canonicalJson(summary);
 if (pretty) {

--- a/schemas/trace.v0.4.schema.json
+++ b/schemas/trace.v0.4.schema.json
@@ -27,6 +27,15 @@
     "effect": {
       "type": "string",
       "description": "Effect name inferred for the primitive invocation."
+    },
+    "meta": {
+      "type": "object",
+      "properties": {
+        "ir_hash": { "type": "string" },
+        "manifest_hash": { "type": "string" },
+        "catalog_hash": { "type": "string" }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/scripts/pilot-build-run.mjs
+++ b/scripts/pilot-build-run.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import './pilot-min.mjs';

--- a/scripts/validate-trace.mjs
+++ b/scripts/validate-trace.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // scripts/validate-trace.mjs
-import fs from 'node:fs';
 import { readFileSync } from 'node:fs';
 import readline from 'node:readline';
 import path from 'node:path';
 import url from 'node:url';
+import { parseArgs } from 'node:util';
 import Ajv2020 from 'ajv/dist/2020.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
@@ -14,35 +14,112 @@ const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
 const ajv = new Ajv2020({ allErrors: true, strict: true });
 const validate = ajv.compile(schema);
 
+const { values, positionals } = parseArgs({
+  options: {
+    'require-meta': { type: 'boolean' },
+    ir: { type: 'string' },
+    manifest: { type: 'string' },
+    catalog: { type: 'string' },
+  },
+  allowPositionals: true,
+});
+
+if (positionals.length > 0) {
+  console.error(`unexpected positional argument: ${positionals[0]}`);
+  process.exit(2);
+}
+
+const requireMeta = Boolean(values['require-meta']);
+const expectedIr = typeof values.ir === 'string' ? values.ir : null;
+const expectedManifest = typeof values.manifest === 'string' ? values.manifest : null;
+const expectedCatalog = typeof values.catalog === 'string' ? values.catalog : null;
+const expectMeta = Boolean(requireMeta || expectedIr || expectedManifest || expectedCatalog);
+
 const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 
 let lineNo = 0;
-let ok = true;
-
+let total = 0;
+let invalid = 0;
 const errors = [];
 
 for await (const line of rl) {
   lineNo++;
   const trimmed = line.trim();
-  if (!trimmed) continue; // allow blank lines
+  if (!trimmed) continue;
+  total++;
+
   let obj;
   try {
     obj = JSON.parse(trimmed);
-  } catch (e) {
-    ok = false;
-    errors.push({ line: lineNo, error: `invalid JSON: ${e.message}` });
+  } catch (err) {
+    invalid += 1;
+    errors.push({ line: lineNo, error: `invalid JSON: ${err.message}` });
     continue;
   }
-  const valid = validate(obj);
-  if (!valid) {
-    ok = false;
+
+  if (!validate(obj)) {
+    invalid += 1;
     errors.push({ line: lineNo, error: ajv.errorsText(validate.errors, { separator: '; ' }) });
+    continue;
+  }
+
+  const meta = obj.meta;
+  if (expectMeta && (!meta || typeof meta !== 'object')) {
+    invalid += 1;
+    errors.push({ line: lineNo, error: 'missing meta object' });
+    continue;
+  }
+
+  if (meta && typeof meta === 'object') {
+    let mismatch = false;
+    if (expectedIr) {
+      const actual = typeof meta.ir_hash === 'string' ? meta.ir_hash : '';
+      if (actual !== expectedIr) {
+        mismatch = true;
+        errors.push({
+          line: lineNo,
+          error: `meta.ir_hash mismatch (expected ${expectedIr}, got ${actual || '""'})`,
+        });
+      }
+    }
+    if (expectedManifest) {
+      const actual = typeof meta.manifest_hash === 'string' ? meta.manifest_hash : '';
+      if (actual !== expectedManifest) {
+        mismatch = true;
+        errors.push({
+          line: lineNo,
+          error: `meta.manifest_hash mismatch (expected ${expectedManifest}, got ${actual || '""'})`,
+        });
+      }
+    }
+    if (expectedCatalog) {
+      const actual = typeof meta.catalog_hash === 'string' ? meta.catalog_hash : '';
+      if (actual !== expectedCatalog) {
+        mismatch = true;
+        errors.push({
+          line: lineNo,
+          error: `meta.catalog_hash mismatch (expected ${expectedCatalog}, got ${actual || '""'})`,
+        });
+      }
+    }
+    if (mismatch) {
+      invalid += 1;
+    }
   }
 }
 
+const ok = invalid === 0;
+const summary = {
+  ok,
+  total,
+  invalid,
+  meta_checked: expectMeta,
+};
+
 if (!ok) {
-  console.error(JSON.stringify({ ok, errors }, null, 2));
+  summary.errors = errors;
+  console.error(JSON.stringify(summary, null, 2));
   process.exit(1);
 } else {
-  console.log(JSON.stringify({ ok: true, lines: lineNo }));
+  process.stdout.write(JSON.stringify(summary) + '\n');
 }

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -24,6 +24,22 @@ test('pilot_min flow runs and summarizes deterministically', () => {
   assert.ok(summary.total >= 3);
   assert.ok(summary.by_prim['tf:network/publish@1'] >= 1);
   assert.ok(summary.by_prim['tf:resource/write-object@1'] >= 1);
+  if (summary.by_meta) {
+    const metaEntries = Object.entries(summary.by_meta);
+    assert.ok(metaEntries.length > 0, 'expected meta buckets when by_meta present');
+    for (const [, counts] of metaEntries) {
+      assert.ok(counts && typeof counts === 'object', 'expected counts map for meta bucket');
+      const countValues = Object.values(counts);
+      assert.ok(countValues.length > 0, 'expected at least one meta fingerprint count');
+      for (const value of countValues) {
+        assert.equal(
+          value,
+          summary.total,
+          'meta fingerprint count should match total operations',
+        );
+      }
+    }
+  }
 
   const summaryRaw1 = readFileSync(summaryPath, 'utf8');
 

--- a/tests/provenance-status-trace.test.mjs
+++ b/tests/provenance-status-trace.test.mjs
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const rootDir = fileURLToPath(new URL('..', import.meta.url));
+const scriptsDir = join(rootDir, 'scripts');
+const pilotScript = join(scriptsDir, 'pilot-min.mjs');
+const outDir = join(rootDir, 'out', '0.4', 'pilot-l0');
+const runDir = join(outDir, 'codegen-ts', 'pilot_min');
+const runScriptPath = join(runDir, 'run.mjs');
+const capsPath = join(runDir, 'caps.json');
+const irPath = join(outDir, 'pilot_min.ir.json');
+const manifestPath = join(outDir, 'pilot_min.manifest.json');
+const specCatalogPath = join(rootDir, 'packages', 'tf-l0-spec', 'spec', 'catalog.json');
+const cliPath = join(rootDir, 'packages', 'tf-compose', 'bin', 'tf-verify-trace.mjs');
+const validateScript = join(rootDir, 'scripts', 'validate-trace.mjs');
+
+function runNode(command, args, options = {}) {
+  return spawnSync(process.execPath, [command, ...args], {
+    stdio: options.stdio ?? 'pipe',
+    input: options.input,
+    encoding: 'utf8',
+    env: options.env ? { ...process.env, ...options.env } : process.env,
+  });
+}
+
+function ensurePilotBuild() {
+  if (existsSync(runScriptPath) && existsSync(capsPath) && existsSync(irPath) && existsSync(manifestPath)) {
+    return;
+  }
+  const result = runNode(pilotScript, []);
+  assert.equal(result.status, 0, result.stderr);
+}
+
+test('status and trace include provenance fingerprints', () => {
+  ensurePilotBuild();
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'tf-provenance-'));
+  const tempStatusPath = join(tempDir, 'status.json');
+  const tempTracePath = join(tempDir, 'trace.jsonl');
+
+  const run = runNode(runScriptPath, ['--caps', capsPath], {
+    env: {
+      TF_PROVENANCE: '1',
+      TF_STATUS_PATH: tempStatusPath,
+      TF_TRACE_PATH: tempTracePath,
+    },
+  });
+  assert.equal(run.status, 0, run.stderr);
+
+  const status = JSON.parse(readFileSync(tempStatusPath, 'utf8'));
+  assert.equal(status.ok, true);
+  assert.ok(status.provenance, 'expected provenance in status');
+  const provenance = status.provenance;
+  assert.match(provenance.ir_hash, /^sha256:/);
+  assert.match(provenance.manifest_hash, /^sha256:/);
+  assert.match(provenance.catalog_hash, /^sha256:/);
+  assert.equal(provenance.caps_source, 'file');
+  assert.deepEqual(provenance.caps_effects, [
+    'Network.Out',
+    'Observability',
+    'Pure',
+    'Storage.Write',
+  ]);
+  assert.ok(status.effects.includes('Network.Out'));
+  assert.ok(status.effects.includes('Storage.Write'));
+
+  const traceLines = readFileSync(tempTracePath, 'utf8')
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+  assert.ok(traceLines.length > 0, 'expected trace records');
+  const firstRecord = JSON.parse(traceLines[0]);
+  assert.ok(firstRecord.meta, 'expected meta in trace record');
+  assert.equal(firstRecord.meta.ir_hash, provenance.ir_hash);
+  assert.equal(firstRecord.meta.manifest_hash, provenance.manifest_hash);
+  assert.equal(firstRecord.meta.catalog_hash, provenance.catalog_hash);
+
+  const traceData = traceLines.join('\n') + '\n';
+  const validate = runNode(
+    validateScript,
+    [
+      '--require-meta',
+      '--ir',
+      provenance.ir_hash,
+      '--manifest',
+      provenance.manifest_hash,
+      '--catalog',
+      provenance.catalog_hash,
+    ],
+    { input: traceData },
+  );
+  assert.equal(validate.status, 0, validate.stderr);
+  const validationSummary = JSON.parse(validate.stdout.trim());
+  assert.equal(validationSummary.ok, true);
+  assert.equal(validationSummary.meta_checked, true);
+  assert.equal(validationSummary.invalid, 0);
+  assert.equal(validationSummary.total, traceLines.length);
+
+  const verify = runNode(
+    cliPath,
+    [
+      '--ir',
+      irPath,
+      '--trace',
+      tempTracePath,
+      '--status',
+      tempStatusPath,
+      '--manifest',
+      manifestPath,
+      '--catalog',
+      specCatalogPath,
+    ],
+  );
+  assert.equal(verify.status, 0, verify.stderr);
+  const verifyResult = JSON.parse(verify.stdout.trim());
+  assert.equal(verifyResult.ok, true);
+  assert.equal(verifyResult.counts.provenance_mismatches, 0);
+
+  const badVerify = runNode(
+    cliPath,
+    [
+      '--ir',
+      irPath,
+      '--trace',
+      tempTracePath,
+      '--status',
+      tempStatusPath,
+      '--manifest',
+      manifestPath,
+      '--manifest-hash',
+      'sha256:deadbeef',
+      '--catalog',
+      specCatalogPath,
+    ],
+  );
+  assert.equal(badVerify.status, 1);
+  const badResult = JSON.parse(badVerify.stdout.trim());
+  assert.equal(badResult.ok, false);
+  assert.ok(badResult.issues.some((issue) => issue.includes('manifest_hash expected sha256:deadbeef')));
+  assert.ok(badResult.counts.provenance_mismatches > 0);
+
+});

--- a/tests/trace-schema.test.mjs
+++ b/tests/trace-schema.test.mjs
@@ -110,7 +110,9 @@ await runIR(ir, runtime);
   assert.equal(validateOk.code, 0, validateOk.stderr);
   const okSummary = JSON.parse(validateOk.stdout.trim());
   assert.equal(okSummary.ok, true, 'expected validator ok summary');
-  assert.equal(okSummary.lines, finalTraceLines.length);
+  assert.equal(okSummary.total, finalTraceLines.length);
+  assert.equal(okSummary.invalid, 0);
+  assert.equal(okSummary.meta_checked, false);
 
   const unwritableEnv = { TF_TRACE_PATH: '/root/nope/publish.jsonl' };
   const unwritableResult = await runNode(join(publishOutDir, 'run.mjs'), ['--caps', capsPath], {
@@ -136,6 +138,8 @@ await runIR(ir, runtime);
   assert.equal(validateBad.code, 1, validateBad.stderr);
   const badSummary = JSON.parse(validateBad.stderr.trim());
   assert.equal(badSummary.ok, false, 'expected validator to fail');
+  assert.equal(badSummary.total, 1);
+  assert.equal(badSummary.invalid, 1);
   assert.ok(Array.isArray(badSummary.errors) && badSummary.errors.length >= 1);
   assert.equal(badSummary.errors[0].line, 1);
   assert.ok(/prim_id/.test(badSummary.errors[0].error));

--- a/tests/verify-trace.test.mjs
+++ b/tests/verify-trace.test.mjs
@@ -67,6 +67,7 @@ test('passes for known prims without manifest', async () => {
     records: 2,
     unknown_prims: 0,
     denied_writes: 0,
+    provenance_mismatches: 0,
   });
 });
 
@@ -85,6 +86,7 @@ test('passes for known prims with catalog mapping', async () => {
     records: 2,
     unknown_prims: 0,
     denied_writes: 0,
+    provenance_mismatches: 0,
   });
 });
 
@@ -101,6 +103,7 @@ test('allows writes when manifest patterns match', async () => {
   assert.equal(result.ok, true);
   assert.deepEqual(result.issues, []);
   assert.equal(result.counts.denied_writes, 0);
+  assert.equal(result.counts.provenance_mismatches, 0);
 });
 
 test('reports unknown prims', async () => {
@@ -111,6 +114,7 @@ test('reports unknown prims', async () => {
   assert.equal(result.ok, false);
   assert.ok(result.issues.includes('unknown prim: tf:resource/unknown@1'));
   assert.equal(result.counts.unknown_prims, 1);
+  assert.equal(result.counts.provenance_mismatches, 0);
 });
 
 test('requires canonical match when provided', async () => {
@@ -127,6 +131,7 @@ test('requires canonical match when provided', async () => {
     'unknown prim: tf:resource/write-object@99',
   ]);
   assert.equal(result.counts.unknown_prims, 2);
+  assert.equal(result.counts.provenance_mismatches, 0);
 });
 
 test('canonical mismatch results are deterministic across trace orderings', async () => {
@@ -148,6 +153,7 @@ test('denies writes outside manifest prefixes', async () => {
   assert.equal(result.ok, false);
   assert.ok(result.issues.includes('write denied: res://kv/mybucket/blocked/item'));
   assert.equal(result.counts.denied_writes, 1);
+  assert.equal(result.counts.provenance_mismatches, 0);
 });
 
 test('allows bare names when canonical is absent', async () => {


### PR DESCRIPTION
## Summary
- compute provenance fingerprints during code generation and propagate them through the runtime status JSON and trace meta (behind TF_PROVENANCE)
- extend the trace schema, validator, summary, and verify CLI to enforce provenance hashes when provided
- add provenance-focused documentation and tests, including pilot summary assertions that tolerate optional by_meta counts

## Testing
- pnpm -w -r build
- TF_PROVENANCE=1 pnpm run pilot:build-run
- node scripts/validate-trace.mjs --require-meta --ir $(jq -r .provenance.ir_hash out/0.4/pilot-l0/status.json) --manifest $(jq -r .provenance.manifest_hash out/0.4/pilot-l0/status.json) --catalog $(jq -r .provenance.catalog_hash out/0.4/pilot-l0/status.json) < out/0.4/pilot-l0/trace.jsonl
- node packages/tf-compose/bin/tf-verify-trace.mjs --ir out/0.4/pilot-l0/pilot_min.ir.json --trace out/0.4/pilot-l0/trace.jsonl --status out/0.4/pilot-l0/status.json --manifest out/0.4/pilot-l0/pilot_min.manifest.json --catalog packages/tf-l0-spec/spec/catalog.json
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d032b4d8a883209d7c6298b6ff9be5