### PR TITLE
B6+F1: docgen automation

### DIFF
--- a/.github/workflows/l0-docs.yml
+++ b/.github/workflows/l0-docs.yml
@@ -1,0 +1,37 @@
+name: L0 Docs (regen check)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+
+      - name: Build (for lattice import)
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Regenerate docs
+        run: |
+          node scripts/docgen/catalog.mjs
+          node scripts/docgen/dsl.mjs
+          node scripts/docgen/effects.mjs
+
+      - name: Fail if changed
+        run: |
+          if [[ -n "$(git status --porcelain docs/*.md)" ]]; then
+            echo "Docs out of date. Run docgen scripts and commit." >&2
+            git diff -- docs
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ TF_CAPS='{"effects":["Network.Out","Pure"],"allow_writes_prefixes":[]}' node out
 # Summarize traces
 cat tests/fixtures/trace-sample.jsonl | node packages/tf-l0-tools/trace-summary.mjs --top=3 --pretty
 
+### Generated docs
+- Catalog: [docs/l0-catalog.md](docs/l0-catalog.md)
+- DSL Cheatsheet: [docs/l0-dsl.md](docs/l0-dsl.md)
+- Effects/Lattice: [docs/l0-effects.md](docs/l0-effects.md)
+
 ### Trace files (T3)
 - Runners always print JSON trace lines to stdout; setting `TF_TRACE_PATH=out/0.4/traces/<name>.jsonl` is an optional mirror.
 - Per run: `TF_TRACE_PATH=out/0.4/traces/publish.jsonl node out/0.4/codegen-ts/run_publish/run.mjs --caps caps.json`.

--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -1,23 +1,87 @@
-# L0 Catalog (A1 skeleton)
-- `spec/ids.json` — IDs
-- `spec/catalog.json` — normalized catalog with placeholders
-- `spec/effects.json` — derived effect tags
-- `spec/laws.json` — law registry (sample rules)
+# L0 Catalog (generated)
+Primitives: 14
+Effects: Pure, Observability, Network.Out, Storage.Read, Storage.Write, Crypto, Policy, Infra, Time, UI
 
-### Seed Overlay
-Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
-`spec/seed/*.json` overlay into the generated catalog. The seed entries carry
-minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
-conflict detection stay runnable while curation continues.
+### tf:information/deserialize@1
 
-### Effect derivation rules
-Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
-Seed overlays remain authoritative for existing effects or qos values.
-Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Pure | — | — | law:serialize-deserialize-eq-id |
 
-### Manifest compatibility
-For v0.4 manifests we emit both the legacy `effects`/`footprints` fields and the new
-`required_effects`/`footprints_rw`/`qos` structure for downstream compatibility. The
-two shapes are mutually exclusive, but the schema and CLI validator accept either so
-consumers can migrate on their own schedule. Use
-`node scripts/validate-manifest.mjs <path>` to confirm conformance.
+### tf:information/hash@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Pure | — | — | law:hash-idempotent |
+
+### tf:information/serialize@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Pure | — | — | law:serialize-deserialize-eq-id |
+
+### tf:network/acknowledge@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.Out | — | QoS: delivery_guarantee=at-least-once, ordering=per-key | — |
+
+### tf:network/publish@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.Out | — | QoS: delivery_guarantee=at-least-once, ordering=per-key | — |
+
+### tf:network/request@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.Out | — | QoS: delivery_guarantee=at-least-once, ordering=per-key | — |
+
+### tf:network/subscribe@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Network.In | — | QoS: delivery_guarantee=at-least-once, ordering=per-key | — |
+
+### tf:observability/emit-metric@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Observability | — | — | law:emitmetric-commutes-with-pure |
+
+### tf:resource/compare-and-swap@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Write | — | Writes: res://kv/<bucket>/:<key> (mode=write, notes=seed) | — |
+
+### tf:resource/delete-object@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Write | — | Writes: res://kv/<bucket>/:<key> (mode=write, notes=seed) | — |
+
+### tf:resource/read-object@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Read | Reads: res://kv/<bucket>/:<key> (mode=read, notes=seed) | — | — |
+
+### tf:resource/write-object@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Storage.Write | — | Writes: res://kv/<bucket>/:<key> (mode=write, notes=seed) | — |
+
+### tf:security/sign-data@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Crypto | Data classes: secrets | — | — |
+
+### tf:security/verify-signature@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| Crypto | Data classes: none | — | — |

--- a/docs/l0-dsl.md
+++ b/docs/l0-dsl.md
@@ -1,59 +1,106 @@
-# L0 DSL (minimal)
+# L0 DSL Cheatsheet (generated)
 
-**Grammar (subset):**
+## Basics
+* `a |> b` composes primitives into a left-associated sequence.
+* `seq{ ... }` groups steps explicitly; semicolons separate statements inside the block.
+* `par{ ... }` evaluates children in parallel; separate branches with semicolons.
+* Bare identifiers call primitives; add `(key=value, ...)` to supply arguments.
+
+## Args & Literals
+* Strings accept single or double quotes with standard escape handling.
+* Numbers support optional leading `-` and fractional parts.
+* Boolean and null literals map to `true`, `false`, and `null`.
+* Arrays allow trailing commas and can nest arbitrary literal forms.
+* Objects accept string, identifier, or numeric keys with trailing commas.
+
+## Regions
+* `authorize{ ... }` fences steps that require explicit capabilities.
+* Add attributes with `authorize(scope="kms.sign"){ ... }`; attributes are parsed as key/value pairs.
+* `txn{ ... }` introduces a transactional region with the same attribute syntax.
+* Region blocks behave like sequence blocks for canonicalization boundaries.
+
+## Comments
+* The current tokenizer does not recognize `#` or `//` comments; keep `.tf` files comment-free.
+
+## CLI usage
+* Usage: tf <parse|check|canon|emit|manifest|fmt|show> <flow.tf> [--out path] [--lang ts|rs] [--write|-w].
+* `tf parse` → emit canonical IR JSON for a flow.
+* `tf check` → validate effects and region fences using the current catalog.
+* `tf canon` → apply registered algebraic laws for normalization.
+* `tf emit --lang ts|rs` → generate runnable scaffolding in the requested language.
+
+## Examples
+
+### app_order_publish.tf
+```tf
+seq{
+  publish(topic="orders", key="o-1", payload="{}");
+  emit-metric(name="sent")
+}
 ```
-flow  := step ('|>' step)*
-step  := prim | parblock
-prim  := IDENT '(' arglist? ')' | IDENT
-parblock := 'par{' step (';' step)* '}'
 
-arglist := IDENT '=' (NUMBER | STRING | IDENT) (',' IDENT '=' (NUMBER | STRING | IDENT))*
-
-Examples:
-  serialize |> hash |> sign-data(key_ref="k1")
-  par{ a(); b(x=1); c() }
+### auth_missing.tf
+```tf
+sign-data(key="k1")
 ```
 
-## Literals
-
-Arguments accept rich literal forms in addition to bare identifiers:
-
-* Numbers with optional leading `-`: `-42`, `3.14`
-* Booleans: `true`, `false`
-* `null`
-* Arrays with trailing commas allowed on input: `[1, "two", true, null, -0.5]`
-* Objects with string or identifier keys: `{name:"alice", retry:{count:2}}`
-
-Nested combinations are supported, e.g.:
-
-```
-write-object(meta={retry:{count:2, windows:[1,2,3]}}, tags=[true,false])
+### auth_ok.tf
+```tf
+authorize(scope="kms.sign"){ sign-data(key="k1") }
 ```
 
-## Tooling
+### auth_wrong_scope.tf
+```tf
+authorize(scope="kms.decrypt"){ sign-data(key="k1") }
+```
 
-The CLI includes helpers for working with DSL flows:
+### crypto_sign_verify.tf
+```tf
+authorize(scope="kms.sign"){
+  seq{
+    sign-data(key="k1", payload="hello");
+    verify-signature(key="k1", payload="hello", signature="iKqz7ejTrflNJquQ07r9SiCDBww7zOnAFO4EpEOEfAs=")
+  }
+}
+```
 
-* `tf fmt flow.tf` reprints the flow using a canonical layout. Add `--write`/`-w` to update the file in-place. The formatter is idempotent and sorts argument keys, object members, and normalizes commas/semicolons.
-* `tf show flow.tf` prints a tree representation of the parsed IR for quick inspection.
+### emit_commute.tf
+```tf
+emit-metric(key="ok") |> hash
+```
 
-The formatter quotes object keys that aren’t identifiers (such as keys with spaces or numeric names) and always produces a stable, idempotent layout.
+### info_roundtrip.tf
+```tf
+serialize |> deserialize
+```
 
-Parse errors report a `line:col` location with a short caret span to highlight the offending range, making it easier to pinpoint syntax issues.
+### manifest_publish.tf
+```tf
+publish(topic="orders", key="abc", payload="{}")
+```
 
-The canonicalizer flattens nested `Seq` blocks before applying registered algebraic laws.
-It collapses idempotent primitives, eliminates declared inverse pairs, and swaps commute-with-pure primitives across adjacent pure nodes.
-Normalization never moves steps across `Region{}` or `Par{}` boundaries, so localized effects stay fenced.
-Running the canonicalizer twice yields the same result, keeping canonical hashes deterministic.
+### manifest_storage.tf
+```tf
+seq{
+  write-object(uri="res://kv/bucket", key="z", value="1");
+  read-object(uri="res://kv/bucket", key="z")
+}
+```
 
-## Authorize dominance check
+### metrics_publish.tf
+```tf
+seq{
+  emit-metric(name="flows.processed", value=2);
+  publish(topic="flows", key="demo", payload="{\"ok\":true}")
+}
+```
 
-Use `authorize(scope="kms.sign"){ ... }` to wrap protected operations that require explicit scopes.
+### net_publish.tf
+```tf
+authorize{ publish(topic="orders", key="abc", payload="{}") }
+```
 
-CLI helpers:
-
-* `pnpm run policy:auth -- check examples/flows/auth_ok.tf`
-* `pnpm run policy:auth -- check --warn-unused examples/flows/auth_ok.tf`
-* `pnpm run policy:auth -- check --strict-warns examples/flows/auth_ok.tf`
-
-Scope requirements are bundled in `packages/tf-l0-check/rules/authorize-scopes.json`.
+### obs_pure_EP.tf
+```tf
+emit-metric |> hash
+```

--- a/docs/l0-effects.md
+++ b/docs/l0-effects.md
@@ -1,0 +1,56 @@
+# L0 Effects (generated)
+
+## Canonical families
+* Pure
+* Observability
+* Storage.Read
+* Storage.Write
+* Network.In
+* Network.Out
+* Crypto
+* Policy
+* Infra
+* Time
+* UI
+
+## Commutation matrix
+Family | Pure | Observability | Storage.Read | Storage.Write | Network.In | Network.Out | Crypto | Policy | Infra | Time | UI
+--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
+Pure | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Observability | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+Storage.Read | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Storage.Write | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Network.In | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Network.Out | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Crypto | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Policy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Infra | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+Time | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+UI | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌
+
+## Parallel safety matrix
+Family | Pure | Observability | Storage.Read | Storage.Write | Network.In | Network.Out | Crypto | Policy | Infra | Time | UI
+--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
+Pure | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Observability | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Storage.Read | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Storage.Write | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Network.In | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Network.Out | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Crypto | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Policy | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Infra | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+Time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+UI | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
+
+## Normalization precedence
+1. Pure
+2. Observability
+3. Network.Out
+4. Storage.Read
+5. Storage.Write
+6. Crypto
+7. Policy
+8. Infra
+9. Time
+10. UI

--- a/scripts/docgen/catalog.mjs
+++ b/scripts/docgen/catalog.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const DEFAULT_CATALOG_PATH = path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'catalog.json');
+const DEFAULT_LAWS_PATH = path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'laws.json');
+const DEFAULT_OUTPUT_PATH = path.join(repoRoot, 'docs', 'l0-catalog.md');
+
+const EFFECT_LIST = [
+  'Pure',
+  'Observability',
+  'Network.Out',
+  'Storage.Read',
+  'Storage.Write',
+  'Crypto',
+  'Policy',
+  'Infra',
+  'Time',
+  'UI'
+];
+
+function readOptionalJson(filePath) {
+  if (!filePath || !existsSync(filePath)) {
+    return null;
+  }
+  return readFile(filePath, 'utf8').then((data) => JSON.parse(data)).catch(() => null);
+}
+
+function escapeCell(value) {
+  return String(value ?? '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\|/g, '\\|')
+    .trim();
+}
+
+function formatFootprints(entries = []) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return [];
+  }
+  const formatted = entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return '(unspecified)';
+      }
+      const uri = typeof entry.uri === 'string' && entry.uri.trim().length > 0 ? entry.uri.trim() : '(unspecified)';
+      const details = [];
+      if (entry.mode) {
+        details.push(`mode=${entry.mode}`);
+      }
+      if (entry.notes) {
+        details.push(`notes=${entry.notes}`);
+      }
+      if (details.length === 0) {
+        return uri;
+      }
+      return `${uri} (${details.join(', ')})`;
+    })
+    .map((value) => escapeCell(value))
+    .sort((a, b) => a.localeCompare(b));
+  return formatted;
+}
+
+function gatherInputDetails(primitive) {
+  const lines = [];
+  const dataClasses = Array.isArray(primitive?.data_classes) ? primitive.data_classes.filter(Boolean) : [];
+  if (dataClasses.length > 0) {
+    const sorted = [...new Set(dataClasses.map(String))].sort((a, b) => a.localeCompare(b));
+    lines.push(`Data classes: ${sorted.join(', ')}`);
+  }
+  const keys = Array.isArray(primitive?.keys) ? primitive.keys.filter(Boolean) : [];
+  if (keys.length > 0) {
+    const sorted = [...new Set(keys.map(String))].sort((a, b) => a.localeCompare(b));
+    lines.push(`Keys: ${sorted.join(', ')}`);
+  }
+  const reads = formatFootprints(primitive?.reads);
+  if (reads.length > 0) {
+    lines.push(`Reads: ${reads.join('; ')}`);
+  }
+  return lines;
+}
+
+function gatherOutputDetails(primitive) {
+  const lines = [];
+  const writes = formatFootprints(primitive?.writes);
+  if (writes.length > 0) {
+    lines.push(`Writes: ${writes.join('; ')}`);
+  }
+  const qosEntries = primitive?.qos && typeof primitive.qos === 'object' ? Object.entries(primitive.qos) : [];
+  if (qosEntries.length > 0) {
+    const normalized = qosEntries
+      .filter(([key, value]) => key && value != null && String(value).length > 0)
+      .map(([key, value]) => `${key}=${value}`)
+      .sort((a, b) => a.localeCompare(b));
+    if (normalized.length > 0) {
+      lines.push(`QoS: ${normalized.join(', ')}`);
+    }
+  }
+  return lines;
+}
+
+function collectEffects(primitive) {
+  const effects = Array.isArray(primitive?.effects) ? primitive.effects.filter(Boolean).map(String) : [];
+  if (effects.length === 0) {
+    return '—';
+  }
+  const sorted = [...new Set(effects)].sort((a, b) => a.localeCompare(b));
+  return escapeCell(sorted.join(', '));
+}
+
+function collectLaws(primitive, laws = []) {
+  if (!primitive?.id || !Array.isArray(laws)) {
+    return '—';
+  }
+  const matches = laws
+    .filter((law) => Array.isArray(law?.applies_to) && law.applies_to.map(String).includes(primitive.id))
+    .map((law) => law.id)
+    .filter(Boolean)
+    .map(String)
+    .sort((a, b) => a.localeCompare(b));
+  if (matches.length === 0) {
+    return '—';
+  }
+  return escapeCell(matches.join(', '));
+}
+
+function formatCell(lines) {
+  if (!lines || lines.length === 0) {
+    return '—';
+  }
+  return escapeCell(lines.join(' \u2022 '));
+}
+
+function buildCatalogMarkdown(catalog, lawsData) {
+  const primitives = Array.isArray(catalog?.primitives) ? [...catalog.primitives] : [];
+  primitives.sort((a, b) => {
+    const ida = String(a?.id ?? '');
+    const idb = String(b?.id ?? '');
+    return ida.localeCompare(idb);
+  });
+
+  const laws = Array.isArray(lawsData?.laws) ? lawsData.laws : [];
+  const lines = [];
+  lines.push('# L0 Catalog (generated)');
+  lines.push(`Primitives: ${primitives.length}`);
+  lines.push(`Effects: ${EFFECT_LIST.join(', ')}`);
+
+  for (const primitive of primitives) {
+    lines.push('');
+    lines.push(`### ${primitive.id}`);
+    lines.push('');
+    lines.push('| Effects | Input | Output | Laws |');
+    lines.push('| --- | --- | --- | --- |');
+    const effectsCell = collectEffects(primitive);
+    const inputCell = formatCell(gatherInputDetails(primitive));
+    const outputCell = formatCell(gatherOutputDetails(primitive));
+    const lawsCell = collectLaws(primitive, laws);
+    lines.push(`| ${effectsCell} | ${inputCell} | ${outputCell} | ${lawsCell} |`);
+  }
+
+  let doc = lines.join('\n');
+  if (!doc.endsWith('\n')) {
+    doc += '\n';
+  }
+  return doc;
+}
+
+export async function generateCatalogDoc({
+  catalogPath = DEFAULT_CATALOG_PATH,
+  lawsPath = DEFAULT_LAWS_PATH,
+  outputPath = DEFAULT_OUTPUT_PATH
+} = {}) {
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  const laws = (await readOptionalJson(lawsPath)) ?? { laws: [] };
+  const markdown = buildCatalogMarkdown(catalog, laws);
+  await writeFile(outputPath, markdown, 'utf8');
+  return markdown;
+}
+
+async function main() {
+  await generateCatalogDoc();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/docgen/dsl.mjs
+++ b/scripts/docgen/dsl.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { readFile, writeFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const PARSER_PATH = path.join(repoRoot, 'packages', 'tf-compose', 'src', 'parser.mjs');
+const CLI_PATH = path.join(repoRoot, 'packages', 'tf-compose', 'bin', 'tf.mjs');
+const EXAMPLES_DIR = path.join(repoRoot, 'examples', 'flows');
+const OUTPUT_PATH = path.join(repoRoot, 'docs', 'l0-dsl.md');
+
+const MAX_EXAMPLE_LINES = 6;
+const MAX_EXAMPLE_CHARS = 240;
+const MAX_EXAMPLES = 12;
+
+async function loadUsageLine() {
+  const cliSource = await readFile(CLI_PATH, 'utf8');
+  const match = cliSource.match(/Usage: tf [^']+/);
+  if (match) {
+    return match[0].trim();
+  }
+  return 'Usage: tf <parse|check|canon|emit> <flow.tf> [--out path]';
+}
+
+async function loadParserFacts() {
+  const source = await readFile(PARSER_PATH, 'utf8');
+  return {
+    supportsAuthorize: source.includes("REGION_AUTH"),
+    supportsTxn: source.includes("REGION_TXN"),
+    supportsSeqBlocks: source.includes("SEQ_OPEN"),
+    supportsParBlocks: source.includes("PAR_OPEN")
+  };
+}
+
+function describeLiterals() {
+  return [
+    'Strings accept single or double quotes with standard escape handling.',
+    'Numbers support optional leading `-` and fractional parts.',
+    'Boolean and null literals map to `true`, `false`, and `null`.',
+    'Arrays allow trailing commas and can nest arbitrary literal forms.',
+    'Objects accept string, identifier, or numeric keys with trailing commas.'
+  ];
+}
+
+function describeBasics(parserFacts) {
+  const lines = [];
+  if (parserFacts.supportsSeqBlocks) {
+    lines.push('`a |> b` composes primitives into a left-associated sequence.');
+    lines.push('`seq{ ... }` groups steps explicitly; semicolons separate statements inside the block.');
+  } else {
+    lines.push('Sequence composition uses the `|>` operator.');
+  }
+  if (parserFacts.supportsParBlocks) {
+    lines.push('`par{ ... }` evaluates children in parallel; separate branches with semicolons.');
+  }
+  lines.push('Bare identifiers call primitives; add `(key=value, ...)` to supply arguments.');
+  return lines;
+}
+
+function describeRegions(parserFacts) {
+  const lines = [];
+  if (parserFacts.supportsAuthorize) {
+    lines.push('`authorize{ ... }` fences steps that require explicit capabilities.');
+    lines.push('Add attributes with `authorize(scope="kms.sign"){ ... }`; attributes are parsed as key/value pairs.');
+  }
+  if (parserFacts.supportsTxn) {
+    lines.push('`txn{ ... }` introduces a transactional region with the same attribute syntax.');
+  }
+  lines.push('Region blocks behave like sequence blocks for canonicalization boundaries.');
+  return lines;
+}
+
+function describeComments() {
+  return ['The current tokenizer does not recognize `#` or `//` comments; keep `.tf` files comment-free.'];
+}
+
+async function loadExamples() {
+  const entries = await readdir(EXAMPLES_DIR, { withFileTypes: true });
+  const snippets = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.tf')) {
+      continue;
+    }
+    const examplePath = path.join(EXAMPLES_DIR, entry.name);
+    const contents = await readFile(examplePath, 'utf8');
+    const trimmed = contents.trimEnd();
+    const lineCount = trimmed.split(/\r?\n/).length;
+    if (lineCount > MAX_EXAMPLE_LINES) {
+      continue;
+    }
+    if (trimmed.length > MAX_EXAMPLE_CHARS) {
+      continue;
+    }
+    snippets.push({ name: entry.name, contents: trimmed });
+  }
+  snippets.sort((a, b) => a.name.localeCompare(b.name));
+  return snippets.slice(0, MAX_EXAMPLES);
+}
+
+function buildSection(title, bullets) {
+  const lines = [`## ${title}`];
+  for (const bullet of bullets) {
+    lines.push(`* ${bullet}`);
+  }
+  return lines;
+}
+
+async function buildDslMarkdown() {
+  const usageLine = await loadUsageLine();
+  const parserFacts = await loadParserFacts();
+  const lines = ['# L0 DSL Cheatsheet (generated)'];
+
+  lines.push('');
+  lines.push(...buildSection('Basics', describeBasics(parserFacts)));
+  lines.push('');
+  lines.push(...buildSection('Args & Literals', describeLiterals()));
+  lines.push('');
+  lines.push(...buildSection('Regions', describeRegions(parserFacts)));
+  lines.push('');
+  lines.push(...buildSection('Comments', describeComments()));
+  lines.push('');
+  const cliBullets = [
+    `${usageLine}.`,
+    '`tf parse` → emit canonical IR JSON for a flow.',
+    '`tf check` → validate effects and region fences using the current catalog.',
+    '`tf canon` → apply registered algebraic laws for normalization.',
+    '`tf emit --lang ts|rs` → generate runnable scaffolding in the requested language.'
+  ];
+  lines.push(...buildSection('CLI usage', cliBullets));
+
+  const examples = await loadExamples();
+  if (examples.length > 0) {
+    lines.push('');
+    lines.push('## Examples');
+    for (const example of examples) {
+      lines.push('');
+      lines.push(`### ${example.name}`);
+      lines.push('```tf');
+      lines.push(example.contents);
+      lines.push('```');
+    }
+  }
+
+  let doc = lines.join('\n');
+  if (!doc.endsWith('\n')) {
+    doc += '\n';
+  }
+  return doc;
+}
+
+export async function generateDslDoc({ outputPath = OUTPUT_PATH } = {}) {
+  const markdown = await buildDslMarkdown();
+  await writeFile(outputPath, markdown, 'utf8');
+  return markdown;
+}
+
+async function main() {
+  await generateDslDoc();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/docgen/effects.mjs
+++ b/scripts/docgen/effects.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  CANONICAL_EFFECT_FAMILIES,
+  EFFECT_PRECEDENCE,
+  canCommute,
+  parSafe
+} from '../../packages/tf-l0-check/src/effect-lattice.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const OUTPUT_PATH = path.join(repoRoot, 'docs', 'l0-effects.md');
+
+function formatBoolean(value) {
+  return value ? '✅' : '❌';
+}
+
+function buildMatrixRows(evaluator) {
+  const header = ['Family', ...CANONICAL_EFFECT_FAMILIES];
+  const rows = [header.join(' | '), header.map(() => '---').join(' | ')];
+  for (const rowFam of CANONICAL_EFFECT_FAMILIES) {
+    const cells = [rowFam];
+    for (const colFam of CANONICAL_EFFECT_FAMILIES) {
+      cells.push(formatBoolean(evaluator(rowFam, colFam)));
+    }
+    rows.push(cells.join(' | '));
+  }
+  return rows;
+}
+
+function buildEffectsMarkdown() {
+  const lines = ['# L0 Effects (generated)'];
+
+  lines.push('');
+  lines.push('## Canonical families');
+  for (const family of CANONICAL_EFFECT_FAMILIES) {
+    lines.push(`* ${family}`);
+  }
+
+  lines.push('');
+  lines.push('## Commutation matrix');
+  lines.push(...buildMatrixRows((a, b) => canCommute(a, b)));
+
+  lines.push('');
+  lines.push('## Parallel safety matrix');
+  lines.push(...buildMatrixRows((a, b) => parSafe(a, b)));
+
+  lines.push('');
+  lines.push('## Normalization precedence');
+  EFFECT_PRECEDENCE.forEach((family, index) => {
+    lines.push(`${index + 1}. ${family}`);
+  });
+
+  let doc = lines.join('\n');
+  if (!doc.endsWith('\n')) {
+    doc += '\n';
+  }
+  return doc;
+}
+
+export async function generateEffectsDoc({ outputPath = OUTPUT_PATH } = {}) {
+  const markdown = buildEffectsMarkdown();
+  await writeFile(outputPath, markdown, 'utf8');
+  return markdown;
+}
+
+async function main() {
+  await generateEffectsDoc();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}

--- a/tests/docgen.test.mjs
+++ b/tests/docgen.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const DOC_PATHS = {
+  catalog: path.join(repoRoot, 'docs', 'l0-catalog.md'),
+  dsl: path.join(repoRoot, 'docs', 'l0-dsl.md'),
+  effects: path.join(repoRoot, 'docs', 'l0-effects.md')
+};
+
+const SCRIPT_PATHS = [
+  path.join(repoRoot, 'scripts', 'docgen', 'catalog.mjs'),
+  path.join(repoRoot, 'scripts', 'docgen', 'dsl.mjs'),
+  path.join(repoRoot, 'scripts', 'docgen', 'effects.mjs')
+];
+
+async function runDocgenScripts() {
+  for (const scriptPath of SCRIPT_PATHS) {
+    await execFileAsync('node', [scriptPath], { cwd: repoRoot });
+  }
+}
+
+async function loadDocs() {
+  const entries = {};
+  for (const [key, docPath] of Object.entries(DOC_PATHS)) {
+    entries[key] = await readFile(docPath, 'utf8');
+  }
+  return entries;
+}
+
+function assertSingleTrailingNewline(content, label) {
+  assert.ok(content.endsWith('\n'), `${label} should end with a newline`);
+  assert.ok(!content.endsWith('\n\n'), `${label} should not end with extra blank lines`);
+}
+
+test('docgen outputs are deterministic and aligned with catalog', async () => {
+  await runDocgenScripts();
+  const firstDocs = await loadDocs();
+
+  for (const [key, content] of Object.entries(firstDocs)) {
+    assertSingleTrailingNewline(content, key);
+  }
+
+  const catalogJsonPath = path.join(repoRoot, 'packages', 'tf-l0-spec', 'spec', 'catalog.json');
+  const catalogJson = JSON.parse(await readFile(catalogJsonPath, 'utf8'));
+  const primitiveCount = Array.isArray(catalogJson?.primitives) ? catalogJson.primitives.length : 0;
+
+  const countMatch = firstDocs.catalog.match(/^Primitives: (\d+)/m);
+  assert.ok(countMatch, 'catalog doc should include primitive count line');
+  const countValue = Number(countMatch[1]);
+  if (primitiveCount > 0) {
+    assert.equal(countValue, primitiveCount, 'primitive count line should match catalog length');
+  } else {
+    assert.equal(countValue, 0, 'primitive count should be zero when catalog is empty');
+  }
+
+  await runDocgenScripts();
+  const secondDocs = await loadDocs();
+
+  for (const key of Object.keys(DOC_PATHS)) {
+    assert.equal(secondDocs[key], firstDocs[key], `${key} doc changed after re-running docgen`);
+  }
+});


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

## Summary
- Scope: B6+F1 docgen
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [x] CI wiring + determinism re-run

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`

## Determinism & Seeds
- Repeats: 1
- Seeds: n/a (docgen only)
- Notes: Docgen scripts normalize ordering; regression test reruns generators to confirm byte-identical output.

## Tests & CI
- TS tests: passed 152 / failed 0 (`pnpm -w -r test`)
- Rust tests: not run (n/a)
- CI jobs: not run (local only)

## Implementation Notes
- ABI / paths unchanged? Y (documentation + tooling only)
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`, Rust panic-free

## Hurdles / Follow-ups
- Known gaps: None
- Suggested next steps: Monitor docs as catalog/DSL evolve so generators stay aligned.


------
https://chatgpt.com/codex/tasks/task_e_68d05cec9c8c83208e79f88b1041fbf7