### PR TITLE
Add authorize Alloy model and extend SMT law suite

### DIFF
--- a/packages/tf-l0-proofs/src/alloy-auth.mjs
+++ b/packages/tf-l0-proofs/src/alloy-auth.mjs
@@ -1,0 +1,299 @@
+const REGION_PREFIX = 'Region';
+const PRIM_PREFIX = 'Prim';
+const SCOPE_PREFIX = 'Scope';
+
+export function emitAlloyAuth(ir, options = {}) {
+  const context = {
+    regions: [],
+    prims: [],
+    scopeEntries: [],
+    scopeMap: new Map(),
+    regionCounter: 0,
+    primCounter: 0,
+    nodeNames: new WeakMap(),
+    primIndex: normalizePrimIndex(options.primIndex),
+  };
+
+  traverse(ir, [], context);
+
+  const lines = [];
+  lines.push('module tf_lang_authorize');
+  lines.push('');
+  lines.push('open util/ordering[Node]');
+  lines.push('');
+  lines.push('sig Node {}');
+  lines.push('sig Region extends Node { scopes: set Scope, children: set Node }');
+  lines.push('sig Prim extends Node { primId: one String, scopeNeed: set Scope }');
+  lines.push('sig Scope {}');
+  lines.push('');
+  lines.push('pred Dominates[r:Region, n:Node] { n in r.*children }');
+  lines.push('pred Covered[n:Prim] { some r:Region | Dominates[r, n] and some (r.scopes & n.scopeNeed) }');
+  lines.push('pred MissingAuth { some n:Prim | some n.scopeNeed and not Covered[n] }');
+  lines.push('');
+
+  appendScopeDeclarations(lines, context.scopeEntries);
+  appendRegionDeclarations(lines, context.regions);
+  appendPrimDeclarations(lines, context.prims);
+  appendRegionFacts(lines, context.regions);
+  appendPrimFacts(lines, context.prims);
+
+  lines.push('run { MissingAuth }');
+  lines.push('run { not MissingAuth }');
+
+  return lines.join('\n') + '\n';
+}
+
+function normalizePrimIndex(value) {
+  if (value instanceof Map) {
+    return value;
+  }
+  if (!value || typeof value !== 'object') {
+    return new Map();
+  }
+  const map = new Map();
+  for (const [key, entry] of Object.entries(value)) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const { id, scopes } = entry;
+    if (typeof key === 'string') {
+      map.set(key, {
+        id: typeof id === 'string' && id.length > 0 ? id : null,
+        scopes: Array.isArray(scopes) ? scopes.filter(isNonEmptyString) : [],
+      });
+    }
+  }
+  return map;
+}
+
+function traverse(node, regionStack, context) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  if (context.nodeNames.has(node)) {
+    return;
+  }
+
+  if (node.node === 'Region' && node.kind === 'Authorize') {
+    const region = registerRegion(node, context);
+    if (regionStack.length > 0) {
+      const parent = regionStack[regionStack.length - 1];
+      parent.children.add(region.name);
+    }
+    regionStack.push(region);
+    for (const child of node.children || []) {
+      traverse(child, regionStack, context);
+    }
+    regionStack.pop();
+    return;
+  }
+
+  if (node.node === 'Prim') {
+    const prim = registerPrim(node, context);
+    if (regionStack.length > 0) {
+      const parent = regionStack[regionStack.length - 1];
+      parent.children.add(prim.name);
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      traverse(child, regionStack, context);
+    }
+  }
+}
+
+function registerRegion(node, context) {
+  if (context.nodeNames.has(node)) {
+    return context.nodeNames.get(node);
+  }
+  const name = `${REGION_PREFIX}${context.regionCounter++}`;
+  const scopes = collectRegionScopes(node, context);
+  const entry = { name, scopes, children: new Set() };
+  context.nodeNames.set(node, entry);
+  context.regions.push(entry);
+  return entry;
+}
+
+function collectRegionScopes(node, context) {
+  const scopes = new Set();
+  const raw = node?.attrs?.scope;
+  if (typeof raw === 'string') {
+    for (const scope of splitScopes(raw)) {
+      const atom = internScope(scope, context);
+      if (atom) {
+        scopes.add(atom);
+      }
+    }
+  }
+  return scopes;
+}
+
+function registerPrim(node, context) {
+  if (context.nodeNames.has(node)) {
+    return context.nodeNames.get(node);
+  }
+  const name = `${PRIM_PREFIX}${context.primCounter++}`;
+  const info = lookupPrimInfo(node, context.primIndex);
+  const scopeNeeds = new Set();
+  for (const scope of info.scopes) {
+    const atom = internScope(scope, context);
+    if (atom) {
+      scopeNeeds.add(atom);
+    }
+  }
+  const entry = {
+    name,
+    primId: info.id ?? inferPrimId(node),
+    scopeNeeds,
+  };
+  context.nodeNames.set(node, entry);
+  context.prims.push(entry);
+  return entry;
+}
+
+function lookupPrimInfo(node, primIndex) {
+  const primName = typeof node?.prim === 'string' ? node.prim.toLowerCase() : '';
+  return primIndex.get(primName) ?? { id: null, scopes: [] };
+}
+
+function inferPrimId(node) {
+  if (typeof node?.prim === 'string' && node.prim.length > 0) {
+    return node.prim;
+  }
+  return 'unknown-prim';
+}
+
+function splitScopes(value) {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(isNonEmptyString);
+}
+
+function internScope(scope, context) {
+  if (!isNonEmptyString(scope)) {
+    return null;
+  }
+  if (context.scopeMap.has(scope)) {
+    return context.scopeMap.get(scope).name;
+  }
+  const name = makeScopeAtom(scope, context.scopeEntries);
+  const entry = { label: scope, name };
+  context.scopeEntries.push(entry);
+  context.scopeMap.set(scope, entry);
+  return name;
+}
+
+function makeScopeAtom(scope, entries) {
+  const base = `${SCOPE_PREFIX}_${sanitize(scope)}`;
+  let candidate = base;
+  let index = 1;
+  while (entries.some((entry) => entry.name === candidate)) {
+    candidate = `${base}_${index++}`;
+  }
+  return candidate;
+}
+
+function sanitize(text) {
+  let result = text.replace(/[^A-Za-z0-9_]/g, '_');
+  if (!/[A-Za-z_]/.test(result.charAt(0))) {
+    result = `S_${result}`;
+  }
+  return result;
+}
+
+function appendScopeDeclarations(lines, scopes) {
+  if (scopes.length === 0) {
+    return;
+  }
+  const ordered = [...scopes].sort((a, b) => a.name.localeCompare(b.name));
+  for (const scope of ordered) {
+    lines.push(`one sig ${scope.name} extends Scope {}`);
+  }
+  lines.push('');
+}
+
+function appendRegionDeclarations(lines, regions) {
+  if (regions.length === 0) {
+    return;
+  }
+  const ordered = [...regions].sort((a, b) => a.name.localeCompare(b.name));
+  for (const region of ordered) {
+    lines.push(`one sig ${region.name} extends Region {}`);
+  }
+  lines.push('');
+}
+
+function appendPrimDeclarations(lines, prims) {
+  if (prims.length === 0) {
+    return;
+  }
+  const ordered = [...prims].sort((a, b) => a.name.localeCompare(b.name));
+  for (const prim of ordered) {
+    lines.push(`one sig ${prim.name} extends Prim {}`);
+  }
+  lines.push('');
+}
+
+function appendRegionFacts(lines, regions) {
+  if (regions.length === 0) {
+    return;
+  }
+  const ordered = [...regions].sort((a, b) => a.name.localeCompare(b.name));
+  lines.push('fact RegionScopes {');
+  for (const region of ordered) {
+    lines.push(`  ${region.name}.scopes = ${formatSet(region.scopes)}`);
+  }
+  lines.push('}');
+  lines.push('');
+
+  lines.push('fact RegionChildren {');
+  for (const region of ordered) {
+    lines.push(`  ${region.name}.children = ${formatSet(region.children)}`);
+  }
+  lines.push('}');
+  lines.push('');
+}
+
+function appendPrimFacts(lines, prims) {
+  if (prims.length === 0) {
+    return;
+  }
+  const ordered = [...prims].sort((a, b) => a.name.localeCompare(b.name));
+  lines.push('fact PrimIds {');
+  for (const prim of ordered) {
+    lines.push(`  ${prim.name}.primId = ${stringLiteral(prim.primId)}`);
+  }
+  lines.push('}');
+  lines.push('');
+
+  lines.push('fact PrimScopeNeeds {');
+  for (const prim of ordered) {
+    lines.push(`  ${prim.name}.scopeNeed = ${formatSet(prim.scopeNeeds)}`);
+  }
+  lines.push('}');
+  lines.push('');
+}
+
+function formatSet(values) {
+  if (!values || values.size === 0) {
+    return 'none';
+  }
+  const list = Array.from(values).sort();
+  if (list.length === 1) {
+    return list[0];
+  }
+  return list.join(' + ');
+}
+
+function stringLiteral(value) {
+  if (typeof value !== 'string') {
+    return '""';
+  }
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/scripts/emit-alloy-auth.mjs
+++ b/scripts/emit-alloy-auth.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitAlloyAuth } from '../packages/tf-l0-proofs/src/alloy-auth.mjs';
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      out: { type: 'string', short: 'o' },
+    },
+    allowPositionals: true,
+  });
+
+  if (positionals.length !== 1) {
+    usage('expected exactly one input flow');
+    process.exit(2);
+  }
+
+  const outPath = typeof values.out === 'string' ? resolve(values.out) : null;
+  if (!outPath) {
+    usage('missing --out <file>');
+    process.exit(2);
+  }
+
+  const inputPath = resolve(positionals[0]);
+  const ir = await loadIR(inputPath);
+  const primIndex = await loadPrimIndex();
+  const alloy = emitAlloyAuth(ir, { primIndex });
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, ensureTrailingNewline(alloy), 'utf8');
+  process.stdout.write(`wrote ${outPath}\n`);
+}
+
+function usage(message) {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.stderr.write('Usage: node scripts/emit-alloy-auth.mjs <input.tf|input.ir.json> -o <out.als>\n');
+}
+
+async function loadIR(sourcePath) {
+  if (sourcePath.endsWith('.tf')) {
+    return loadFlow(sourcePath);
+  }
+  if (sourcePath.endsWith('.ir.json')) {
+    const raw = await readFile(sourcePath, 'utf8');
+    return JSON.parse(raw);
+  }
+  throw new Error('unsupported input; expected .tf or .ir.json');
+}
+
+async function loadFlow(srcPath) {
+  const raw = await readFile(srcPath, 'utf8');
+  return parseDSL(raw);
+}
+
+async function loadPrimIndex() {
+  const [catalog, scopeRules] = await Promise.all([loadCatalog(), loadAuthorizeScopes()]);
+  return buildPrimIndex(catalog, scopeRules);
+}
+
+async function loadCatalog() {
+  const catalogUrl = new URL('../packages/tf-l0-spec/spec/catalog.json', import.meta.url);
+  const raw = await readFile(catalogUrl, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function loadAuthorizeScopes() {
+  const scopeUrl = new URL('../packages/tf-l0-check/rules/authorize-scopes.json', import.meta.url);
+  const raw = await readFile(scopeUrl, 'utf8');
+  return JSON.parse(raw);
+}
+
+function buildPrimIndex(catalog, scopeRules) {
+  const map = new Map();
+  const prims = Array.isArray(catalog?.primitives) ? catalog.primitives : [];
+  for (const prim of prims) {
+    if (!prim || typeof prim.name !== 'string') {
+      continue;
+    }
+    const key = prim.name.toLowerCase();
+    const id = typeof prim.id === 'string' ? prim.id : prim.name;
+    const scopes = Array.isArray(scopeRules?.[id]) ? scopeRules[id] : [];
+    map.set(key, { id, scopes });
+  }
+  return map;
+}
+
+function ensureTrailingNewline(text) {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error?.stack || error}\n`);
+  process.exit(1);
+});

--- a/scripts/emit-smt-laws-suite.mjs
+++ b/scripts/emit-smt-laws-suite.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+const SUITE = [
+  { file: 'idempotent_hash.smt2', kind: 'law', law: 'idempotent:hash' },
+  {
+    file: 'inverse_roundtrip.smt2',
+    kind: 'equiv',
+    left: ['serialize', 'deserialize'],
+    right: ['id'],
+    laws: ['inverse:serialize-deserialize'],
+  },
+  { file: 'write_idempotent_by_key.smt2', kind: 'law', law: 'idempotent:write-by-key' },
+  { file: 'emit_commute.smt2', kind: 'law', law: 'commute:emit-metric-with-pure' },
+];
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      out: { type: 'string', short: 'o' },
+    },
+    allowPositionals: true,
+  });
+
+  if (positionals.length > 0) {
+    usage('unexpected positional arguments');
+    process.exit(2);
+  }
+
+  const outDir = typeof values.out === 'string' ? resolve(values.out) : null;
+  if (!outDir) {
+    usage('missing --out <dir>');
+    process.exit(2);
+  }
+
+  await mkdir(outDir, { recursive: true });
+
+  for (const entry of SUITE) {
+    const target = join(outDir, entry.file);
+    const payload = emitEntry(entry);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, ensureTrailingNewline(payload), 'utf8');
+    process.stdout.write(`wrote ${target}\n`);
+  }
+}
+
+function emitEntry(entry) {
+  if (entry.kind === 'law') {
+    return emitLaw(entry.law);
+  }
+  if (entry.kind === 'equiv') {
+    const left = Array.isArray(entry.left) ? entry.left : [];
+    const right = Array.isArray(entry.right) ? entry.right : [];
+    const laws = Array.isArray(entry.laws) ? entry.laws : [];
+    return emitFlowEquivalence(left, right, laws);
+  }
+  throw new Error(`Unknown suite entry kind: ${entry.kind}`);
+}
+
+function ensureTrailingNewline(text) {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+function usage(message) {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.stderr.write('Usage: node scripts/emit-smt-laws-suite.mjs -o <outDir>\n');
+}
+
+main(process.argv).catch((error) => {
+  process.stderr.write(`${error?.stack || error}\n`);
+  process.exit(1);
+});

--- a/tests/alloy-auth.test.mjs
+++ b/tests/alloy-auth.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseDSL } from '../packages/tf-compose/src/parser.mjs';
+import { emitAlloyAuth } from '../packages/tf-l0-proofs/src/alloy-auth.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const flowsDir = join(repoRoot, 'examples', 'flows');
+
+const primIndexPromise = loadPrimIndex();
+
+test('authorize dominance model flags missing coverage', async () => {
+  const ir = await loadFlow('auth_missing.tf');
+  const primIndex = await primIndexPromise;
+  const alloy = emitAlloyAuth(ir, { primIndex });
+
+  assert.ok(alloy.includes('pred MissingAuth { some n:Prim | some n.scopeNeed and not Covered[n] }'));
+  assert.ok(alloy.includes('pred Covered[n:Prim] { some r:Region | Dominates[r, n] and some (r.scopes & n.scopeNeed) }'));
+  assert.ok(alloy.includes('run { MissingAuth }'));
+  assert.ok(alloy.includes('run { not MissingAuth }'));
+  assert.ok(/Scope_kms_sign/.test(alloy), 'declares kms.sign scope atom');
+  assert.ok(/PrimScopeNeeds\s*\{[\s\S]*Scope_kms_sign/.test(alloy), 'links prim to scope need');
+});
+
+test('authorize dominance model is deterministic and includes runs when covered', async () => {
+  const ir = await loadFlow('auth_ok.tf');
+  const primIndex = await primIndexPromise;
+  const first = emitAlloyAuth(ir, { primIndex });
+  const second = emitAlloyAuth(ir, { primIndex });
+
+  assert.equal(first, second, 'emission is deterministic');
+  assert.ok(first.includes('pred MissingAuth'));
+  assert.ok(first.includes('run { MissingAuth }'));
+  assert.ok(first.includes('run { not MissingAuth }'));
+});
+
+async function loadFlow(filename) {
+  const raw = await readFile(join(flowsDir, filename), 'utf8');
+  return parseDSL(raw);
+}
+
+async function loadPrimIndex() {
+  const [catalogRaw, scopesRaw] = await Promise.all([
+    readFile(join(repoRoot, 'packages/tf-l0-spec/spec/catalog.json'), 'utf8'),
+    readFile(join(repoRoot, 'packages/tf-l0-check/rules/authorize-scopes.json'), 'utf8'),
+  ]);
+  const catalog = JSON.parse(catalogRaw);
+  const scopeRules = JSON.parse(scopesRaw);
+  const map = new Map();
+  const prims = Array.isArray(catalog?.primitives) ? catalog.primitives : [];
+  for (const prim of prims) {
+    if (!prim || typeof prim.name !== 'string') {
+      continue;
+    }
+    const key = prim.name.toLowerCase();
+    const id = typeof prim.id === 'string' ? prim.id : prim.name;
+    const scopes = Array.isArray(scopeRules?.[id]) ? scopeRules[id] : [];
+    map.set(key, { id, scopes });
+  }
+  return map;
+}

--- a/tests/smt-laws-extend.test.mjs
+++ b/tests/smt-laws-extend.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { emitLaw, emitFlowEquivalence } from '../packages/tf-l0-proofs/src/smt-laws.mjs';
+
+const exec = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+function tmpPath(prefix) {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+test('write idempotency law encodes repeated write collapse', () => {
+  const smt = emitLaw('idempotent:write-by-key');
+  assert.ok(smt.includes('(declare-fun W (URI Key IdKey Val) Val)'), 'declares write function');
+  assert.ok(
+    smt.includes('(assert (not (= (twice x u k ik v) (once x u k ik v))))'),
+    'idempotent law asserts collapse'
+  );
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'law ends with check-sat');
+});
+
+test('serialize/deserialize equivalence compares against identity', () => {
+  const smt = emitFlowEquivalence(
+    ['serialize', 'deserialize'],
+    ['id'],
+    ['inverse:serialize-deserialize']
+  );
+  assert.ok(
+    smt.includes('(forall ((v Val)) (= (D (S v)) v))'),
+    'includes forward roundtrip axiom'
+  );
+  assert.ok(
+    smt.includes('(forall ((b Bytes)) (= (S (D b)) b))'),
+    'includes reverse roundtrip axiom'
+  );
+  assert.ok(
+    smt.includes('(assert (not (= outA outB)))'),
+    'equivalence asserts disequality'
+  );
+  assert.ok(smt.trim().endsWith('(check-sat)'), 'equivalence ends with check-sat');
+});
+
+test('suite emitter is deterministic', async () => {
+  const firstDir = await tmpPath('smt-laws-suite-');
+  const secondDir = await tmpPath('smt-laws-suite-');
+
+  await exec('node', ['scripts/emit-smt-laws-suite.mjs', '-o', firstDir], { cwd: repoRoot });
+  await exec('node', ['scripts/emit-smt-laws-suite.mjs', '-o', secondDir], { cwd: repoRoot });
+
+  const writeLaw = await readFile(join(firstDir, 'write_idempotent_by_key.smt2'), 'utf8');
+  assert.ok(
+    writeLaw.includes('(assert (not (= (twice x u k ik v) (once x u k ik v))))'),
+    'write law captures idempotency'
+  );
+  assert.ok(writeLaw.trim().endsWith('(check-sat)'), 'write law ends with check-sat');
+
+  const inverse = await readFile(join(firstDir, 'inverse_roundtrip.smt2'), 'utf8');
+  assert.ok(
+    inverse.includes('(forall ((b Bytes)) (= (S (D b)) b))'),
+    'inverse roundtrip includes reverse axiom'
+  );
+  assert.ok(
+    inverse.includes('(forall ((v Val)) (= (D (S v)) v))'),
+    'inverse roundtrip includes forward axiom'
+  );
+  assert.ok(inverse.trim().endsWith('(check-sat)'), 'inverse file ends with check-sat');
+
+  await assertDirectoriesEqual(firstDir, secondDir);
+});
+
+async function assertDirectoriesEqual(leftDir, rightDir) {
+  const [leftFiles, rightFiles] = await Promise.all([
+    listFiles(leftDir),
+    listFiles(rightDir),
+  ]);
+  assert.deepEqual(leftFiles.map((f) => f.name), rightFiles.map((f) => f.name), 'file sets match');
+  for (let i = 0; i < leftFiles.length; i++) {
+    const leftContent = await readFile(join(leftDir, leftFiles[i].name), 'utf8');
+    const rightContent = await readFile(join(rightDir, rightFiles[i].name), 'utf8');
+    assert.equal(leftContent, rightContent, `content matches for ${leftFiles[i].name}`);
+  }
+}
+
+async function listFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = entries.filter((entry) => entry.isFile()).map((entry) => ({ name: entry.name }));
+  files.sort((a, b) => a.name.localeCompare(b.name));
+  return files;
+}


### PR DESCRIPTION
## Summary
- extend the SMT law encoder with keyed-write idempotency, identity-aware roundtrip support, and a suite CLI
- add an authorize-dominance Alloy emitter plus CLI wired to catalog scope metadata
- document the new obligations and add regression tests for the SMT suite and Alloy auth exports

## Testing
- pnpm -w -r build *(fails: @tf-lang/coverage-generator build exits 2 — missing workspace deps)*
- node scripts/emit-smt-laws-suite.mjs -o out/0.4/proofs/laws
- node scripts/emit-alloy-auth.mjs examples/flows/auth_missing.tf -o out/0.4/proofs/auth/missing.als
- node scripts/emit-alloy-auth.mjs examples/flows/auth_ok.tf -o out/0.4/proofs/auth/ok.als
- pnpm -w -r test *(fails: @tf-lang/adapter-execution-ts test exits 1 via vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d04a97edd0832092bde78d79302022