### PR TITLE
Add deterministic adapters and provenance tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ node scripts/generate-rs.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/si
 # Generate TS skeleton for the flow
 npm run tf -- emit --lang ts examples/flows/signing.tf --out out/0.4/codegen-ts/signing
 
+### Generated pipeline adapters
+
+Generated TypeScript bundles include a shared `src/adapters.ts` definition that re-exports the runtime adapter surface. The runtime layer wires deterministic in-memory implementations for network publish, storage writes/CAS, crypto sign/verify/hash, and observability metrics. Each `run.mjs` bootstraps these adapters automatically and enforces capability manifests via `--caps` or `TF_CAPS`, so flows can be executed in tests without external services.
+
 # Run generated code with capability enforcement (+ env fallback)
 # caps.json: {"effects":["Storage.Write","Pure","Observability"],"allow_writes_prefixes":["res://kv/"]}
 npm run tf -- emit --lang ts examples/flows/run_storage_ok.tf --out out/0.4/codegen-ts/run_storage_ok

--- a/examples/flows/crypto_sign_verify.tf
+++ b/examples/flows/crypto_sign_verify.tf
@@ -1,0 +1,4 @@
+seq{
+  sign-data(key_ref="k1", data="payload");
+  verify-signature(key_ref="k1", data="payload", signature="b82fcb791acec57859b989b430a826488ce2e479fdf92326bd0a2e8375a42ba4");
+}

--- a/examples/flows/metrics_publish.tf
+++ b/examples/flows/metrics_publish.tf
@@ -1,0 +1,4 @@
+seq{
+  emit-metric(name="pipeline.run", value=1);
+  publish(topic="events", key="run-1", payload="{\"ok\":true}");
+}

--- a/examples/flows/storage_cas.tf
+++ b/examples/flows/storage_cas.tf
@@ -1,1 +1,5 @@
-read-object(uri="res://kv/users", key="alice") |> transform(fn="setField", field="status", value="active") |> compare-and-swap(uri="res://kv/users", key="alice")
+seq{
+  write-object(uri="res://kv/users", key="alice", value="v1", idempotency_key="init-1");
+  compare-and-swap(uri="res://kv/users", key="alice", value="v2", ifMatch="mismatch");
+  compare-and-swap(uri="res://kv/users", key="alice", value="v3", ifMatch="v1");
+}

--- a/packages/tf-l0-codegen-ts/src/adapters/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/adapters/inmem.mjs
@@ -1,0 +1,219 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+const encoder = new TextEncoder();
+
+function isHexString(value) {
+  return typeof value === 'string' && value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value);
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  const out = {};
+  for (const key of Object.keys(value).sort()) {
+    const canonical = canonicalize(value[key]);
+    if (canonical !== undefined) {
+      out[key] = canonical;
+    }
+  }
+  return out;
+}
+
+function stableStringify(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function toUint8Array(value) {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (typeof value === 'string') {
+    if (isHexString(value)) {
+      return new Uint8Array(Buffer.from(value, 'hex'));
+    }
+    return encoder.encode(value);
+  }
+  if (value === null || value === undefined) {
+    return new Uint8Array(0);
+  }
+  if (typeof value === 'number') {
+    return encoder.encode(String(value));
+  }
+  if (typeof value === 'boolean') {
+    return encoder.encode(value ? 'true' : 'false');
+  }
+  return encoder.encode(stableStringify(value));
+}
+
+function normalizeString(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value instanceof Uint8Array || ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return Buffer.from(toUint8Array(value)).toString('utf8');
+  }
+  return stableStringify(value);
+}
+
+function snapshotStorage(storage) {
+  const out = new Map();
+  for (const [uri, bucket] of storage.entries()) {
+    out.set(uri, new Map(bucket.entries()));
+  }
+  return out;
+}
+
+export function createInmemAdapters(options = {}) {
+  const published = [];
+  const storage = new Map();
+  const idempotency = new Set();
+  const metrics = new Map();
+  const keyMap = new Map(Object.entries(options.keys || { k1: 'secret' }));
+
+  function bucketFor(uri) {
+    if (!storage.has(uri)) {
+      storage.set(uri, new Map());
+    }
+    return storage.get(uri);
+  }
+
+  function recordMetric(name, value) {
+    const current = metrics.get(name) || 0;
+    metrics.set(name, current + value);
+  }
+
+  async function publish(topic, key, payload) {
+    const entry = {
+      topic: normalizeString(topic),
+      key: normalizeString(key),
+      payload: normalizeString(payload),
+    };
+    published.push(entry);
+  }
+
+  async function writeObject(uri, key, value, idempotencyKey) {
+    const targetUri = normalizeString(uri);
+    const targetKey = normalizeString(key);
+    const targetValue = normalizeString(value);
+    if (idempotencyKey) {
+      const token = `${targetUri}#${targetKey}#${normalizeString(idempotencyKey)}`;
+      if (idempotency.has(token)) {
+        return;
+      }
+      idempotency.add(token);
+    }
+    bucketFor(targetUri).set(targetKey, targetValue);
+  }
+
+  async function readObject(uri, key) {
+    const targetUri = normalizeString(uri);
+    const targetKey = normalizeString(key);
+    const bucket = storage.get(targetUri);
+    if (!bucket || !bucket.has(targetKey)) {
+      return null;
+    }
+    return bucket.get(targetKey);
+  }
+
+  async function compareAndSwap(uri, key, expect, update) {
+    const targetUri = normalizeString(uri);
+    const targetKey = normalizeString(key);
+    const bucket = storage.get(targetUri);
+    if (!bucket || !bucket.has(targetKey)) {
+      return false;
+    }
+    const current = bucket.get(targetKey);
+    if (current !== normalizeString(expect)) {
+      return false;
+    }
+    bucket.set(targetKey, normalizeString(update));
+    return true;
+  }
+
+  function loadKey(keyId) {
+    const secret = keyMap.get(keyId);
+    if (typeof secret !== 'string') {
+      throw new Error(`inmem adapters: unknown keyId ${keyId}`);
+    }
+    return secret;
+  }
+
+  async function sign(keyId, data) {
+    const secret = loadKey(normalizeString(keyId));
+    const bytes = toUint8Array(data);
+    return createHmac('sha256', secret).update(bytes).digest();
+  }
+
+  async function verify(keyId, data, sig) {
+    const secret = loadKey(normalizeString(keyId));
+    const bytes = toUint8Array(data);
+    const expected = createHmac('sha256', secret).update(bytes).digest();
+    const actual = toUint8Array(sig);
+    const actualBuffer = Buffer.from(actual);
+    if (actualBuffer.length !== expected.length) {
+      return false;
+    }
+    return timingSafeEqual(expected, actualBuffer);
+  }
+
+  async function hash(data) {
+    const bytes = toUint8Array(data);
+    const digest = createHash('sha256').update(bytes).digest('hex');
+    return `sha256:${digest}`;
+  }
+
+  async function emitMetric(name, value = 1) {
+    const metricName = normalizeString(name);
+    const numeric = Number(value ?? 1);
+    const delta = Number.isFinite(numeric) ? numeric : 1;
+    recordMetric(metricName, delta);
+  }
+
+  function reset() {
+    published.length = 0;
+    storage.clear();
+    idempotency.clear();
+    metrics.clear();
+  }
+
+  return {
+    adapters: {
+      publish,
+      writeObject,
+      readObject,
+      compareAndSwap,
+      sign,
+      verify,
+      hash,
+      emitMetric,
+    },
+    reset,
+    getPublished() {
+      return published.map((entry) => ({ ...entry }));
+    },
+    getStorageSnapshot() {
+      return snapshotStorage(storage);
+    },
+    getMetrics() {
+      return new Map(metrics.entries());
+    },
+  };
+}
+
+export default createInmemAdapters;

--- a/packages/tf-l0-codegen-ts/src/adapters/types.ts
+++ b/packages/tf-l0-codegen-ts/src/adapters/types.ts
@@ -1,0 +1,21 @@
+export interface Network {
+  publish(topic: string, key: string, payload: string): Promise<void>;
+}
+
+export interface Storage {
+  writeObject(uri: string, key: string, value: string, idempotencyKey?: string): Promise<void>;
+  readObject?(uri: string, key: string): Promise<string | null>;
+  compareAndSwap?(uri: string, key: string, expect: string, update: string): Promise<boolean>;
+}
+
+export interface Crypto {
+  sign(keyId: string, data: Uint8Array): Promise<Uint8Array>;
+  verify?(keyId: string, data: Uint8Array, sig: Uint8Array): Promise<boolean>;
+  hash?(data: Uint8Array): Promise<string>;
+}
+
+export interface Observability {
+  emitMetric(name: string, value?: number): Promise<void>;
+}
+
+export interface Adapters extends Partial<Crypto & Storage & Network & Observability> {}

--- a/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
+++ b/packages/tf-l0-codegen-ts/src/runtime/inmem.mjs
@@ -1,132 +1,23 @@
-import { createHash } from 'node:crypto';
+import { createInmemAdapters } from '../adapters/inmem.mjs';
+import { runtimeFromAdapters } from './run-ir.mjs';
 
-const storage = new Map();
-const metricsLog = [];
-const topicQueues = new Map();
-const registry = new Map();
-const handlers = Object.create(null);
-
-function stableStringify(value) {
-  return JSON.stringify(canonicalize(value));
+export function createRuntime(options = {}) {
+  const instance = createInmemAdapters(options);
+  const runtime = runtimeFromAdapters(instance.adapters);
+  runtime.state = {
+    adapters: instance.adapters,
+    getPublished: instance.getPublished,
+    getMetrics: instance.getMetrics,
+    getStorageSnapshot: instance.getStorageSnapshot,
+    reset: instance.reset,
+  };
+  runtime.reset = instance.reset;
+  runtime.getPublished = instance.getPublished;
+  runtime.getMetrics = instance.getMetrics;
+  runtime.getStorageSnapshot = instance.getStorageSnapshot;
+  return runtime;
 }
 
-function canonicalize(value) {
-  if (value === null || typeof value !== 'object') {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => canonicalize(item));
-  }
-  const out = {};
-  for (const key of Object.keys(value).sort()) {
-    const canonical = canonicalize(value[key]);
-    if (canonical !== undefined) {
-      out[key] = canonical;
-    }
-  }
-  return out;
-}
-
-function keyFor(uri, key) {
-  return `${uri}#${key}`;
-}
-
-function nextEtag(current) {
-  return (Number.isFinite(current) ? Number(current) : 0) + 1;
-}
-
-function register(canonicalId, aliases, effect, impl) {
-  const entry = { canonicalId, effect, impl };
-  const names = new Set([canonicalId, ...(aliases || [])]);
-  for (const name of names) {
-    registry.set(name, entry);
-    handlers[name] = impl;
-  }
-}
-
-register('tf:resource/write-object@1', ['write-object'], 'Storage.Write', async ({ uri, key, value }) => {
-  const storageKey = keyFor(uri, key);
-  const current = storage.get(storageKey);
-  const etag = nextEtag(current?.etag);
-  storage.set(storageKey, { value, etag });
-  return { ok: true, etag };
-});
-
-register('tf:resource/read-object@1', ['read-object'], 'Storage.Read', async ({ uri, key }) => {
-  const storageKey = keyFor(uri, key);
-  const current = storage.get(storageKey);
-  if (!current) {
-    return { ok: false, value: null, etag: null };
-  }
-  return { ok: true, value: current.value, etag: current.etag };
-});
-
-register('tf:resource/compare-and-swap@1', ['compare-and-swap'], 'Storage.Write', async ({ uri, key, value, ifMatch }) => {
-  const storageKey = keyFor(uri, key);
-  const current = storage.get(storageKey);
-  if (!current) {
-    return { ok: false, etag: null };
-  }
-  const matches = String(current.etag) === String(ifMatch);
-  if (!matches) {
-    return { ok: false, etag: current.etag };
-  }
-  const etag = nextEtag(current.etag);
-  storage.set(storageKey, { value, etag });
-  return { ok: true, etag };
-});
-
-register('tf:information/hash@1', ['hash'], 'Information.Hash', async (args = {}) => {
-  const target = Object.prototype.hasOwnProperty.call(args, 'value') ? args.value : args;
-  const s = stableStringify(target);
-  const digest = createHash('sha256').update(s).digest('hex');
-  return { ok: true, hash: `sha256:${digest}` };
-});
-
-register('tf:observability/emit-metric@1', ['emit-metric'], 'Observability.EmitMetric', async (args = {}) => {
-  metricsLog.push(args);
-  if (process.env.DEV_PROOFS) {
-    console.log('[metric]', JSON.stringify(args));
-  }
-  return { ok: true };
-});
-
-register('tf:network/publish@1', ['publish'], 'Network.Out', async (args = {}) => {
-  const topic = args.topic ?? 'default';
-  if (!topicQueues.has(topic)) {
-    topicQueues.set(topic, []);
-  }
-  topicQueues.get(topic).push(args);
-  return { ok: true };
-});
-
-function effectFor(name) {
-  const entry = registry.get(name);
-  return entry?.effect ?? null;
-}
-
-const inmem = handlers;
-
-inmem.getAdapter = function getAdapter(name) {
-  return registry.get(name)?.impl ?? null;
-};
-
-inmem.canonicalPrim = function canonicalPrim(name) {
-  return registry.get(name)?.canonicalId ?? name;
-};
-
-inmem.effectFor = effectFor;
-
-inmem.state = {
-  storage,
-  metrics: metricsLog,
-  topics: topicQueues,
-};
-
-inmem.reset = function reset() {
-  storage.clear();
-  metricsLog.length = 0;
-  topicQueues.clear();
-};
+const inmem = createRuntime();
 
 export default inmem;

--- a/tests/adapters-inmem.test.mjs
+++ b/tests/adapters-inmem.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInmemAdapters } from '../packages/tf-l0-codegen-ts/src/adapters/inmem.mjs';
+import { runtimeFromAdapters } from '../packages/tf-l0-codegen-ts/src/runtime/run-ir.mjs';
+
+const encoder = new TextEncoder();
+
+test('network publish appends entries for inspection', async () => {
+  const instance = createInmemAdapters();
+  await instance.adapters.publish('events', 'run-1', '{"ok":true}');
+  await instance.adapters.publish('events', 'run-2', '{"ok":false}');
+  assert.deepEqual(instance.getPublished(), [
+    { topic: 'events', key: 'run-1', payload: '{"ok":true}' },
+    { topic: 'events', key: 'run-2', payload: '{"ok":false}' },
+  ]);
+});
+
+test('storage write honors idempotency keys and supports reads', async () => {
+  const instance = createInmemAdapters();
+  await instance.adapters.writeObject('res://kv/users', 'alice', 'v1', 'idem-1');
+  await instance.adapters.writeObject('res://kv/users', 'alice', 'v2', 'idem-1');
+  const stored = await instance.adapters.readObject('res://kv/users', 'alice');
+  assert.equal(stored, 'v1');
+  await instance.adapters.writeObject('res://kv/users', 'alice', 'v3');
+  const updated = await instance.adapters.readObject('res://kv/users', 'alice');
+  assert.equal(updated, 'v3');
+});
+
+test('compareAndSwap transitions false to true with matching values', async () => {
+  const instance = createInmemAdapters();
+  await instance.adapters.writeObject('res://kv/users', 'bob', 'seed');
+  const first = await instance.adapters.compareAndSwap('res://kv/users', 'bob', 'other', 'v1');
+  assert.equal(first, false);
+  const second = await instance.adapters.compareAndSwap('res://kv/users', 'bob', 'seed', 'v2');
+  assert.equal(second, true);
+  const stored = await instance.adapters.readObject('res://kv/users', 'bob');
+  assert.equal(stored, 'v2');
+});
+
+test('sign/verify round-trip and hashing return deterministic values', async () => {
+  const instance = createInmemAdapters();
+  const data = encoder.encode('payload');
+  const signature = await instance.adapters.sign('k1', data);
+  assert.ok(signature instanceof Uint8Array);
+  assert.ok(signature.length > 0);
+  const ok = await instance.adapters.verify('k1', data, signature);
+  assert.equal(ok, true);
+  const digest = await instance.adapters.hash(data);
+  assert.match(digest, /^sha256:/);
+});
+
+test('hash adapter receives canonicalized bytes from runtime', async () => {
+  const instance = createInmemAdapters();
+  const runtime = runtimeFromAdapters(instance.adapters);
+  const first = await runtime['tf:information/hash@1']({ data: { b: 2, a: 1 } });
+  const second = await runtime['tf:information/hash@1']({ data: { a: 1, b: 2 } });
+  assert.equal(first.hash, second.hash);
+  const permuted = await runtime['tf:information/hash@1']({ data: [{ y: 2, x: 1 }, { x: 1, y: 2 }] });
+  const permutedAlt = await runtime['tf:information/hash@1']({ data: [{ x: 1, y: 2 }, { y: 2, x: 1 }] });
+  assert.equal(permuted.hash, permutedAlt.hash);
+});
+
+test('metrics accumulate counts deterministically', async () => {
+  const instance = createInmemAdapters();
+  await instance.adapters.emitMetric('pipeline.run');
+  await instance.adapters.emitMetric('pipeline.run', 3);
+  await instance.adapters.emitMetric('pipeline.error', 0);
+  const metrics = instance.getMetrics();
+  assert.equal(metrics.get('pipeline.run'), 4);
+  assert.equal(metrics.get('pipeline.error'), 0);
+});

--- a/tests/codegen-adapters-wireup.test.mjs
+++ b/tests/codegen-adapters-wireup.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const capsPath = join(repoRoot, 'tests/fixtures/caps-all.json');
+const flows = [
+  {
+    name: 'storage_cas',
+    flowPath: join(repoRoot, 'examples/flows/storage_cas.tf'),
+    expectEffects: ['Storage.Write'],
+  },
+  {
+    name: 'crypto_sign_verify',
+    flowPath: join(repoRoot, 'examples/flows/crypto_sign_verify.tf'),
+    expectEffects: ['Crypto'],
+  },
+  {
+    name: 'metrics_publish',
+    flowPath: join(repoRoot, 'examples/flows/metrics_publish.tf'),
+    expectEffects: ['Network.Out', 'Observability.EmitMetric'],
+  },
+];
+
+async function runFlow(outDir) {
+  const runScript = join(outDir, 'run.mjs');
+  const { stdout } = await execFileAsync('node', [runScript, '--caps', capsPath], { cwd: outDir });
+  const lastLine = stdout.trim().split('\n').filter(Boolean).pop();
+  return JSON.parse(lastLine);
+}
+
+test('generated TS pipelines wire adapters into the runtime', async (t) => {
+  for (const flow of flows) {
+    await t.test(flow.name, async () => {
+      const outDir = join(repoRoot, 'out', '0.4', 'codegen-ts', flow.name);
+      await rm(outDir, { recursive: true, force: true });
+      await execFileAsync('node', [
+        join(repoRoot, 'packages/tf-compose/bin/tf.mjs'),
+        '--',
+        'emit',
+        '--lang',
+        'ts',
+        flow.flowPath,
+        '--out',
+        outDir,
+      ], { cwd: repoRoot });
+
+      const first = await runFlow(outDir);
+      assert.equal(first.ok, true, 'first run ok');
+      assert.ok(Number.isFinite(first.ops) && first.ops >= 1, 'first run has ops');
+      for (const effect of flow.expectEffects) {
+        assert.ok(first.effects.includes(effect), `expected effect ${effect}`);
+      }
+
+      const statusPath = join(outDir, 'status.json');
+      const firstStatusRaw = await readFile(statusPath, 'utf8');
+
+      const second = await runFlow(outDir);
+      assert.equal(second.ok, true, 'second run ok');
+      assert.deepEqual(second.effects, first.effects, 'effects deterministic');
+      assert.equal(second.ops, first.ops, 'ops deterministic');
+      const secondStatusRaw = await readFile(statusPath, 'utf8');
+      assert.equal(secondStatusRaw, firstStatusRaw, 'status.json deterministic');
+    });
+  }
+});

--- a/tests/fixtures/caps-all.json
+++ b/tests/fixtures/caps-all.json
@@ -1,0 +1,1 @@
+{"effects":["Crypto","Network.Out","Observability","Pure","Storage.Read","Storage.Write"],"allow_writes_prefixes":["res://"]}


### PR DESCRIPTION
## Summary
- add a typed adapter surface and deterministic in-memory implementations to the TS runtime while canonicalizing hash inputs
- wire default adapters/capability checks into generated bundles and expand pilot scripts to export canonical IR, manifest hashes, and status provenance
- document adapter usage and add sample flows/tests covering storage CAS, crypto sign/verify, metrics+publish, and runtime wiring determinism

## Testing
- pnpm -w -r build
- pnpm -w -r test
- pnpm run tf -- emit --lang ts examples/flows/storage_cas.tf --out out/0.4/codegen-ts/storage_cas
- node out/0.4/codegen-ts/storage_cas/run.mjs --caps tests/fixtures/caps-observability.json

------
https://chatgpt.com/codex/tasks/task_e_68d04a8043508320922e103eef842447