### PR TITLE
Extend SMT law suite and add authorize Alloy emitter

### DIFF
--- a/packages/tf-l0-proofs/src/alloy-auth.mjs
+++ b/packages/tf-l0-proofs/src/alloy-auth.mjs
@@ -1,0 +1,336 @@
+import authorizeRules from '../../tf-l0-check/rules/authorize-scopes.json' with { type: 'json' };
+
+export function emitAuthorizeAlloy(ir, options = {}) {
+  const ruleIndex = buildRuleIndex(options.rules ?? authorizeRules);
+  const context = createContext(ruleIndex);
+  visit(ir, context, []);
+
+  return serializeModel(context);
+}
+
+function createContext(ruleIndex) {
+  return {
+    ruleIndex,
+    regions: [],
+    regionMap: new Map(),
+    prims: [],
+    scopeNames: new Set()
+  };
+}
+
+function visit(node, context, regionStack) {
+  if (node == null) {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      visit(child, context, regionStack);
+    }
+    return;
+  }
+  if (typeof node !== 'object') {
+    return;
+  }
+
+  if (node.node === 'Region' && node.kind === 'Authorize') {
+    handleAuthorizeRegion(node, context, regionStack);
+    return;
+  }
+
+  if (node.node === 'Prim') {
+    handlePrimNode(node, context, regionStack);
+    return;
+  }
+
+  const children = Array.isArray(node.children) ? node.children : [];
+  for (const child of children) {
+    visit(child, context, regionStack);
+  }
+}
+
+function handleAuthorizeRegion(node, context, regionStack) {
+  const scopes = extractRegionScopes(node);
+  const region = registerRegion(scopes, context);
+
+  for (const ancestorName of regionStack) {
+    addChild(context, ancestorName, region.name);
+  }
+
+  regionStack.push(region.name);
+  const children = Array.isArray(node.children) ? node.children : [];
+  for (const child of children) {
+    visit(child, context, regionStack);
+  }
+  regionStack.pop();
+}
+
+function handlePrimNode(node, context, regionStack) {
+  const analysis = analyzePrim(node, context.ruleIndex);
+  if (!analysis || analysis.scopes.length === 0) {
+    return;
+  }
+
+  const name = `Prim${context.prims.length}`;
+  const prim = {
+    name,
+    display: analysis.display,
+    scopeNeed: analysis.scopes
+  };
+  context.prims.push(prim);
+
+  for (const scope of analysis.scopes) {
+    context.scopeNames.add(scope);
+  }
+
+  for (const regionName of regionStack) {
+    addChild(context, regionName, prim.name);
+  }
+}
+
+function registerRegion(scopes, context) {
+  const name = `Region${context.regions.length}`;
+  const entry = {
+    name,
+    scopes,
+    children: new Set()
+  };
+  context.regions.push(entry);
+  context.regionMap.set(name, entry);
+  for (const scope of scopes) {
+    context.scopeNames.add(scope);
+  }
+  return entry;
+}
+
+function addChild(context, regionName, childName) {
+  const region = context.regionMap.get(regionName);
+  if (!region) {
+    return;
+  }
+  region.children.add(childName);
+}
+
+function extractRegionScopes(node) {
+  const raw = node?.attrs?.scope;
+  if (typeof raw !== 'string') {
+    return [];
+  }
+  const scopes = raw
+    .split(',')
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+  const unique = [...new Set(scopes.map((scope) => scope.toLowerCase()))];
+  unique.sort((a, b) => a.localeCompare(b));
+  return unique;
+}
+
+function analyzePrim(node, ruleIndex) {
+  const canonicalId = extractCanonicalId(node);
+  const byIdScopes = canonicalId ? ruleIndex.byId.get(canonicalId) ?? [] : [];
+  if (byIdScopes.length > 0) {
+    return { display: canonicalId, scopes: byIdScopes };
+  }
+
+  const baseName = extractBaseName(node, canonicalId);
+  if (!baseName) {
+    return null;
+  }
+  const fallback = ruleIndex.byBase.get(baseName);
+  if (!fallback || fallback.scopes.length === 0) {
+    return null;
+  }
+  const display = canonicalId ?? fallback.id ?? baseName;
+  return { display, scopes: fallback.scopes };
+}
+
+function extractCanonicalId(node) {
+  const candidates = [
+    node?.impl?.id,
+    node?.impl?.canonical_id,
+    node?.impl?.canonical?.id,
+    node?.prim_id,
+    node?.primId,
+    node?.id
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function extractBaseName(node, canonicalId) {
+  if (typeof canonicalId === 'string') {
+    const base = baseNameFromId(canonicalId);
+    if (base) {
+      return base;
+    }
+  }
+  const name = typeof node?.prim === 'string' ? node.prim : null;
+  if (name && name.length > 0) {
+    return name.toLowerCase();
+  }
+  return null;
+}
+
+function baseNameFromId(id) {
+  if (typeof id !== 'string') {
+    return null;
+  }
+  const match = id.match(/\/([^/@]+)@/);
+  if (match) {
+    return match[1].toLowerCase();
+  }
+  const trimmed = id.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const slashIndex = trimmed.lastIndexOf('/');
+  const segment = slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed;
+  const atIndex = segment.indexOf('@');
+  const base = atIndex >= 0 ? segment.slice(0, atIndex) : segment;
+  return base.toLowerCase();
+}
+
+function buildRuleIndex(rules) {
+  const byId = new Map();
+  const byBase = new Map();
+  const entries = rules && typeof rules === 'object' ? Object.entries(rules) : [];
+  for (const [id, scopes] of entries) {
+    if (typeof id !== 'string') {
+      continue;
+    }
+    const normalizedScopes = normalizeScopes(scopes);
+    byId.set(id, normalizedScopes);
+    const base = baseNameFromId(id);
+    if (base && !byBase.has(base)) {
+      byBase.set(base, { id, scopes: normalizedScopes });
+    }
+  }
+  return { byId, byBase };
+}
+
+function normalizeScopes(scopes) {
+  if (!Array.isArray(scopes)) {
+    return [];
+  }
+  const unique = new Set();
+  for (const scope of scopes) {
+    if (typeof scope !== 'string') {
+      continue;
+    }
+    const trimmed = scope.trim();
+    if (trimmed.length > 0) {
+      unique.add(trimmed.toLowerCase());
+    }
+  }
+  return Array.from(unique).sort((a, b) => a.localeCompare(b));
+}
+
+function serializeModel(context) {
+  const regions = [...context.regions].sort((a, b) => a.name.localeCompare(b.name));
+  const prims = [...context.prims].sort((a, b) => a.name.localeCompare(b.name));
+  const scopeValues = Array.from(context.scopeNames).sort((a, b) => a.localeCompare(b));
+  const scopeAtoms = new Map();
+  scopeValues.forEach((scope, index) => {
+    scopeAtoms.set(scope, `Scope${index}`);
+  });
+
+  const lines = [];
+  lines.push('module tf_lang_auth');
+  lines.push('open util/ordering[Node]');
+  lines.push('open util/strings');
+  lines.push('');
+  lines.push('sig Node {}');
+  lines.push('sig Region extends Node { scopes: set Scope, children: set Node }');
+  lines.push('sig Prim extends Node { primId: one String, scopeNeed: set Scope }');
+  lines.push('sig Scope {}');
+  lines.push('');
+
+  if (scopeValues.length > 0) {
+    for (const scope of scopeValues) {
+      lines.push(`one sig ${scopeAtoms.get(scope)} extends Scope {}`);
+    }
+    lines.push('');
+  }
+
+  if (regions.length > 0) {
+    for (const region of regions) {
+      lines.push(`one sig ${region.name} extends Region {}`);
+    }
+    lines.push('');
+  }
+
+  if (prims.length > 0) {
+    for (const prim of prims) {
+      lines.push(`one sig ${prim.name} extends Prim {}`);
+    }
+    lines.push('');
+  }
+
+  if (regions.length > 0) {
+    lines.push('fact RegionScopes {');
+    for (const region of regions) {
+      lines.push(`  ${region.name}.scopes = ${formatSet(region.scopes.map((scope) => scopeAtoms.get(scope)))}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+
+  if (regions.length > 0) {
+    lines.push('fact RegionChildren {');
+    for (const region of regions) {
+      const children = Array.from(region.children).sort((a, b) => a.localeCompare(b));
+      lines.push(`  ${region.name}.children = ${formatSet(children)}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+
+  if (prims.length > 0) {
+    lines.push('fact PrimIds {');
+    for (const prim of prims) {
+      lines.push(`  ${prim.name}.primId = ${stringLiteral(prim.display)}`);
+    }
+    lines.push('}');
+    lines.push('');
+
+    lines.push('fact PrimScopes {');
+    for (const prim of prims) {
+      const scopes = prim.scopeNeed.map((scope) => scopeAtoms.get(scope));
+      lines.push(`  ${prim.name}.scopeNeed = ${formatSet(scopes)}`);
+    }
+    lines.push('}');
+    lines.push('');
+  }
+
+  lines.push('pred Dominates[r: Region, n: Node] { n in r.*children }');
+  lines.push('pred Covered[n: Prim] { some r: Region | Dominates[r, n] and some (r.scopes & n.scopeNeed) }');
+  lines.push('pred MissingAuth { some n: Prim | some n.scopeNeed and not Covered[n] }');
+  lines.push('');
+  lines.push('run { MissingAuth }');
+  lines.push('run { not MissingAuth }');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function formatSet(values) {
+  const filtered = values.filter((value) => typeof value === 'string' && value.length > 0);
+  if (filtered.length === 0) {
+    return 'none';
+  }
+  const sorted = [...new Set(filtered)].sort((a, b) => a.localeCompare(b));
+  if (sorted.length === 1) {
+    return sorted[0];
+  }
+  return sorted.join(' + ');
+}
+
+function stringLiteral(value) {
+  if (typeof value !== 'string') {
+    return '""';
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}

--- a/scripts/emit-alloy-auth.mjs
+++ b/scripts/emit-alloy-auth.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitAuthorizeAlloy } from '../packages/tf-l0-proofs/src/alloy-auth.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      out: { type: 'string', short: 'o' }
+    },
+    allowPositionals: true
+  });
+
+  if (positionals.length !== 1 || typeof values.out !== 'string') {
+    usage();
+    process.exit(2);
+  }
+
+  const inputPath = resolve(positionals[0]);
+  const outPath = resolve(values.out);
+
+  const ir = await loadIR(inputPath);
+  const alloy = ensureTrailingNewline(emitAuthorizeAlloy(ir));
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, alloy, 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+async function loadIR(sourcePath) {
+  if (sourcePath.endsWith('.tf')) {
+    const raw = await readFile(sourcePath, 'utf8');
+    return parseDSL(raw);
+  }
+  if (sourcePath.endsWith('.ir.json')) {
+    const raw = await readFile(sourcePath, 'utf8');
+    return JSON.parse(raw);
+  }
+  throw new Error('unsupported input; expected .tf or .ir.json');
+}
+
+function ensureTrailingNewline(text) {
+  if (text.endsWith('\n')) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+function usage() {
+  process.stderr.write('Usage: node scripts/emit-alloy-auth.mjs <flow.tf|flow.ir.json> -o <out.als>\n');
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error?.message ?? error}\n`);
+  process.exit(1);
+});

--- a/scripts/emit-smt-laws-suite.mjs
+++ b/scripts/emit-smt-laws-suite.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import {
+  emitLaw,
+  listLawNames
+} from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+const LAW_FILENAME_OVERRIDES = new Map([
+  ['commute:emit-metric-with-pure', 'emit_commute.smt2'],
+  ['idempotent:hash', 'idempotent_hash.smt2'],
+  ['idempotent:write-by-key', 'write_idempotent_by_key.smt2'],
+  ['inverse:serialize-deserialize', 'inverse_roundtrip.smt2']
+]);
+
+async function main(argv) {
+  const { values } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      out: { type: 'string', short: 'o' }
+    },
+    allowPositionals: false
+  });
+
+  const outDir = typeof values.out === 'string' ? resolve(values.out) : null;
+  if (!outDir) {
+    usage('missing --out <dir>');
+    process.exit(2);
+  }
+
+  await mkdir(outDir, { recursive: true });
+
+  const lawNames = listLawNames();
+  const written = [];
+
+  for (const lawName of lawNames) {
+    const fileName = LAW_FILENAME_OVERRIDES.get(lawName) ?? `${sanitize(lawName)}.smt2`;
+    const filePath = join(outDir, fileName);
+    const content = ensureTrailingNewline(emitLaw(lawName));
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, 'utf8');
+    written.push(filePath);
+  }
+
+  written.sort((a, b) => a.localeCompare(b));
+  for (const filePath of written) {
+    process.stdout.write(`wrote ${filePath}\n`);
+  }
+}
+
+function sanitize(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gi, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function ensureTrailingNewline(text) {
+  if (text.endsWith('\n')) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+function usage(message) {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.stderr.write('Usage: node scripts/emit-smt-laws-suite.mjs -o <out-dir>\n');
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error?.message ?? error}\n`);
+  process.exit(1);
+});

--- a/scripts/proofs-emit-all.mjs
+++ b/scripts/proofs-emit-all.mjs
@@ -55,6 +55,11 @@ emit(
   ['--law', 'idempotent:hash']
 );
 emit(
+  'laws/write_idempotent_by_key.smt2',
+  join(scriptsDir, 'emit-smt-laws.mjs'),
+  ['--law', 'idempotent:write-by-key']
+);
+emit(
   'laws/inverse_roundtrip.smt2',
   join(scriptsDir, 'emit-smt-laws.mjs'),
   ['--law', 'inverse:serialize-deserialize']

--- a/tests/alloy-auth.test.mjs
+++ b/tests/alloy-auth.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { emitAuthorizeAlloy } from '../packages/tf-l0-proofs/src/alloy-auth.mjs';
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+async function loadFlow(name) {
+  const sourcePath = join(repoRoot, 'examples', 'flows', name);
+  const raw = await readFile(sourcePath, 'utf8');
+  return parseDSL(raw);
+}
+
+test('auth_missing model exposes MissingAuth run', async () => {
+  const ir = await loadFlow('auth_missing.tf');
+  const alloy = emitAuthorizeAlloy(ir);
+
+  assertOrder(
+    alloy,
+    [
+      'sig Node {}',
+      'pred Dominates[r: Region, n: Node] { n in r.*children }',
+      'pred Covered[n: Prim] { some r: Region | Dominates[r, n] and some (r.scopes & n.scopeNeed) }',
+      'pred MissingAuth { some n: Prim | some n.scopeNeed and not Covered[n] }',
+      'run { MissingAuth }',
+      'run { not MissingAuth }'
+    ]
+  );
+
+  assert.ok(alloy.includes('Prim0.scopeNeed = Scope0'), 'annotates protected prim scope');
+});
+
+test('auth_ok model remains deterministic', async () => {
+  const ir = await loadFlow('auth_ok.tf');
+  const first = emitAuthorizeAlloy(ir);
+  const second = emitAuthorizeAlloy(ir);
+
+  assert.ok(first.includes('pred MissingAuth'), 'includes MissingAuth predicate');
+  assert.ok(first.includes('run { MissingAuth }'), 'includes run MissingAuth command');
+  assert.ok(first.includes('run { not MissingAuth }'), 'includes negated run command');
+  assert.equal(first, second, 'emission is deterministic');
+});
+
+function assertOrder(text, segments) {
+  let cursor = -1;
+  for (const segment of segments) {
+    const index = text.indexOf(segment);
+    assert.ok(index >= 0, `expected segment ${segment}`);
+    assert.ok(index > cursor, `segment ${segment} should follow previous content`);
+    cursor = index;
+  }
+}

--- a/tests/smt-laws-extend.test.mjs
+++ b/tests/smt-laws-extend.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { emitLaw } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+const execFileAsync = promisify(execFile);
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+function lawIncludes(text, snippet, message) {
+  assert.ok(text.includes(snippet), message);
+}
+
+test('write idempotent law models repeated writes', () => {
+  const text = emitLaw('idempotent:write-by-key');
+  lawIncludes(
+    text,
+    '(define-fun once ((x Val) (u URI) (k Key) (ik IdKey) (v Val)) Val (W u k ik v))',
+    'defines once helper'
+  );
+  lawIncludes(
+    text,
+    '(define-fun twice ((x Val) (u URI) (k Key) (ik IdKey) (v Val)) Val (W u k ik v))',
+    'defines twice helper'
+  );
+  lawIncludes(
+    text,
+    '(assert (not (= (twice x u k ik v) (once x u k ik v))))',
+    'asserts disequality for duplicate write pipeline'
+  );
+  assert.ok(text.trim().endsWith('(check-sat)'), 'write law terminates with check-sat');
+});
+
+test('serialize/deserialize law encodes both directions', () => {
+  const text = emitLaw('inverse:serialize-deserialize');
+  lawIncludes(text, '(forall ((v Val)) (= (D (S v)) v))', 'includes forward quantifier');
+  lawIncludes(text, '(forall ((b Bytes)) (= (S (D b)) b))', 'includes reverse quantifier');
+  assert.ok(text.trim().endsWith('(check-sat)'), 'inverse law terminates with check-sat');
+});
+
+test('suite emission is deterministic', async () => {
+  const baseDir = await mkdtemp(join(tmpdir(), 'smt-laws-suite-'));
+  const firstDir = join(baseDir, 'first');
+  const secondDir = join(baseDir, 'second');
+  const script = join(repoRoot, 'scripts', 'emit-smt-laws-suite.mjs');
+
+  try {
+    await execFileAsync('node', [script, '-o', firstDir], { cwd: repoRoot });
+    await execFileAsync('node', [script, '-o', secondDir], { cwd: repoRoot });
+
+    const first = await readDirContents(firstDir);
+    const second = await readDirContents(secondDir);
+    assert.deepEqual(first, second);
+  } finally {
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+async function readDirContents(dir) {
+  const entries = await readdir(dir);
+  entries.sort((a, b) => a.localeCompare(b));
+  const result = {};
+  for (const entry of entries) {
+    result[entry] = await readFile(join(dir, entry), 'utf8');
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a keyed write idempotency law, expose a law name listing helper, and update the law suite emitter
- introduce an authorize-focused Alloy emitter and CLI along with new regression tests
- document the new obligations and alloy mode plus update proofs-emit-all to ship the additional law file

## Testing
- pnpm -w -r build *(fails: adapter-legal-ts@0.1.0 build missing local node_modules)*
- node scripts/emit-smt-laws-suite.mjs -o out/0.4/proofs/laws
- node scripts/emit-alloy-auth.mjs examples/flows/auth_missing.tf -o out/0.4/proofs/auth/missing.als
- node scripts/emit-alloy-auth.mjs examples/flows/auth_ok.tf -o out/0.4/proofs/auth/ok.als
- pnpm -w -r test *(fails: @tf-lang/adapter-execution-ts@0.1.0 test vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68d04a97edd0832092bde78d79302022