### PR TITLE
Add docgen scripts and CI check

### DIFF
--- a/.github/workflows/l0-docs.yml
+++ b/.github/workflows/l0-docs.yml
@@ -1,0 +1,37 @@
+name: L0 Docs (regen check)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+
+      - name: Build (for lattice import)
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Regenerate docs
+        run: |
+          node scripts/docgen/catalog.mjs
+          node scripts/docgen/dsl.mjs
+          node scripts/docgen/effects.mjs
+
+      - name: Fail if changed
+        run: |
+          if [[ -n "$(git status --porcelain docs/*.md)" ]]; then
+            echo "Docs out of date. Run docgen scripts and commit." >&2
+            git diff -- docs
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ This repo skeleton grounds A0 → B4 so builders can flesh out implementations w
 arguing about structure. It includes: IDs & versions, catalog ingest, effects/laws stubs,
 DSL+IR+canonicalizer, checker glue, and TS/Rust codegen skeletons.
 
+- Catalog: [docs/l0-catalog.md](docs/l0-catalog.md)
+- DSL Cheatsheet: [docs/l0-dsl.md](docs/l0-dsl.md)
+- Effects/Lattice: [docs/l0-effects.md](docs/l0-effects.md)
+
 ### Quick Start
 
 ```bash

--- a/docs/l0-catalog.md
+++ b/docs/l0-catalog.md
@@ -1,23 +1,87 @@
-# L0 Catalog (A1 skeleton)
-- `spec/ids.json` — IDs
-- `spec/catalog.json` — normalized catalog with placeholders
-- `spec/effects.json` — derived effect tags
-- `spec/laws.json` — law registry (sample rules)
+# L0 Catalog (generated)
+Primitives: 14
+Effects: Pure, Observability, Network.Out, Storage.Read, Storage.Write, Crypto, Policy, Infra, Time, UI
 
-### Seed Overlay
-Until the legacy YAML catalogs are fully curated, the A1 pipeline unions any
-`spec/seed/*.json` overlay into the generated catalog. The seed entries carry
-minimal `effects`, `reads`/`writes`, and `qos` data so the checker, flows, and
-conflict detection stay runnable while curation continues.
+### tf:information/deserialize@1
 
-### Effect derivation rules
-Deterministic name-based rules fill in missing effect tags and network QoS only when the catalog lacks curated data.
-Seed overlays remain authoritative for existing effects or qos values.
-Hashing primitives classify as Pure; Crypto is reserved for secret-bearing operations (sign/verify/encrypt/decrypt).
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Pure` | — | — | `law:serialize-deserialize-eq-id` |
 
-### Manifest compatibility
-For v0.4 manifests we emit both the legacy `effects`/`footprints` fields and the new
-`required_effects`/`footprints_rw`/`qos` structure for downstream compatibility. The
-two shapes are mutually exclusive, but the schema and CLI validator accept either so
-consumers can migrate on their own schedule. Use
-`node scripts/validate-manifest.mjs <path>` to confirm conformance.
+### tf:information/hash@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Pure` | — | — | `law:hash-idempotent` |
+
+### tf:information/serialize@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Pure` | — | — | `law:serialize-deserialize-eq-id` |
+
+### tf:network/acknowledge@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Network.Out` | — | — | — |
+
+### tf:network/publish@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Network.Out` | — | — | — |
+
+### tf:network/request@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Network.Out` | — | — | — |
+
+### tf:network/subscribe@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Network.In` | — | — | — |
+
+### tf:observability/emit-metric@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Observability` | — | — | `law:emitmetric-commutes-with-pure` |
+
+### tf:resource/compare-and-swap@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Storage.Write` | — | `res://kv/<bucket>/:<key>` (seed) | — |
+
+### tf:resource/delete-object@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Storage.Write` | — | `res://kv/<bucket>/:<key>` (seed) | — |
+
+### tf:resource/read-object@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Storage.Read` | `res://kv/<bucket>/:<key>` (seed) | — | — |
+
+### tf:resource/write-object@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Storage.Write` | — | `res://kv/<bucket>/:<key>` (seed) | — |
+
+### tf:security/sign-data@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Crypto` | — | — | — |
+
+### tf:security/verify-signature@1
+
+| Effects | Input | Output | Laws |
+| --- | --- | --- | --- |
+| `Crypto` | — | — | — |

--- a/docs/l0-effects.md
+++ b/docs/l0-effects.md
@@ -1,0 +1,51 @@
+# L0 Effects (generated)
+
+## Canonical Families
+
+- `Pure`
+- `Observability`
+- `Storage.Read`
+- `Storage.Write`
+- `Network.In`
+- `Network.Out`
+- `Crypto`
+- `Policy`
+- `Infra`
+- `Time`
+- `UI`
+
+## Commutation Matrix
+
+| Prev \ Next | `Pure` | `Observability` | `Storage.Read` | `Storage.Write` | `Network.In` | `Network.Out` | `Crypto` | `Policy` | `Infra` | `Time` | `UI` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Pure` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Observability` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Storage.Read` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Storage.Write` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Network.In` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Network.Out` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Crypto` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Policy` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Infra` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `Time` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `UI` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Parallel Safety Matrix
+
+| Branch A \ Branch B | `Pure` | `Observability` | `Storage.Read` | `Storage.Write` | `Network.In` | `Network.Out` | `Crypto` | `Policy` | `Infra` | `Time` | `UI` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Pure` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Observability` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Storage.Read` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Storage.Write` | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Network.In` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Network.Out` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Crypto` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Policy` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Infra` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Time` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `UI` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+## Precedence
+
+Normalization order: `Pure` > `Observability` > `Network.Out` > `Storage.Read` > `Storage.Write` > `Crypto` > `Policy` > `Infra` > `Time` > `UI`

--- a/scripts/docgen/catalog.mjs
+++ b/scripts/docgen/catalog.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { EFFECT_PRECEDENCE } from '../../packages/tf-l0-check/src/effect-lattice.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+
+const CATALOG_PATH = path.join(ROOT, 'packages/tf-l0-spec/spec/catalog.json');
+const LAWS_PATH = path.join(ROOT, 'packages/tf-l0-spec/spec/laws.json');
+const OUT_PATH = path.join(ROOT, 'docs/l0-catalog.md');
+
+async function loadJson(filePath, fallback) {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw err;
+  }
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value.slice() : [];
+}
+
+function formatList(values) {
+  if (!values || values.length === 0) return '—';
+  return values.map(v => `\`${v}\``).join(', ');
+}
+
+function formatIo(entries) {
+  const items = toArray(entries)
+    .map(entry => {
+      if (!entry || typeof entry !== 'object') {
+        return '';
+      }
+      const uri = typeof entry.uri === 'string' ? entry.uri : '';
+      const note = typeof entry.notes === 'string' && entry.notes.trim().length > 0 ? entry.notes.trim() : '';
+      const parts = [];
+      if (uri) {
+        parts.push(`\`${uri}\``);
+      }
+      if (note) {
+        parts.push(`(${note})`);
+      }
+      return parts.join(' ');
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+  if (items.length === 0) {
+    return '—';
+  }
+  return items.join('<br>');
+}
+
+function mapLaws(lawsData) {
+  const out = new Map();
+  const laws = toArray(lawsData?.laws);
+  for (const law of laws) {
+    const applies = toArray(law?.applies_to);
+    const id = typeof law?.id === 'string' ? law.id : null;
+    if (!id) continue;
+    for (const prim of applies) {
+      if (typeof prim !== 'string') continue;
+      const existing = out.get(prim) || [];
+      existing.push(id);
+      out.set(prim, existing);
+    }
+  }
+  for (const [key, list] of out.entries()) {
+    list.sort((a, b) => a.localeCompare(b));
+  }
+  return out;
+}
+
+function buildDoc(catalog, lawMap) {
+  const primitives = toArray(catalog?.primitives)
+    .filter(prim => prim && typeof prim === 'object')
+    .sort((a, b) => {
+      const idA = String(a.id || '').toLowerCase();
+      const idB = String(b.id || '').toLowerCase();
+      if (idA < idB) return -1;
+      if (idA > idB) return 1;
+      return 0;
+    });
+
+  const lines = [];
+  lines.push('# L0 Catalog (generated)');
+  lines.push(`Primitives: ${primitives.length}`);
+  lines.push(`Effects: ${EFFECT_PRECEDENCE.join(', ')}`);
+  lines.push('');
+
+  for (const prim of primitives) {
+    const primId = String(prim.id || '');
+    lines.push(`### ${primId}`);
+    lines.push('');
+    lines.push('| Effects | Input | Output | Laws |');
+    lines.push('| --- | --- | --- | --- |');
+
+    const effects = toArray(prim.effects)
+      .map(eff => String(eff || ''))
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+    const reads = formatIo(prim.reads);
+    const writes = formatIo(prim.writes);
+    const laws = lawMap.get(primId) || [];
+
+    lines.push(`| ${formatList(effects)} | ${reads} | ${writes} | ${formatList(laws)} |`);
+    lines.push('');
+  }
+
+  return ensureTrailingNewline(lines.join('\n'));
+}
+
+function ensureTrailingNewline(payload) {
+  const normalized = payload.replace(/\s+$/, match => match.includes('\n') ? '\n' : '');
+  return normalized.endsWith('\n') ? normalized : `${normalized}\n`;
+}
+
+async function main() {
+  const [catalog, laws] = await Promise.all([
+    loadJson(CATALOG_PATH, { primitives: [] }),
+    loadJson(LAWS_PATH, { laws: [] })
+  ]);
+
+  const lawMap = mapLaws(laws);
+  const content = buildDoc(catalog, lawMap);
+  await mkdir(path.dirname(OUT_PATH), { recursive: true });
+  await writeFile(OUT_PATH, content, 'utf8');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main();
+}
+
+export { buildDoc };

--- a/scripts/docgen/dsl.mjs
+++ b/scripts/docgen/dsl.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const OUT_PATH = path.join(ROOT, 'docs/l0-dsl.md');
+const EXAMPLES_DIR = path.join(ROOT, 'examples/flows');
+const ALWAYS_INCLUDE = new Set(['run_publish.tf', 'signing.tf']);
+
+function ensureTrailingNewline(payload) {
+  return payload.endsWith('\n') ? payload : `${payload}\n`;
+}
+
+function formatSection(title, bodyLines) {
+  return [`## ${title}`, '', ...bodyLines, ''];
+}
+
+function trimExample(content) {
+  return content.replace(/\s+$/s, '').replace(/^\s+/s, match => match.includes('\n') ? '' : match);
+}
+
+function pickExamples(entries) {
+  const filtered = entries.filter(entry => {
+    if (ALWAYS_INCLUDE.has(entry.name)) return true;
+    return entry.lines <= 4 && entry.content.length <= 200;
+  });
+  const missing = [...ALWAYS_INCLUDE].filter(name => !filtered.some(entry => entry.name === name));
+  for (const name of missing) {
+    const fallback = entries.find(entry => entry.name === name);
+    if (fallback) {
+      filtered.push(fallback);
+    }
+  }
+  return filtered
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(entry => ({ name: entry.name, content: trimExample(entry.raw) }));
+}
+
+async function loadExamples() {
+  const files = await readdir(EXAMPLES_DIR);
+  const tfFiles = files.filter(f => f.endsWith('.tf'));
+  const entries = [];
+  for (const name of tfFiles) {
+    const raw = await readFile(path.join(EXAMPLES_DIR, name), 'utf8');
+    const trimmed = raw.trim();
+    const lines = trimmed.length === 0 ? 0 : trimmed.split(/\r?\n/).length;
+    entries.push({ name, raw, content: trimmed, lines });
+  }
+  return pickExamples(entries);
+}
+
+async function buildDoc() {
+  const examples = await loadExamples();
+
+  const lines = ['# L0 DSL Cheatsheet (generated)', ''];
+
+  lines.push(...formatSection('Basics', [
+    'The DSL composes primitives with the pipeline operator `|>`. A single line such as ``serialize |> hash`` creates a sequential flow.',
+    'Use `seq{ ... }` blocks to spell out multi-line sequences. Steps inside a block are separated with semicolons (`;`).',
+    '`par{ ... }` introduces parallel branches. Each branch is parsed like a standalone flow and must be terminated with a semicolon unless it is the final branch.'
+  ]));
+
+  lines.push(...formatSection('Args & Literals', [
+    'Arguments follow the form `prim(key=value, ...)`. Strings accept both single and double quotes and support standard escape sequences.',
+    'Numbers accept optional leading minus signs and fractional components. Bare identifiers map to lower-cased primitive IDs or literal booleans (`true`, `false`) and `null`.',
+    'Arrays (`[a, b, c]`) and objects (`{ key: value }`) are supported recursively, so complex payloads can be passed directly in-line.'
+  ]));
+
+  lines.push(...formatSection('Regions', [
+    '`authorize{ ... }` wraps a sub-flow that requires policy checks. Optional attributes may appear as `authorize(scope="admin"){ ... }` before the block.',
+    '`txn{ ... }` declares a transaction region. It shares the same attribute syntax as `authorize{}` and evaluates its children sequentially.'
+  ]));
+
+  lines.push(...formatSection('Comments', [
+    'The grammar does not include line or block comments yet. Keep flows self-documenting or maintain commentary alongside the `.tf` files.'
+  ]));
+
+  lines.push(...formatSection('CLI usage', [
+    'The `tf` helper under `packages/tf-compose/bin/tf.mjs` exposes the main workflows:',
+    '- `tf parse <flow.tf>` → parse and emit the canonical IR JSON.',
+    '- `tf check <flow.tf>` → run the lattice-aware checker and print the verdict JSON.',
+    '- `tf canon <flow.tf>` → normalize the IR using catalog + law data.',
+    '- `tf emit --lang ts|rs <flow.tf>` → write language-specific scaffolding into `out/0.4/codegen-*`.'
+  ]));
+
+  if (examples.length > 0) {
+    lines.push('## Examples');
+    lines.push('');
+    for (const example of examples) {
+      lines.push(`### ${example.name}`);
+      lines.push('');
+      lines.push('```tf');
+      lines.push(example.content);
+      lines.push('```');
+      lines.push('');
+    }
+  }
+
+  const payload = ensureTrailingNewline(lines.join('\n'));
+  await mkdir(path.dirname(OUT_PATH), { recursive: true });
+  await writeFile(OUT_PATH, payload, 'utf8');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await buildDoc();
+}
+
+export { buildDoc };

--- a/scripts/docgen/effects.mjs
+++ b/scripts/docgen/effects.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  CANONICAL_EFFECT_FAMILIES,
+  EFFECT_PRECEDENCE,
+  canCommute,
+  parSafe
+} from '../../packages/tf-l0-check/src/effect-lattice.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const OUT_PATH = path.join(ROOT, 'docs/l0-effects.md');
+
+function ensureTrailingNewline(payload) {
+  return payload.endsWith('\n') ? payload : `${payload}\n`;
+}
+
+function renderMatrix(title, headerLabel, evaluator) {
+  const families = [...CANONICAL_EFFECT_FAMILIES];
+  const header = ['| ' + headerLabel + ' |', ...families.map(f => ` ${formatFamily(f)} |`)].join('');
+  const separator = ['| --- |', ...families.map(() => ' --- |')].join('');
+  const rows = families.map(rowFamily => {
+    const cells = families.map(colFamily => evaluator(rowFamily, colFamily) ? ' ✅ ' : ' ❌ ');
+    return ['| ' + formatFamily(rowFamily) + ' |', ...cells.map(cell => cell + '|')].join('');
+  });
+  return [`## ${title}`, '', header, separator, ...rows, ''];
+}
+
+function formatFamily(family) {
+  return `\`${family}\``;
+}
+
+async function buildDoc() {
+  const lines = ['# L0 Effects (generated)', ''];
+
+  lines.push('## Canonical Families');
+  lines.push('');
+  for (const family of CANONICAL_EFFECT_FAMILIES) {
+    lines.push(`- ${formatFamily(family)}`);
+  }
+  lines.push('');
+
+  lines.push(...renderMatrix('Commutation Matrix', 'Prev \\ Next', (a, b) => canCommute(a, b)));
+  lines.push(...renderMatrix('Parallel Safety Matrix', 'Branch A \\ Branch B', (a, b) => parSafe(a, b)));
+
+  lines.push('## Precedence');
+  lines.push('');
+  lines.push(`Normalization order: ${EFFECT_PRECEDENCE.map(formatFamily).join(' > ')}`);
+  lines.push('');
+
+  const payload = ensureTrailingNewline(lines.join('\n'));
+  await mkdir(path.dirname(OUT_PATH), { recursive: true });
+  await writeFile(OUT_PATH, payload, 'utf8');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await buildDoc();
+}
+
+export { buildDoc };

--- a/tests/docgen.test.mjs
+++ b/tests/docgen.test.mjs
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const DOC_SCRIPTS = [
+  { script: 'catalog.mjs', output: 'docs/l0-catalog.md' },
+  { script: 'dsl.mjs', output: 'docs/l0-dsl.md' },
+  { script: 'effects.mjs', output: 'docs/l0-effects.md' }
+];
+
+async function runScript(name) {
+  const scriptPath = path.join(ROOT, 'scripts/docgen', name);
+  await execFileAsync('node', [scriptPath], { cwd: ROOT });
+}
+
+test('docgen outputs are deterministic', async () => {
+  for (const entry of DOC_SCRIPTS) {
+    await runScript(entry.script);
+  }
+
+  const snapshots = new Map();
+
+  for (const entry of DOC_SCRIPTS) {
+    const absPath = path.join(ROOT, entry.output);
+    const content = await readFile(absPath, 'utf8');
+    assert.ok(content.endsWith('\n'), `${entry.output} should end with a newline`);
+    assert.ok(!content.endsWith('\n\n'), `${entry.output} should not end with an empty line`);
+    snapshots.set(entry.output, content);
+  }
+
+  const catalogPath = path.join(ROOT, 'packages/tf-l0-spec/spec/catalog.json');
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+  const primitiveCount = Array.isArray(catalog?.primitives) ? catalog.primitives.length : 0;
+  const catalogDoc = snapshots.get('docs/l0-catalog.md') ?? '';
+  const countLine = catalogDoc.split('\n').find(line => line.startsWith('Primitives: '));
+  assert.ok(countLine, 'catalog doc should include primitive count');
+  assert.equal(countLine, `Primitives: ${primitiveCount}`);
+
+  for (const entry of DOC_SCRIPTS) {
+    await runScript(entry.script);
+  }
+
+  for (const entry of DOC_SCRIPTS) {
+    const absPath = path.join(ROOT, entry.output);
+    const next = await readFile(absPath, 'utf8');
+    assert.equal(next, snapshots.get(entry.output));
+  }
+});


### PR DESCRIPTION
## Summary
- add node-based generators for catalog, DSL, and effects docs and check them into version control
- create a deterministic docgen test suite and CI workflow to ensure generated docs stay in sync
- publish the generated reference docs and link them from the README

## Testing
- pnpm -w -r build
- node scripts/docgen/catalog.mjs
- node scripts/docgen/dsl.mjs
- node scripts/docgen/effects.mjs
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d05cec9c8c83208e79f88b1041fbf7