### PR TITLE
Add TS adapter surface and in-memory implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out
 # Summarize traces
 cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
+### Generated pipeline adapters
+- Each TS emission includes `runtime/adapters/types.ts`, which defines the minimal `Adapters` surface (network, storage, crypto, observability).
+- `src/adapters.ts` exports `requireAdapters` so pipelines can assert that their runtime implements every primitive referenced in the IR.
+- The runtime ships with `runtime/adapters/inmem.mjs` — a deterministic in-memory implementation (`createInmemAdapters`) that powers the default runner and is handy for local tests.
+
 ### Trace files (T3)
 - Runners always print JSON trace lines to stdout; setting `TF_TRACE_PATH=out/0.4/traces/<name>.jsonl` is an optional mirror.
 - Per run: `TF_TRACE_PATH=out/0.4/traces/publish.jsonl node out/0.4/codegen-ts/run_publish/run.mjs --caps caps.json`.

--- a/examples/flows/crypto_sign_verify.tf
+++ b/examples/flows/crypto_sign_verify.tf
@@ -1,0 +1,4 @@
+seq{
+  sign-data(key_ref="k1", payload="payload");
+  verify-signature(key_ref="k1", payload="payload", signature="uC/LeRrOxXhZuYm0MKgmSIzi5Hn9+SMmvQoug3WkK6Q=")
+}

--- a/examples/flows/metrics_publish.tf
+++ b/examples/flows/metrics_publish.tf
@@ -1,0 +1,4 @@
+seq{
+  emit-metric(name="jobs.processed", value=1);
+  publish(topic="events", key="job-1", payload="{}")
+}

--- a/examples/flows/storage_cas.tf
+++ b/examples/flows/storage_cas.tf
@@ -1,1 +1,5 @@
-read-object(uri="res://kv/users", key="alice") |> transform(fn="setField", field="status", value="active") |> compare-and-swap(uri="res://kv/users", key="alice")
+seq{
+  write-object(uri="res://kv/users", key="alice", value="v1");
+  compare-and-swap(uri="res://kv/users", key="alice", expect="v0", update="v2");
+  compare-and-swap(uri="res://kv/users", key="alice", expect="v1", update="v3")
+}

--- a/packages/tf-l0-codegen-ts/src/adapters/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/adapters/inmem.mjs
@@ -1,0 +1,175 @@
+import { createHash, createHmac } from 'node:crypto';
+
+function ensureString(value) {
+  return typeof value === 'string' ? value : String(value ?? '');
+}
+
+function asUint8Array(data) {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  if (Array.isArray(data)) {
+    return Uint8Array.from(data);
+  }
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data);
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+  throw new TypeError('Expected data to be convertible to Uint8Array');
+}
+
+export function createInmemAdapters(options = {}) {
+  const published = [];
+  const topics = new Map();
+  const storage = new Map();
+  const idempotencyTokens = new Set();
+  const metricCounters = new Map();
+  const keyMap = Object.assign({ k1: 'secret' }, options.keys || {});
+
+  function storageBucket(uri) {
+    if (!storage.has(uri)) {
+      storage.set(uri, new Map());
+    }
+    return storage.get(uri);
+  }
+
+  const adapters = {
+    async publish(topic, key, payload) {
+      const entry = {
+        topic: ensureString(topic),
+        key: ensureString(key),
+        payload: ensureString(payload),
+      };
+      published.push(entry);
+      if (!topics.has(entry.topic)) {
+        topics.set(entry.topic, []);
+      }
+      topics.get(entry.topic).push(entry);
+    },
+
+    async writeObject(uri, key, value, idempotencyKey) {
+      const bucket = storageBucket(ensureString(uri));
+      const storageKey = ensureString(key);
+      const valueStr = ensureString(value);
+      if (idempotencyKey) {
+        const token = `${ensureString(uri)}#${storageKey}#${ensureString(idempotencyKey)}`;
+        if (idempotencyTokens.has(token)) {
+          return;
+        }
+        idempotencyTokens.add(token);
+      }
+      bucket.set(storageKey, valueStr);
+    },
+
+    async readObject(uri, key) {
+      const bucket = storage.get(ensureString(uri));
+      if (!bucket) return null;
+      if (!bucket.has(ensureString(key))) return null;
+      return bucket.get(ensureString(key));
+    },
+
+    async compareAndSwap(uri, key, expect, update) {
+      const bucket = storage.get(ensureString(uri));
+      if (!bucket) return false;
+      const storageKey = ensureString(key);
+      if (!bucket.has(storageKey)) return false;
+      const current = bucket.get(storageKey);
+      if (current !== ensureString(expect)) {
+        return false;
+      }
+      bucket.set(storageKey, ensureString(update));
+      return true;
+    },
+
+    async sign(keyId, data) {
+      const key = keyMap[keyId];
+      if (typeof key !== 'string') {
+        throw new Error(`inmem adapters: unknown keyId ${keyId}`);
+      }
+      const payload = asUint8Array(data);
+      const hmac = createHmac('sha256', key);
+      hmac.update(payload);
+      return Uint8Array.from(hmac.digest());
+    },
+
+    async verify(keyId, data, sig) {
+      const key = keyMap[keyId];
+      if (typeof key !== 'string') {
+        return false;
+      }
+      const expected = await adapters.sign(keyId, data);
+      const provided = asUint8Array(sig);
+      if (expected.length !== provided.length) {
+        return false;
+      }
+      let mismatch = 0;
+      for (let i = 0; i < expected.length; i += 1) {
+        mismatch |= expected[i] ^ provided[i];
+      }
+      return mismatch === 0;
+    },
+
+    async hash(data) {
+      const payload = asUint8Array(data);
+      const digest = createHash('sha256').update(payload).digest('hex');
+      return digest;
+    },
+
+    async emitMetric(name, value = 1) {
+      const metricName = ensureString(name);
+      const delta = Number.isFinite(value) ? Number(value) : 1;
+      const current = metricCounters.get(metricName) ?? 0;
+      metricCounters.set(metricName, current + delta);
+    },
+
+    getPublished() {
+      return published.map((entry) => ({ ...entry }));
+    },
+
+    getMetrics() {
+      return new Map(metricCounters);
+    },
+
+    getTopics() {
+      const out = new Map();
+      for (const [topic, list] of topics.entries()) {
+        out.set(topic, list.map((entry) => ({ ...entry })));
+      }
+      return out;
+    },
+
+    getStorageSnapshot() {
+      const out = new Map();
+      for (const [uri, bucket] of storage.entries()) {
+        out.set(uri, new Map(bucket));
+      }
+      return out;
+    },
+
+    reset() {
+      published.length = 0;
+      topics.clear();
+      storage.clear();
+      idempotencyTokens.clear();
+      metricCounters.clear();
+    },
+  };
+
+  Object.defineProperty(adapters, 'state', {
+    enumerable: false,
+    value: {
+      topics,
+      storage,
+      metrics: metricCounters,
+    },
+  });
+
+  return adapters;
+}
+
+export default createInmemAdapters;

--- a/packages/tf-l0-codegen-ts/src/adapters/types.ts
+++ b/packages/tf-l0-codegen-ts/src/adapters/types.ts
@@ -1,0 +1,21 @@
+export interface Network {
+  publish(topic: string, key: string, payload: string): Promise<void>;
+}
+
+export interface Storage {
+  writeObject(uri: string, key: string, value: string, idempotencyKey?: string): Promise<void>;
+  readObject?(uri: string, key: string): Promise<string | null>;
+  compareAndSwap?(uri: string, key: string, expect: string, update: string): Promise<boolean>;
+}
+
+export interface Crypto {
+  sign(keyId: string, data: Uint8Array): Promise<Uint8Array>;
+  verify?(keyId: string, data: Uint8Array, sig: Uint8Array): Promise<boolean>;
+  hash?(data: Uint8Array): Promise<string>;
+}
+
+export interface Observability {
+  emitMetric(name: string, value?: number): Promise<void>;
+}
+
+export interface Adapters extends Partial<Crypto & Storage & Network & Observability> {}

--- a/tests/adapters-inmem.test.mjs
+++ b/tests/adapters-inmem.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInmemAdapters } from '../packages/tf-l0-codegen-ts/src/adapters/inmem.mjs';
+
+function bytesOf(text) {
+  return Uint8Array.from(Buffer.from(text, 'utf8'));
+}
+
+test('publish entries accumulate', async () => {
+  const adapters = createInmemAdapters();
+  await adapters.publish('events', 'k1', '{"a":1}');
+  await adapters.publish('events', 'k2', '{"a":2}');
+  const published = adapters.getPublished();
+  assert.equal(published.length, 2);
+  assert.deepEqual(published[0], { topic: 'events', key: 'k1', payload: '{"a":1}' });
+});
+
+test('idempotent writeObject honors idempotencyKey', async () => {
+  const adapters = createInmemAdapters();
+  await adapters.writeObject('res://kv/demo', 'doc', 'first', 'ik-1');
+  await adapters.writeObject('res://kv/demo', 'doc', 'second', 'ik-1');
+  const stored = await adapters.readObject('res://kv/demo', 'doc');
+  assert.equal(stored, 'first');
+});
+
+test('compareAndSwap requires matching expected value', async () => {
+  const adapters = createInmemAdapters();
+  await adapters.writeObject('res://kv/demo', 'flag', 'off');
+  const fail = await adapters.compareAndSwap('res://kv/demo', 'flag', 'on', 'mid');
+  assert.equal(fail, false);
+  const ok = await adapters.compareAndSwap('res://kv/demo', 'flag', 'off', 'on');
+  assert.equal(ok, true);
+  const stored = await adapters.readObject('res://kv/demo', 'flag');
+  assert.equal(stored, 'on');
+});
+
+test('sign and verify succeed for matching inputs', async () => {
+  const adapters = createInmemAdapters({ keys: { k1: 'secret-key' } });
+  const payload = bytesOf('payload');
+  const signature = await adapters.sign('k1', payload);
+  const ok = await adapters.verify('k1', payload, signature);
+  assert.equal(ok, true);
+  const bad = await adapters.verify('k1', payload, Uint8Array.from(signature, (b) => b ^ 0xff));
+  assert.equal(bad, false);
+});
+
+test('emitMetric aggregates counts deterministically', async () => {
+  const adapters = createInmemAdapters();
+  await adapters.emitMetric('jobs');
+  await adapters.emitMetric('jobs', 2);
+  await adapters.emitMetric('errors');
+  const metrics = adapters.getMetrics();
+  assert.equal(metrics.get('jobs'), 3);
+  assert.equal(metrics.get('errors'), 1);
+});

--- a/tests/codegen-adapters-wireup.test.mjs
+++ b/tests/codegen-adapters-wireup.test.mjs
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const tfCli = join(repoRoot, 'packages', 'tf-compose', 'bin', 'tf.mjs');
+const validatorCli = join(repoRoot, 'scripts', 'validate-trace.mjs');
+
+function runNode(script, args = [], { cwd = repoRoot, env = {}, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [script, ...args], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    if (input !== undefined) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+const flows = [
+  {
+    name: 'storage_cas',
+    path: 'examples/flows/storage_cas.tf',
+    expectedEffects: ['Storage.Write'],
+    minOps: 3,
+    caps: {
+      effects: ['Storage.Write', 'Storage.Read', 'Pure'],
+      allow_writes_prefixes: ['res://kv/'],
+    },
+  },
+  {
+    name: 'crypto_sign_verify',
+    path: 'examples/flows/crypto_sign_verify.tf',
+    expectedEffects: ['Crypto'],
+    minOps: 2,
+    caps: {
+      effects: ['Crypto', 'Pure'],
+      allow_writes_prefixes: [],
+    },
+  },
+  {
+    name: 'metrics_publish',
+    path: 'examples/flows/metrics_publish.tf',
+    expectedEffects: ['Network.Out', 'Observability.EmitMetric'],
+    minOps: 2,
+    caps: {
+      effects: ['Network.Out', 'Observability.EmitMetric', 'Observability', 'Pure'],
+      allow_writes_prefixes: [],
+    },
+  },
+];
+
+test('generated adapters run end-to-end with in-memory implementations', async () => {
+  const tempRoot = await fs.mkdtemp(join(tmpdir(), 'tf-wireup-'));
+  for (const flow of flows) {
+    const outDir = join(repoRoot, 'out', '0.4', 'codegen-ts', flow.name);
+    await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
+    const emit = await runNode(tfCli, ['emit', '--lang', 'ts', flow.path, '--out', outDir]);
+    assert.equal(emit.code, 0, emit.stderr);
+
+    const capsPath = join(tempRoot, `${flow.name}-caps.json`);
+    await fs.writeFile(capsPath, JSON.stringify(flow.caps));
+
+    const tracePath = join(tempRoot, `${flow.name}-trace.jsonl`);
+
+    const run1 = await runNode(join(outDir, 'run.mjs'), ['--caps', capsPath], { env: { TF_TRACE_PATH: tracePath } });
+    assert.equal(run1.code, 0, run1.stderr);
+    const summaryLine = run1.stdout.trim().split('\n').filter(Boolean).pop();
+    assert.ok(summaryLine, 'expected summary JSON on stdout');
+    const summary = JSON.parse(summaryLine);
+    assert.equal(summary.ok, true, `expected ok summary for ${flow.name}`);
+    assert.ok(summary.ops >= flow.minOps, `expected at least ${flow.minOps} ops for ${flow.name}`);
+    for (const effect of flow.expectedEffects) {
+      assert.ok(summary.effects.includes(effect), `expected effect ${effect} in ${flow.name}`);
+    }
+
+    const statusPath = join(outDir, 'status.json');
+    const statusFirst = await fs.readFile(statusPath, 'utf8');
+
+    const run2 = await runNode(join(outDir, 'run.mjs'), ['--caps', capsPath], { env: { TF_TRACE_PATH: tracePath } });
+    assert.equal(run2.code, 0, run2.stderr);
+    const summaryLineTwo = run2.stdout.trim().split('\n').filter(Boolean).pop();
+    assert.equal(summaryLineTwo, summaryLine, 'summary output should be deterministic');
+    const statusSecond = await fs.readFile(statusPath, 'utf8');
+    assert.equal(statusSecond, statusFirst, 'status.json should be stable between runs');
+
+    try {
+      const traceRaw = await fs.readFile(tracePath, 'utf8');
+      if (traceRaw.trim().length > 0) {
+        const validate = await runNode(validatorCli, [], { input: traceRaw });
+        assert.equal(validate.code, 0, validate.stderr);
+        const validatorSummary = JSON.parse(validate.stdout.trim());
+        assert.equal(validatorSummary.ok, true);
+      }
+    } catch (err) {
+      if (err?.code !== 'ENOENT') throw err;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add typed adapter interfaces plus deterministic in-memory implementations for the TS codegen output and runtime
- extend the generator, sample flows, and docs to surface the new adapters
- add adapter/unit/integration tests and align pilot tooling with the new manifest + IR hashes

## Testing
- pnpm -w -r build
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d04a8043508320922e103eef842447