### PR TITLE
Add docgen scripts and CI check for L0 docs

### DIFF
--- a/.github/workflows/l0-docs.yml
+++ b/.github/workflows/l0-docs.yml
@@ -1,0 +1,37 @@
+name: L0 Docs (regen check)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+
+      - name: Build (for lattice import)
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Regenerate docs
+        run: |
+          node scripts/docgen/catalog.mjs
+          node scripts/docgen/dsl.mjs
+          node scripts/docgen/effects.mjs
+
+      - name: Fail if changed
+        run: |
+          if [[ -n "$(git status --porcelain docs/*.md)" ]]; then
+            echo "Docs out of date. Run docgen scripts and commit." >&2
+            git diff -- docs
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ This repo skeleton grounds A0 → B4 so builders can flesh out implementations w
 arguing about structure. It includes: IDs & versions, catalog ingest, effects/laws stubs,
 DSL+IR+canonicalizer, checker glue, and TS/Rust codegen skeletons.
 
+Links:
+- [Catalog: docs/l0-catalog.md](docs/l0-catalog.md)
+- [DSL Cheatsheet: docs/l0-dsl.md](docs/l0-dsl.md)
+- [Effects/Lattice: docs/l0-effects.md](docs/l0-effects.md)
+
 ### Quick Start
 
 ```bash

--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -1,23 +1,129 @@
-# L0 Catalog (A1 skeleton)
-- `spec/ids.json` — IDs
-- `spec/catalog.json` — normalized catalog with placeholders
-- `spec/effects.json` — derived effect tags
-- `spec/laws.json` — law registry (sample rules)
+# L0 Catalog (generated)
+Primitives: 14
+Effects: Pure, Observability, Network.Out, Storage.Read, Storage.Write, Crypto, Policy, Infra, Time, UI
 
-### Seed Overlay
-Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
-`spec/seed/*.json` overlay into the generated catalog. The seed entries carry
-minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
-conflict detection stay runnable while curation continues.
+### tf:information/deserialize@1
 
-### Effect derivation rules
-Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
-Seed overlays remain authoritative for existing effects or qos values.
-Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+| Field | Value |
+| --- | --- |
+| Effects | `Pure` |
+| Input | None |
+| Output | None |
+| Laws | `law:serialize-deserialize-eq-id` |
 
-### Manifest compatibility
-For v0.4 manifests we emit both the legacy `effects`/`footprints` fields and the new
-`required_effects`/`footprints_rw`/`qos` structure for downstream compatibility. The
-two shapes are mutually exclusive, but the schema and CLI validator accept either so
-consumers can migrate on their own schedule. Use
-`node scripts/validate-manifest.mjs <path>` to confirm conformance.
+### tf:information/hash@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Pure` |
+| Input | None |
+| Output | None |
+| Laws | `law:hash-idempotent` |
+
+### tf:information/serialize@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Pure` |
+| Input | None |
+| Output | None |
+| Laws | `law:serialize-deserialize-eq-id` |
+
+### tf:network/acknowledge@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Network.Out` |
+| Input | None |
+| Output | None |
+| Laws | None |
+
+### tf:network/publish@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Network.Out` |
+| Input | None |
+| Output | None |
+| Laws | None |
+
+### tf:network/request@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Network.Out` |
+| Input | None |
+| Output | None |
+| Laws | None |
+
+### tf:network/subscribe@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Network.In` |
+| Input | None |
+| Output | None |
+| Laws | None |
+
+### tf:observability/emit-metric@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Observability` |
+| Input | None |
+| Output | None |
+| Laws | `law:emitmetric-commutes-with-pure` |
+
+### tf:resource/compare-and-swap@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Storage.Write` |
+| Input | None |
+| Output | mode=write, uri=res://kv/<bucket>/:<key>, notes=seed |
+| Laws | None |
+
+### tf:resource/delete-object@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Storage.Write` |
+| Input | None |
+| Output | mode=write, uri=res://kv/<bucket>/:<key>, notes=seed |
+| Laws | None |
+
+### tf:resource/read-object@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Storage.Read` |
+| Input | mode=read, uri=res://kv/<bucket>/:<key>, notes=seed |
+| Output | None |
+| Laws | None |
+
+### tf:resource/write-object@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Storage.Write` |
+| Input | None |
+| Output | mode=write, uri=res://kv/<bucket>/:<key>, notes=seed |
+| Laws | None |
+
+### tf:security/sign-data@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Crypto` |
+| Input | None |
+| Output | None |
+| Laws | None |
+
+### tf:security/verify-signature@1
+
+| Field | Value |
+| --- | --- |
+| Effects | `Crypto` |
+| Input | None |
+| Output | None |
+| Laws | None |

--- a/docs/l0-effects.md
+++ b/docs/l0-effects.md
@@ -1,0 +1,62 @@
+# L0 Effects Lattice (generated)
+
+## Canonical families
+
+- Pure
+- Observability
+- Storage.Read
+- Storage.Write
+- Network.In
+- Network.Out
+- Crypto
+- Policy
+- Infra
+- Time
+- UI
+
+## Commutation matrix
+
+| Prev \ Next | Pure | Observability | Storage.Read | Storage.Write | Network.In | Network.Out | Crypto | Policy | Infra | Time | UI |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Pure | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Observability | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Storage.Read | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Storage.Write | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Network.In | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Network.Out | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Crypto | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Policy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Infra | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Time | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| UI | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Parallel safety matrix
+
+| Prev \ Next | Pure | Observability | Storage.Read | Storage.Write | Network.In | Network.Out | Crypto | Policy | Infra | Time | UI |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Pure | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Observability | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Storage.Read | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Storage.Write | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Network.In | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Network.Out | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Crypto | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Policy | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Infra | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| UI | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+## Precedence order
+
+The normalize pass orders effects using the following precedence:
+
+1. Pure
+2. Observability
+3. Network.Out
+4. Storage.Read
+5. Storage.Write
+6. Crypto
+7. Policy
+8. Infra
+9. Time
+10. UI

--- a/scripts/docgen/catalog.mjs
+++ b/scripts/docgen/catalog.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const EFFECT_ORDER = [
+  'Pure',
+  'Observability',
+  'Network.Out',
+  'Storage.Read',
+  'Storage.Write',
+  'Crypto',
+  'Policy',
+  'Infra',
+  'Time',
+  'UI'
+];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function resolveRepoRoot(root) {
+  if (root) return root;
+  return path.resolve(__dirname, '..', '..');
+}
+
+async function readJsonMaybe(filePath) {
+  try {
+    await access(filePath);
+  } catch {
+    return null;
+  }
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function uniqueSorted(list = []) {
+  const seen = new Set();
+  const out = [];
+  for (const item of Array.isArray(list) ? list : []) {
+    if (typeof item !== 'string') continue;
+    if (seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  out.sort((a, b) => a.localeCompare(b));
+  return out;
+}
+
+function formatList(list) {
+  if (!list || list.length === 0) {
+    return 'None';
+  }
+  return list.map(item => `\`${item}\``).join(', ');
+}
+
+function normalizeFootprints(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .map(entry => ({
+      mode: typeof entry?.mode === 'string' ? entry.mode : null,
+      uri: typeof entry?.uri === 'string' ? entry.uri : null,
+      notes: typeof entry?.notes === 'string' ? entry.notes : null
+    }))
+    .map(entry => ({
+      mode: entry.mode || 'unspecified',
+      uri: entry.uri || '—',
+      notes: entry.notes || null
+    }))
+    .sort((a, b) => {
+      const byUri = a.uri.localeCompare(b.uri);
+      if (byUri !== 0) return byUri;
+      const byMode = a.mode.localeCompare(b.mode);
+      if (byMode !== 0) return byMode;
+      const aNotes = a.notes || '';
+      const bNotes = b.notes || '';
+      return aNotes.localeCompare(bNotes);
+    });
+}
+
+function formatFootprints(entries) {
+  const normalized = normalizeFootprints(entries);
+  if (normalized.length === 0) {
+    return 'None';
+  }
+  return normalized
+    .map(entry => {
+      const parts = [`mode=${entry.mode}`, `uri=${entry.uri}`];
+      if (entry.notes) {
+        parts.push(`notes=${entry.notes}`);
+      }
+      return parts.join(', ');
+    })
+    .join('<br />');
+}
+
+function collectLawMap(lawsJson) {
+  const map = new Map();
+  if (!lawsJson || !Array.isArray(lawsJson.laws)) {
+    return map;
+  }
+  for (const law of lawsJson.laws) {
+    const lawId = typeof law?.id === 'string' ? law.id : null;
+    if (!lawId) continue;
+    const applies = Array.isArray(law.applies_to) ? law.applies_to : [];
+    for (const target of applies) {
+      if (typeof target !== 'string') continue;
+      if (!map.has(target)) {
+        map.set(target, []);
+      }
+      map.get(target).push(lawId);
+    }
+  }
+  for (const [, arr] of map) {
+    arr.sort((a, b) => a.localeCompare(b));
+  }
+  return map;
+}
+
+export async function generateCatalogDoc(options = {}) {
+  const repoRoot = resolveRepoRoot(options.root);
+  const catalogPath = path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'catalog.json');
+  const lawsPath = path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'laws.json');
+  const outPath = path.join(repoRoot, 'docs', 'l0-catalog.md');
+
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  const lawsJson = await readJsonMaybe(lawsPath);
+  const lawMap = collectLawMap(lawsJson);
+
+  const primitives = Array.isArray(catalog?.primitives) ? catalog.primitives.slice() : [];
+  primitives.sort((a, b) => {
+    const aId = typeof a?.id === 'string' ? a.id : '';
+    const bId = typeof b?.id === 'string' ? b.id : '';
+    return aId.localeCompare(bId);
+  });
+
+  const lines = [];
+  lines.push('# L0 Catalog (generated)');
+  lines.push(`Primitives: ${primitives.length}`);
+  lines.push(`Effects: ${EFFECT_ORDER.join(', ')}`);
+  lines.push('');
+
+  if (primitives.length === 0) {
+    lines.push('_No primitives defined in the current catalog._');
+    lines.push('');
+  }
+
+  for (const prim of primitives) {
+    const primId = typeof prim?.id === 'string' ? prim.id : '(unknown)';
+    const effects = uniqueSorted(prim?.effects);
+    const reads = Array.isArray(prim?.reads) ? prim.reads : [];
+    const writes = Array.isArray(prim?.writes) ? prim.writes : [];
+    const laws = lawMap.get(primId) || [];
+
+    lines.push(`### ${primId}`);
+    lines.push('');
+    lines.push('| Field | Value |');
+    lines.push('| --- | --- |');
+    lines.push(`| Effects | ${formatList(effects)} |`);
+    lines.push(`| Input | ${formatFootprints(reads)} |`);
+    lines.push(`| Output | ${formatFootprints(writes)} |`);
+    lines.push(`| Laws | ${formatList(laws)} |`);
+    lines.push('');
+  }
+
+  const output = lines.join('\n').replace(/\s+$/u, '').concat('\n');
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, output, 'utf8');
+  return outPath;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await generateCatalogDoc();
+}

--- a/scripts/docgen/dsl.mjs
+++ b/scripts/docgen/dsl.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function resolveRepoRoot(root) {
+  if (root) return root;
+  return path.resolve(__dirname, '..', '..');
+}
+
+function detectFeatures(source) {
+  return {
+    hasPipeline: source.includes("makeToken('PIPE'"),
+    hasSeqBlock: source.includes("'SEQ_OPEN'"),
+    hasParBlock: source.includes("'PAR_OPEN'"),
+    hasAuthorize: source.includes("'REGION_AUTH'"),
+    hasTxn: source.includes("'REGION_TXN'"),
+    hasStrings: source.includes("'STRING'"),
+    hasNumbers: source.includes("'NUMBER'"),
+    hasBooleans: source.includes("if (token.v === 'true')"),
+    hasNull: source.includes("if (token.v === 'null')"),
+    hasArrays: source.includes('function parseArray('),
+    hasObjects: source.includes('function parseObject(')
+  };
+}
+
+function buildBasicsSection(features) {
+  const bullets = [];
+  if (features.hasPipeline) {
+    bullets.push('`step |> next` composes primitives left-to-right.');
+  }
+  if (features.hasSeqBlock) {
+    bullets.push('`seq{ ... }` groups statements sequentially; semicolons separate explicit steps.');
+  }
+  if (features.hasParBlock) {
+    bullets.push('`par{ ... }` evaluates children in parallel; wrap multiple steps with semicolons.');
+  }
+  if (bullets.length === 0) {
+    bullets.push('Pipelines compose primitives and explicit `seq{}` / `par{}` blocks when available.');
+  }
+  bullets.push('Identifiers map to primitives and are normalized to lowercase during parsing.');
+  return bullets;
+}
+
+function buildArgsSection(features) {
+  const bullets = [];
+  if (features.hasStrings) {
+    bullets.push('Strings support single or double quotes with standard escape handling.');
+  }
+  if (features.hasNumbers) {
+    bullets.push('Numbers accept integers and decimals with optional leading minus.');
+  }
+  if (features.hasBooleans) {
+    bullets.push('Boolean literals `true` and `false` are parsed as actual booleans.');
+  }
+  if (features.hasNull) {
+    bullets.push('`null` produces a JavaScript null literal.');
+  }
+  if (features.hasArrays) {
+    bullets.push('Array literals use `[value, ...]` with trailing commas supported.');
+  }
+  if (features.hasObjects) {
+    bullets.push('Object literals use `{ key: value, ... }` and accept string, identifier, or numeric keys.');
+  }
+  bullets.push('Argument lists appear as `prim(arg=value, ...)` and default to an empty object when omitted.');
+  return bullets;
+}
+
+function buildRegionsSection(features) {
+  const bullets = [];
+  if (features.hasAuthorize) {
+    bullets.push('`authorize{ ... }` wraps a region; optional `authorize(attrs){ ... }` attaches metadata.');
+  }
+  if (features.hasTxn) {
+    bullets.push('`txn{ ... }` models transactional regions with optional attributes like `txn(scope="ledger"){ ... }`.');
+  }
+  if (bullets.length === 0) {
+    bullets.push('Regions wrap blocks with optional `(key=value)` metadata when supported.');
+  }
+  return bullets;
+}
+
+function buildCommentsSection() {
+  return [
+    'The tokenizer does not implement comment skipping; treat `#`, `//`, or `/* */` as syntax errors and keep flows comment-free.'
+  ];
+}
+
+async function loadCliCommands(cliSource) {
+  const usageMatch = cliSource.match(/Usage: tf <([^>]+)>/);
+  if (!usageMatch) {
+    return [];
+  }
+  const commands = usageMatch[1]
+    .split('|')
+    .map(token => token.trim())
+    .filter(Boolean);
+  const primary = ['parse', 'check', 'canon', 'emit'];
+  const descriptions = {
+    parse: 'Parse a `.tf` file and emit canonical IR JSON.',
+    check: 'Validate a flow against the catalog and region policies, returning JSON verdicts.',
+    canon: 'Normalize a parsed flow using effect laws for deterministic ordering.',
+    emit: 'Generate code for the requested language (TypeScript or Rust) under `out/`. Use `--lang ts|rs` and optionally `--out` for the destination.'
+  };
+  return primary
+    .filter(cmd => commands.includes(cmd))
+    .map(cmd => ({ cmd, description: descriptions[cmd] }));
+}
+
+async function loadShortExamples(root) {
+  const flowsDir = path.join(root, 'examples', 'flows');
+  const entries = await readdir(flowsDir);
+  const selected = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.tf')) continue;
+    const filePath = path.join(flowsDir, entry);
+    const raw = await readFile(filePath, 'utf8');
+    const trimmed = raw.trimEnd();
+    const charCount = trimmed.length;
+    const lineCount = trimmed === '' ? 0 : trimmed.split(/\r?\n/).length;
+    if (charCount <= 80 && lineCount <= 6) {
+      selected.push({ name: entry, content: trimmed });
+    }
+  }
+  selected.sort((a, b) => a.name.localeCompare(b.name));
+  return selected;
+}
+
+function renderSection(lines, title, bullets) {
+  lines.push(`## ${title}`);
+  lines.push('');
+  for (const bullet of bullets) {
+    lines.push(`- ${bullet}`);
+  }
+  lines.push('');
+}
+
+function renderCliTable(lines, commands) {
+  lines.push('## CLI usage');
+  lines.push('');
+  if (!commands || commands.length === 0) {
+    lines.push('No CLI commands detected in `packages/tf-compose/bin/tf.mjs`.');
+    lines.push('');
+    return;
+  }
+  lines.push('| Command | Summary |');
+  lines.push('| --- | --- |');
+  for (const { cmd, description } of commands) {
+    lines.push(`| \`tf ${cmd}\` | ${description} |`);
+  }
+  lines.push('');
+}
+
+function renderExamples(lines, examples) {
+  lines.push('## Examples');
+  lines.push('');
+  if (!examples || examples.length === 0) {
+    lines.push('_No short examples (≤80 characters) were found in `examples/flows`.');
+    lines.push('');
+    return;
+  }
+  for (const example of examples) {
+    lines.push(`### ${example.name}`);
+    lines.push('');
+    lines.push('```tf');
+    lines.push(example.content);
+    lines.push('```');
+    lines.push('');
+  }
+}
+
+export async function generateDSLDoc(options = {}) {
+  const repoRoot = resolveRepoRoot(options.root);
+  const parserPath = path.join(repoRoot, 'packages', 'tf-compose', 'src', 'parser.mjs');
+  const cliPath = path.join(repoRoot, 'packages', 'tf-compose', 'bin', 'tf.mjs');
+  const outPath = path.join(repoRoot, 'docs', 'l0-dsl.md');
+
+  const [parserSource, cliSource, examples] = await Promise.all([
+    readFile(parserPath, 'utf8'),
+    readFile(cliPath, 'utf8'),
+    loadShortExamples(repoRoot)
+  ]);
+
+  const features = detectFeatures(parserSource);
+  const commands = await loadCliCommands(cliSource);
+
+  const lines = [];
+  lines.push('# L0 DSL Cheatsheet (generated)');
+  lines.push('');
+
+  renderSection(lines, 'Basics', buildBasicsSection(features));
+  renderSection(lines, 'Args & Literals', buildArgsSection(features));
+  renderSection(lines, 'Regions', buildRegionsSection(features));
+  renderSection(lines, 'Comments', buildCommentsSection());
+  renderCliTable(lines, commands);
+  renderExamples(lines, examples);
+
+  const output = lines.join('\n').replace(/\s+$/u, '').concat('\n');
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, output, 'utf8');
+  return outPath;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await generateDSLDoc();
+}

--- a/scripts/docgen/effects.mjs
+++ b/scripts/docgen/effects.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  CANONICAL_EFFECT_FAMILIES,
+  EFFECT_PRECEDENCE,
+  canCommute,
+  parSafe
+} from '../../packages/tf-l0-check/src/effect-lattice.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function resolveRepoRoot(root) {
+  if (root) return root;
+  return path.resolve(__dirname, '..', '..');
+}
+
+function boolCell(value) {
+  return value ? '✅' : '❌';
+}
+
+function renderMatrix(title, families, compute) {
+  const lines = [];
+  lines.push(`## ${title}`);
+  lines.push('');
+  const header = ['Prev \\ Next', ...families];
+  lines.push(`| ${header.join(' | ')} |`);
+  lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+  for (const prev of families) {
+    const row = [prev];
+    for (const next of families) {
+      row.push(boolCell(compute(prev, next)));
+    }
+    lines.push(`| ${row.join(' | ')} |`);
+  }
+  lines.push('');
+  return lines;
+}
+
+export async function generateEffectsDoc(options = {}) {
+  const repoRoot = resolveRepoRoot(options.root);
+  const outPath = path.join(repoRoot, 'docs', 'l0-effects.md');
+  const families = CANONICAL_EFFECT_FAMILIES.slice();
+  const precedence = EFFECT_PRECEDENCE.slice();
+
+  const lines = [];
+  lines.push('# L0 Effects Lattice (generated)');
+  lines.push('');
+  lines.push('## Canonical families');
+  lines.push('');
+  for (const family of families) {
+    lines.push(`- ${family}`);
+  }
+  lines.push('');
+
+  lines.push(...renderMatrix('Commutation matrix', families, (prev, next) => canCommute(prev, next)));
+  lines.push(...renderMatrix('Parallel safety matrix', families, (prev, next) => parSafe(prev, next)));
+
+  lines.push('## Precedence order');
+  lines.push('');
+  lines.push('The normalize pass orders effects using the following precedence:');
+  lines.push('');
+  lines.push(precedence.map((family, index) => `${index + 1}. ${family}`).join('\n'));
+  lines.push('');
+
+  const output = lines.join('\n').replace(/\s+$/u, '').concat('\n');
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, output, 'utf8');
+  return outPath;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await generateEffectsDoc();
+}

--- a/tests/docgen.test.mjs
+++ b/tests/docgen.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { generateCatalogDoc } from '../scripts/docgen/catalog.mjs';
+import { generateDSLDoc } from '../scripts/docgen/dsl.mjs';
+import { generateEffectsDoc } from '../scripts/docgen/effects.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function ensureSingleTrailingNewline(content) {
+  assert.ok(content.endsWith('\n'), 'output should end with a newline');
+  assert.ok(!content.endsWith('\n\n'), 'output should end with a single newline');
+}
+
+test('doc generators are deterministic', async (t) => {
+  const catalogPath = await generateCatalogDoc({ root: repoRoot });
+  const catalogContent = await readFile(catalogPath, 'utf8');
+  ensureSingleTrailingNewline(catalogContent);
+  const trimmed = catalogContent.trimEnd();
+  const countLine = trimmed.split('\n').find(line => line.startsWith('Primitives: '));
+  assert.ok(countLine, 'catalog doc should report primitive count');
+
+  const catalogJson = JSON.parse(await readFile(path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'catalog.json'), 'utf8'));
+  const expectedCount = Array.isArray(catalogJson?.primitives) ? catalogJson.primitives.length : 0;
+  assert.strictEqual(countLine, `Primitives: ${expectedCount}`);
+
+  await generateCatalogDoc({ root: repoRoot });
+  const catalogContentAgain = await readFile(catalogPath, 'utf8');
+  assert.strictEqual(catalogContentAgain, catalogContent);
+
+  const dslPath = await generateDSLDoc({ root: repoRoot });
+  await stat(dslPath);
+  const dslContent = await readFile(dslPath, 'utf8');
+  ensureSingleTrailingNewline(dslContent);
+  await generateDSLDoc({ root: repoRoot });
+  const dslContentAgain = await readFile(dslPath, 'utf8');
+  assert.strictEqual(dslContentAgain, dslContent);
+
+  const effectsPath = await generateEffectsDoc({ root: repoRoot });
+  await stat(effectsPath);
+  const effectsContent = await readFile(effectsPath, 'utf8');
+  ensureSingleTrailingNewline(effectsContent);
+  await generateEffectsDoc({ root: repoRoot });
+  const effectsContentAgain = await readFile(effectsPath, 'utf8');
+  assert.strictEqual(effectsContentAgain, effectsContent);
+});


### PR DESCRIPTION
## Summary
- add deterministic doc generators for the catalog, DSL cheatsheet, and effects lattice along with the generated docs
- wire a CI workflow that rebuilds the docs after the build so divergences fail the check
- cover the generators with a node:test suite and surface the docs in the README quick links

## Testing
- pnpm -w -r build
- node scripts/docgen/catalog.mjs
- node scripts/docgen/dsl.mjs
- node scripts/docgen/effects.mjs
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d05cec9c8c83208e79f88b1041fbf7