### PR TITLE
Add deterministic L0 doc generation and CI check

### DIFF
--- a/.github/workflows/l0-docs.yml
+++ b/.github/workflows/l0-docs.yml
@@ -1,0 +1,37 @@
+name: L0 Docs (regen check)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+
+      - name: Build (for lattice import)
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Regenerate docs
+        run: |
+          node scripts/docgen/catalog.mjs
+          node scripts/docgen/dsl.mjs
+          node scripts/docgen/effects.mjs
+
+      - name: Fail if changed
+        run: |
+          if [[ -n "$(git status --porcelain docs/*.md)" ]]; then
+            echo "Docs out of date. Run docgen scripts and commit." >&2
+            git diff -- docs
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ out/ (artifacts)/
 * Streaming scale (1M–10M frames) and perf suite.
 * Plugin SDK + config schema.
 * Release pipeline (packages, SBOMs, checksums).
+* Catalog: [docs/l0-catalog.md](docs/l0-catalog.md)
+* DSL Cheatsheet: [docs/l0-dsl.md](docs/l0-dsl.md)
+* Effects/Lattice: [docs/l0-effects.md](docs/l0-effects.md)
 
 ## Contributing
 

--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -1,23 +1,73 @@
-# L0 Catalog (A1 skeleton)
-- `spec/ids.json` — IDs
-- `spec/catalog.json` — normalized catalog with placeholders
-- `spec/effects.json` — derived effect tags
-- `spec/laws.json` — law registry (sample rules)
+# L0 Catalog (generated)
+Primitives: 14
+Effects: Pure, Observability, Network.Out, Storage.Read, Storage.Write, Crypto, Policy, Infra, Time, UI
 
-### Seed Overlay
-Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
-`spec/seed/*.json` overlay into the generated catalog. The seed entries carry
-minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
-conflict detection stay runnable while curation continues.
+### tf:information/deserialize@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Pure | — | — | `law:serialize-deserialize-eq-id` |
 
-### Effect derivation rules
-Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
-Seed overlays remain authoritative for existing effects or qos values.
-Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+### tf:information/hash@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Pure | — | — | `law:hash-idempotent` |
 
-### Manifest compatibility
-For v0.4 manifests we emit both the legacy `effects`/`footprints` fields and the new
-`required_effects`/`footprints_rw`/`qos` structure for downstream compatibility. The
-two shapes are mutually exclusive, but the schema and CLI validator accept either so
-consumers can migrate on their own schedule. Use
-`node scripts/validate-manifest.mjs <path>` to confirm conformance.
+### tf:information/serialize@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Pure | — | — | `law:serialize-deserialize-eq-id` |
+
+### tf:network/acknowledge@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.Out | — | — | — |
+
+### tf:network/publish@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.Out | — | — | — |
+
+### tf:network/request@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.Out | — | — | — |
+
+### tf:network/subscribe@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.In | — | — | — |
+
+### tf:observability/emit-metric@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Observability | — | — | `law:emitmetric-commutes-with-pure` |
+
+### tf:resource/compare-and-swap@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Write | — | `mode="write", notes="seed", uri="res://kv/<bucket>/:<key>"` | — |
+
+### tf:resource/delete-object@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Write | — | `mode="write", notes="seed", uri="res://kv/<bucket>/:<key>"` | — |
+
+### tf:resource/read-object@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Read | `mode="read", notes="seed", uri="res://kv/<bucket>/:<key>"` | — | — |
+
+### tf:resource/write-object@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Write | — | `mode="write", notes="seed", uri="res://kv/<bucket>/:<key>"` | — |
+
+### tf:security/sign-data@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Crypto | — | — | — |
+
+### tf:security/verify-signature@1
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Crypto | — | — | — |

--- a/docs/l0-dsl.md
+++ b/docs/l0-dsl.md
@@ -1,59 +1,154 @@
-# L0 DSL (minimal)
+# L0 DSL Cheatsheet (generated)
 
-**Grammar (subset):**
+## Basics
+- Chain primitives or regions with `|>` for sequential pipelines.
+- Use `seq{ ... }` blocks for multi-step sequences and `par{ ... }` for parallel branches.
+- Primitives are lowercase identifiers; pipeline nodes preserve the written order.
+
+## Args & Literals
+- Arguments appear as `prim(key=value, other=123)` with comma separators.
+- Strings accept single or double quotes with standard escape sequences.
+- Numbers allow optional `-` prefix and fractional parts; booleans use `true` or `false`, and `null` is accepted.
+- Arrays `[a, b, c]` and objects `{key: value}` are parsed recursively.
+
+## Regions
+- `authorize{ ... }` wraps a scoped block; optional `authorize(region="us"){ ... }` attributes sit in parentheses.
+- `txn{ ... }` creates a transactional region with the same attribute syntax.
+- Regions compose with pipelines just like primitives (`step |> authorize{ ... }`).
+
+## Comments
+- The parser does not recognize line or block comments; keep DSL files comment-free or encode notes via args.
+
+## CLI usage
+- Commands mirror `tf <parse|check|canon|emit|manifest|fmt|show> <flow.tf> [--out path] [--lang ts|rs] [--write|-w]` from `packages/tf-compose/bin/tf.mjs`.
+- `tf parse <flow.tf> [-o out.json]` emits canonical IR JSON.
+- `tf check <flow.tf> [-o verdict.json]` validates effects and region constraints.
+- `tf canon <flow.tf> [-o canon.json]` normalizes flows with catalog laws.
+- `tf emit <flow.tf> [--lang ts|rs] [--out dir]` generates runnable adapters.
+
+## Examples
+### app_order_publish.tf
+```tf
+seq{
+  publish(topic="orders", key="o-1", payload="{}");
+  emit-metric(name="sent")
+}
 ```
-flow  := step ('|>' step)*
-step  := prim | parblock
-prim  := IDENT '(' arglist? ')' | IDENT
-parblock := 'par{' step (';' step)* '}'
 
-arglist := IDENT '=' (NUMBER | STRING | IDENT) (',' IDENT '=' (NUMBER | STRING | IDENT))*
-
-Examples:
-  serialize |> hash |> sign-data(key_ref="k1")
-  par{ a(); b(x=1); c() }
+### auth_missing.tf
+```tf
+sign-data(key="k1")
 ```
 
-## Literals
-
-Arguments accept rich literal forms in addition to bare identifiers:
-
-* Numbers with optional leading `-`: `-42`, `3.14`
-* Booleans: `true`, `false`
-* `null`
-* Arrays with trailing commas allowed on input: `[1, "two", true, null, -0.5]`
-* Objects with string or identifier keys: `{name:"alice", retry:{count:2}}`
-
-Nested combinations are supported, e.g.:
-
-```
-write-object(meta={retry:{count:2, windows:[1,2,3]}}, tags=[true,false])
+### auth_ok.tf
+```tf
+authorize(scope="kms.sign"){ sign-data(key="k1") }
 ```
 
-## Tooling
+### auth_wrong_scope.tf
+```tf
+authorize(scope="kms.decrypt"){ sign-data(key="k1") }
+```
 
-The CLI includes helpers for working with DSL flows:
+### emit_commute.tf
+```tf
+emit-metric(key="ok") |> hash
+```
 
-* `tf fmt flow.tf` reprints the flow using a canonical layout. Add `--write`/`-w` to update the file in-place. The formatter is idempotent and sorts argument keys, object members, and normalizes commas/semicolons.
-* `tf show flow.tf` prints a tree representation of the parsed IR for quick inspection.
+### info_roundtrip.tf
+```tf
+serialize |> deserialize
+```
 
-The formatter quotes object keys that aren’t identifiers (such as keys with spaces or numeric names) and always produces a stable, idempotent layout.
+### manifest_publish.tf
+```tf
+publish(topic="orders", key="abc", payload="{}")
+```
 
-Parse errors report a `line:col` location with a short caret span to highlight the offending range, making it easier to pinpoint syntax issues.
+### manifest_storage.tf
+```tf
+seq{
+  write-object(uri="res://kv/bucket", key="z", value="1");
+  read-object(uri="res://kv/bucket", key="z")
+}
+```
 
-The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws.
-It collapses idempotent primitives, eliminates declared inverse pairs, and swaps commute-with-pure primitives across adjacent pure nodes.
-Normalization never moves steps across `Region{}` or `Par{}` boundaries, so localized effects stay fenced.
-Running the canonicalizer twice yields the same result, keeping canonical hashes deterministic.
+### metrics_publish.tf
+```tf
+seq{
+  emit-metric(name="flows.processed", value=2);
+  publish(topic="flows", key="demo", payload="{\"ok\":true}")
+}
+```
 
-## Authorize dominance check
+### net_publish.tf
+```tf
+authorize{ publish(topic="orders", key="abc", payload="{}") }
+```
 
-Use `authorize(scope="kms.sign"){ ... }` to wrap protected operations that require explicit scopes.
+### obs_pure_EP.tf
+```tf
+emit-metric |> hash
+```
 
-CLI helpers:
+### obs_pure_PE.tf
+```tf
+hash |> emit-metric
+```
 
-* `pnpm run policy:auth -- check examples/flows/auth_ok.tf`
-* `pnpm run policy:auth -- check --warn-unused examples/flows/auth_ok.tf`
-* `pnpm run policy:auth -- check --strict-warns examples/flows/auth_ok.tf`
+### par_conflict_bad.tf
+```tf
+par{ write-object(uri="res://kv/bucket", key="x", value="1"); write-object(uri="res://kv/bucket", key="x", value="2") }
+```
 
-Scope requirements are bundled in `packages/tf-l0-check/rules/authorize-scopes.json`.
+### run_publish.tf
+```tf
+authorize{ publish(topic="events", key="event-1", payload="{}") }
+```
+
+### run_storage_ok.tf
+```tf
+authorize{
+  seq{
+    write-object(uri="res://inmem/kv", key="alpha", value="1");
+    write-object(uri="res://inmem/kv", key="beta", value="2")
+  }
+}
+```
+
+### signing.tf
+```tf
+serialize |> hash |> authorize{ sign-data(key_ref="k1") }
+```
+
+### storage_conflict.tf
+```tf
+authorize{
+  par{
+    write-object(uri="res://kv/bucket", key="x", value="1");
+    write-object(uri="res://kv/bucket", key="x", value="2")
+  }
+}
+```
+
+### storage_ok.tf
+```tf
+authorize{
+  seq{
+    write-object(uri="res://kv/bucket", key="x", value="1");
+    write-object(uri="res://kv/bucket", key="y", value="2")
+  }
+}
+```
+
+### txn_fail_missing_key.tf
+```tf
+txn{
+  write-object(uri="res://kv/bucket", key="x", value="1")
+}
+```
+
+### write_outside_txn.tf
+```tf
+write-object(uri="res://kv/bucket", key="z", value="3")
+```

--- a/docs/l0-effects.md
+++ b/docs/l0-effects.md
@@ -1,0 +1,47 @@
+# L0 Effects (generated)
+
+## Canonical families
+- `Pure`
+- `Observability`
+- `Storage.Read`
+- `Storage.Write`
+- `Network.In`
+- `Network.Out`
+- `Crypto`
+- `Policy`
+- `Infra`
+- `Time`
+- `UI`
+
+## Precedence order
+- Pure > Observability > Network.Out > Storage.Read > Storage.Write > Crypto > Policy > Infra > Time > UI
+
+## Commutation matrix
+| Family | `Pure` | `Observability` | `Storage.Read` | `Storage.Write` | `Network.In` | `Network.Out` | `Crypto` | `Policy` | `Infra` | `Time` | `UI` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Pure` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Observability` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Storage.Read` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Storage.Write` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Network.In` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Network.Out` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Crypto` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Policy` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Infra` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Time` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `UI` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Parallel safety matrix
+| Family | `Pure` | `Observability` | `Storage.Read` | `Storage.Write` | `Network.In` | `Network.Out` | `Crypto` | `Policy` | `Infra` | `Time` | `UI` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Pure` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Observability` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Storage.Read` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Storage.Write` | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Network.In` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Network.Out` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Crypto` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Policy` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Infra` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Time` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `UI` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/scripts/docgen/catalog.mjs
+++ b/scripts/docgen/catalog.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const EFFECT_ORDER = [
+  'Pure',
+  'Observability',
+  'Network.Out',
+  'Storage.Read',
+  'Storage.Write',
+  'Crypto',
+  'Policy',
+  'Infra',
+  'Time',
+  'UI'
+];
+
+function repoRoot() {
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  return path.resolve(here, '..', '..');
+}
+
+async function loadJsonMaybe(relPath) {
+  try {
+    const txt = await readFile(path.join(repoRoot(), relPath), 'utf8');
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+function sortKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .map(([k, v]) => [k, sortKeys(v)])
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+function formatEffects(effects = []) {
+  const items = Array.isArray(effects) ? [...effects] : [];
+  items.sort((a, b) => a.localeCompare(b));
+  return items.length > 0 ? items.join(', ') : '—';
+}
+
+function formatRecords(records = []) {
+  if (!Array.isArray(records) || records.length === 0) {
+    return '—';
+  }
+  const sorted = [...records].map(sortKeys).sort((a, b) => {
+    const left = JSON.stringify(a);
+    const right = JSON.stringify(b);
+    return left.localeCompare(right);
+  });
+  return sorted
+    .map(entry => {
+      const pairs = Object.entries(entry)
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+        .join(', ');
+      return pairs.length > 0 ? `\`${pairs}\`` : '`{}`';
+    })
+    .join('<br>');
+}
+
+function collectLaws(lawsDoc, primId) {
+  if (!lawsDoc || !Array.isArray(lawsDoc.laws)) {
+    return [];
+  }
+  const id = (primId || '').toLowerCase();
+  const found = new Set();
+  for (const law of lawsDoc.laws) {
+    const applies = Array.isArray(law?.applies_to) ? law.applies_to : [];
+    for (const target of applies) {
+      if (typeof target === 'string' && target.toLowerCase() === id) {
+        if (typeof law.id === 'string' && law.id.length > 0) {
+          found.add(law.id);
+        }
+      }
+    }
+  }
+  return Array.from(found).sort((a, b) => a.localeCompare(b));
+}
+
+function formatLaws(lawIds) {
+  if (!lawIds || lawIds.length === 0) {
+    return '—';
+  }
+  return lawIds.map(id => `\`${id}\``).join('<br>');
+}
+
+function buildPrimitiveSection(primitive, lawsDoc) {
+  const lines = [];
+  const pid = primitive.id || 'unknown';
+  lines.push(`### ${pid}`);
+  const effects = formatEffects(primitive.effects);
+  const inputs = formatRecords(primitive.reads);
+  const outputs = formatRecords(primitive.writes);
+  const lawIds = collectLaws(lawsDoc, pid);
+  const laws = formatLaws(lawIds);
+  lines.push('| Effects | Input | Output | Laws |');
+  lines.push('| --- | --- | --- | --- |');
+  lines.push(`| ${effects} | ${inputs} | ${outputs} | ${laws} |`);
+  lines.push('');
+  return lines;
+}
+
+async function main() {
+  const catalog = (await loadJsonMaybe('packages/tf-l0-spec/spec/catalog.json')) || { primitives: [] };
+  const laws = await loadJsonMaybe('packages/tf-l0-spec/spec/laws.json');
+  const primitives = Array.isArray(catalog.primitives) ? [...catalog.primitives] : [];
+  primitives.sort((a, b) => {
+    const left = (a.id || '').toLowerCase();
+    const right = (b.id || '').toLowerCase();
+    return left.localeCompare(right);
+  });
+
+  const lines = [];
+  lines.push('# L0 Catalog (generated)');
+  lines.push(`Primitives: ${primitives.length}`);
+  lines.push(`Effects: ${EFFECT_ORDER.join(', ')}`);
+  lines.push('');
+
+  for (const primitive of primitives) {
+    lines.push(...buildPrimitiveSection(primitive, laws));
+  }
+
+  const outPath = path.join(repoRoot(), 'docs', 'l0-catalog.md');
+  const payload = lines.join('\n');
+  await writeFile(outPath, payload.endsWith('\n') ? payload : `${payload}\n`, 'utf8');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/docgen/dsl.mjs
+++ b/scripts/docgen/dsl.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+function repoRoot() {
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  return path.resolve(here, '..', '..');
+}
+
+async function loadTfCliUsage() {
+  const cliPath = path.join(repoRoot(), 'packages', 'tf-compose', 'bin', 'tf.mjs');
+  const src = await readFile(cliPath, 'utf8');
+  const usageMatch = src.match(/Usage: tf <[^']+/);
+  const usage = usageMatch ? usageMatch[0].replace('Usage: ', '') : 'tf <parse|check|canon|emit>';
+  const commandMatch = src.match(/\[(?:'[^']+'(?:,\s*)?)+\]/);
+  let commands = [];
+  if (commandMatch) {
+    commands = commandMatch[0]
+      .replace(/[\[\]'\s]/g, '')
+      .split(',')
+      .filter(Boolean);
+  }
+  const primary = ['parse', 'check', 'canon', 'emit'];
+  const listed = primary.filter(cmd => commands.includes(cmd));
+  return { usage, commands: listed };
+}
+
+async function loadExamples() {
+  const examplesDir = path.join(repoRoot(), 'examples', 'flows');
+  const entries = await readdir(examplesDir, { withFileTypes: true });
+  const selected = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.tf')) continue;
+    const fullPath = path.join(examplesDir, entry.name);
+    const content = await readFile(fullPath, 'utf8');
+    const trimmed = content.trimEnd();
+    if (trimmed.length <= 160) {
+      selected.push({ name: entry.name, content: trimmed });
+    }
+  }
+  selected.sort((a, b) => a.name.localeCompare(b.name));
+  return selected;
+}
+
+async function main() {
+  const { usage, commands } = await loadTfCliUsage();
+  const examples = await loadExamples();
+
+  const lines = [];
+  lines.push('# L0 DSL Cheatsheet (generated)');
+  lines.push('');
+
+  lines.push('## Basics');
+  lines.push('- Chain primitives or regions with `|>` for sequential pipelines.');
+  lines.push('- Use `seq{ ... }` blocks for multi-step sequences and `par{ ... }` for parallel branches.');
+  lines.push('- Primitives are lowercase identifiers; pipeline nodes preserve the written order.');
+  lines.push('');
+
+  lines.push('## Args & Literals');
+  lines.push('- Arguments appear as `prim(key=value, other=123)` with comma separators.');
+  lines.push('- Strings accept single or double quotes with standard escape sequences.');
+  lines.push('- Numbers allow optional `-` prefix and fractional parts; booleans use `true` or `false`, and `null` is accepted.');
+  lines.push('- Arrays `[a, b, c]` and objects `{key: value}` are parsed recursively.');
+  lines.push('');
+
+  lines.push('## Regions');
+  lines.push('- `authorize{ ... }` wraps a scoped block; optional `authorize(region="us"){ ... }` attributes sit in parentheses.');
+  lines.push('- `txn{ ... }` creates a transactional region with the same attribute syntax.');
+  lines.push('- Regions compose with pipelines just like primitives (`step |> authorize{ ... }`).');
+  lines.push('');
+
+  lines.push('## Comments');
+  lines.push('- The parser does not recognize line or block comments; keep DSL files comment-free or encode notes via args.');
+  lines.push('');
+
+  lines.push('## CLI usage');
+  lines.push(`- Commands mirror \`${usage}\` from \`packages/tf-compose/bin/tf.mjs\`.`);
+  for (const cmd of commands) {
+    if (cmd === 'parse') {
+      lines.push('- `tf parse <flow.tf> [-o out.json]` emits canonical IR JSON.');
+    } else if (cmd === 'check') {
+      lines.push('- `tf check <flow.tf> [-o verdict.json]` validates effects and region constraints.');
+    } else if (cmd === 'canon') {
+      lines.push('- `tf canon <flow.tf> [-o canon.json]` normalizes flows with catalog laws.');
+    } else if (cmd === 'emit') {
+      lines.push('- `tf emit <flow.tf> [--lang ts|rs] [--out dir]` generates runnable adapters.');
+    }
+  }
+  lines.push('');
+
+  if (examples.length > 0) {
+    lines.push('## Examples');
+    for (const example of examples) {
+      lines.push(`### ${example.name}`);
+      lines.push('```tf');
+      lines.push(example.content);
+      lines.push('```');
+      lines.push('');
+    }
+  }
+
+  const outPath = path.join(repoRoot(), 'docs', 'l0-dsl.md');
+  const payload = lines.join('\n');
+  await writeFile(outPath, payload.endsWith('\n') ? payload : `${payload}\n`, 'utf8');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}
+

--- a/scripts/docgen/effects.mjs
+++ b/scripts/docgen/effects.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  CANONICAL_EFFECT_FAMILIES,
+  EFFECT_PRECEDENCE,
+  canCommute,
+  parSafe
+} from '../../packages/tf-l0-check/src/effect-lattice.mjs';
+
+function repoRoot() {
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  return path.resolve(here, '..', '..');
+}
+
+function renderMatrix(families, fn) {
+  const header = ['| Family |', ...families.map(f => ` \`${f}\` |`)].join('');
+  const divider = ['| --- |', ...families.map(() => ' --- |')].join('');
+  const rows = families.map(row => {
+    const cells = families.map(col => (fn(row, col) ? '✅' : '❌'));
+    return ['|', ` \`${row}\` |`, ...cells.map(cell => ` ${cell} |`)].join('');
+  });
+  return [header, divider, ...rows];
+}
+
+async function main() {
+  const families = [...CANONICAL_EFFECT_FAMILIES];
+  const precedence = [...EFFECT_PRECEDENCE];
+
+  const lines = [];
+  lines.push('# L0 Effects (generated)');
+  lines.push('');
+
+  lines.push('## Canonical families');
+  for (const family of families) {
+    lines.push(`- \`${family}\``);
+  }
+  lines.push('');
+
+  lines.push('## Precedence order');
+  lines.push(`- ${precedence.join(' > ')}`);
+  lines.push('');
+
+  lines.push('## Commutation matrix');
+  lines.push(...renderMatrix(families, canCommute));
+  lines.push('');
+
+  lines.push('## Parallel safety matrix');
+  lines.push(...renderMatrix(families, parSafe));
+  lines.push('');
+
+  const outPath = path.join(repoRoot(), 'docs', 'l0-effects.md');
+  const payload = lines.join('\n');
+  await writeFile(outPath, payload.endsWith('\n') ? payload : `${payload}\n`, 'utf8');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}
+

--- a/tests/docgen.test.mjs
+++ b/tests/docgen.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import { execFile as execFileCb } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFile = promisify(execFileCb);
+const repoRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+const scripts = [
+  'scripts/docgen/catalog.mjs',
+  'scripts/docgen/dsl.mjs',
+  'scripts/docgen/effects.mjs'
+].map(rel => path.join(repoRoot, rel));
+
+const docs = [
+  path.join(repoRoot, 'docs', 'l0-catalog.md'),
+  path.join(repoRoot, 'docs', 'l0-dsl.md'),
+  path.join(repoRoot, 'docs', 'l0-effects.md')
+];
+
+async function runDocgen() {
+  for (const script of scripts) {
+    await execFile('node', [script], { cwd: repoRoot });
+  }
+}
+
+test('docgen outputs are deterministic', async () => {
+  await runDocgen();
+
+  const firstPass = new Map();
+  for (const docPath of docs) {
+    const content = await readFile(docPath, 'utf8');
+    assert.ok(content.length > 0, `${docPath} should exist`);
+    assert.ok(content.endsWith('\n'), `${docPath} should end with a newline`);
+    assert.ok(!content.endsWith('\n\n'), `${docPath} should end with a single newline`);
+    firstPass.set(docPath, content);
+  }
+
+  const catalogSrc = await readFile(path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'catalog.json'), 'utf8');
+  const catalog = JSON.parse(catalogSrc);
+  const primCount = Array.isArray(catalog?.primitives) ? catalog.primitives.length : 0;
+  const catalogDoc = firstPass.get(path.join(repoRoot, 'docs', 'l0-catalog.md'));
+  assert.ok(catalogDoc.includes(`Primitives: ${primCount}`));
+
+  await runDocgen();
+
+  for (const docPath of docs) {
+    const next = await readFile(docPath, 'utf8');
+    assert.strictEqual(next, firstPass.get(docPath));
+  }
+});
+


### PR DESCRIPTION
## Summary
- add docgen scripts that build deterministic catalog, DSL cheatsheet, and effects docs, and check them in
- wire the docs into the README and add a workflow that rebuilds the markdown on CI
- cover doc generation with a node:test regression to ensure newline-terminated, stable outputs

## Testing
- pnpm -w -r build
- node scripts/docgen/catalog.mjs
- node scripts/docgen/dsl.mjs
- node scripts/docgen/effects.mjs
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d05cec9c8c83208e79f88b1041fbf7