### PR TITLE
Add runtime verify workflow and CLI

### DIFF
--- a/.github/workflows/l0-runtime-verify.yml
+++ b/.github/workflows/l0-runtime-verify.yml
@@ -1,0 +1,48 @@
+name: L0 Runtime Verify
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            **/pnpm-lock.yaml
+
+      - name: Build
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Pilot build & run w/ provenance
+        env:
+          TF_PROVENANCE: '1'
+          TF_FIXED_TS: '1750000000000'
+        run: node scripts/pilot-build-run.mjs
+
+      - name: Verify (schema + meta + composition)
+        run: node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json
+
+      - name: List reports
+        run: |
+          echo "::group::verify reports"
+          find out/0.4/verify -type f -print
+          echo "::endgroup::"
+
+      - name: Upload verify artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: l0-runtime-verify
+          path: out/0.4/verify/**

--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -55,3 +55,7 @@ TF_FIXED_TS=1750000000000 pnpm run pilot:all && cat out/0.4/parity/report.json
 ```
 
 The parity harness exits non-zero if any artifact digests differ and is covered by `tests/pilot-parity.test.mjs`, which reruns the harness to ensure byte-for-byte determinism.
+
+### Runtime verify (schema + meta + composition)
+- Local: `node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json`
+- CI: workflow **"L0 Runtime Verify"** runs the same steps and uploads `l0-runtime-verify` artifacts.

--- a/scripts/runtime-verify.mjs
+++ b/scripts/runtime-verify.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+import { dirname, join, resolve, relative, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { canonicalStringify } from './hash-jsonl.mjs';
+import { sha256OfCanonicalJson } from '../packages/tf-l0-tools/lib/digest.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(here, '..');
+const validateScript = fileURLToPath(new URL('./validate-trace.mjs', import.meta.url));
+const verifyScript = fileURLToPath(new URL('../packages/tf-compose/bin/tf-verify-trace.mjs', import.meta.url));
+const defaultCatalogPath = join(rootDir, 'packages', 'tf-l0-spec', 'spec', 'catalog.json');
+
+function resolvePilotOutDir() {
+  const override = process.env.PILOT_OUT_DIR;
+  if (override && override.trim()) {
+    return isAbsolute(override) ? override : resolve(rootDir, override);
+  }
+  return join(rootDir, 'out', '0.4', 'pilot-l0');
+}
+
+function resolveFlowPaths(flow) {
+  if (flow !== 'pilot') return null;
+  const base = resolvePilotOutDir();
+  return {
+    ir: join(base, 'pilot_min.ir.json'),
+    manifest: join(base, 'pilot_min.manifest.json'),
+    status: join(base, 'status.json'),
+    trace: join(base, 'trace.jsonl'),
+    catalog: defaultCatalogPath,
+  };
+}
+
+function resolveInputPath(value) {
+  if (!value) return null;
+  if (isAbsolute(value)) return value;
+  return resolve(process.cwd(), value);
+}
+
+function displayPath(absPath) {
+  if (!absPath) return null;
+  const rel = relative(rootDir, absPath);
+  if (!rel.startsWith('..')) return rel.split('\\').join('/');
+  return absPath.split('\\').join('/');
+}
+
+async function readJson(path) {
+  const raw = await readFile(path, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`unable to parse JSON from ${path}: ${err?.message || err}`);
+  }
+}
+
+async function digestFromJsonFile(path) {
+  const parsed = await readJson(path);
+  return sha256OfCanonicalJson(parsed);
+}
+
+function parseJsonSafe(raw) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function evaluateStep(name, result) {
+  const stdout = (result.stdout || '').trim();
+  const summary = parseJsonSafe(stdout);
+  const ok = Boolean(summary?.ok) && result.status === 0;
+  const issues = [];
+  if (!ok) {
+    if (Array.isArray(summary?.issues)) {
+      issues.push(...summary.issues);
+    }
+    const stderr = (result.stderr || '').trim();
+    if (stderr) {
+      issues.push({ step: name, stderr });
+    }
+    if (result.error) {
+      issues.push({ step: name, error: result.error.message || String(result.error) });
+    }
+    if (!summary && stdout) {
+      issues.push({ step: name, stdout });
+    }
+  }
+  return { ok, summary, issues };
+}
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      flow: { type: 'string' },
+      ir: { type: 'string' },
+      manifest: { type: 'string' },
+      status: { type: 'string' },
+      trace: { type: 'string' },
+      catalog: { type: 'string' },
+      out: { type: 'string' },
+    },
+    allowPositionals: true,
+  });
+
+  if (positionals.length > 0) {
+    process.stderr.write(`unexpected positional argument: ${positionals[0]}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (!values.out) {
+    process.stderr.write('--out is required\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  const outPath = resolveInputPath(values.out);
+  const flowPaths = values.flow ? resolveFlowPaths(values.flow) : null;
+
+  if (values.flow && !flowPaths) {
+    process.stderr.write(`unsupported flow: ${values.flow}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const irPath = flowPaths?.ir || resolveInputPath(values.ir);
+  const manifestPath = flowPaths?.manifest || resolveInputPath(values.manifest);
+  const statusPath = flowPaths?.status || resolveInputPath(values.status);
+  const tracePath = flowPaths?.trace || resolveInputPath(values.trace);
+
+  if (!irPath || !manifestPath || !statusPath || !tracePath) {
+    process.stderr.write('missing required inputs (ir, manifest, status, trace)\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  let catalogPath = flowPaths?.catalog || null;
+  let catalogDigest = null;
+  if (values.catalog) {
+    if (values.catalog.startsWith('sha256:')) {
+      catalogDigest = values.catalog;
+      catalogPath = null;
+    } else {
+      catalogPath = resolveInputPath(values.catalog);
+    }
+  }
+
+  const irHash = await digestFromJsonFile(irPath);
+  const manifestHash = await digestFromJsonFile(manifestPath);
+  if (catalogPath) {
+    catalogDigest = await digestFromJsonFile(catalogPath);
+  }
+
+  const statusRaw = await readFile(statusPath, 'utf8');
+  const status = parseJsonSafe(statusRaw);
+  const provenance = status && typeof status === 'object' ? status.provenance : null;
+
+  if (!catalogDigest && provenance && typeof provenance.catalog_hash === 'string') {
+    catalogDigest = provenance.catalog_hash;
+  }
+
+  if (!catalogDigest) {
+    process.stderr.write('unable to determine catalog digest\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  const traceContent = await readFile(tracePath, 'utf8');
+  const validateArgs = [
+    '--require-meta',
+    '--ir',
+    irHash,
+    '--manifest',
+    manifestHash,
+    '--catalog',
+    catalogDigest,
+  ];
+
+  const validateResult = spawnSync(process.execPath, [validateScript, ...validateArgs], {
+    input: traceContent,
+    encoding: 'utf8',
+  });
+  const validateStep = evaluateStep('validate', validateResult);
+
+  const verifyArgs = ['--ir', irPath, '--manifest', manifestPath, '--status', statusPath, '--trace', tracePath];
+  if (catalogPath) {
+    verifyArgs.push('--catalog', catalogPath);
+  }
+  if (typeof provenance?.ir_hash === 'string') {
+    verifyArgs.push('--ir-hash', provenance.ir_hash);
+  }
+  if (typeof provenance?.manifest_hash === 'string') {
+    verifyArgs.push('--manifest-hash', provenance.manifest_hash);
+  }
+  if (typeof provenance?.catalog_hash === 'string') {
+    verifyArgs.push('--catalog-hash', provenance.catalog_hash);
+  }
+
+  const verifyResult = spawnSync(process.execPath, [verifyScript, ...verifyArgs], {
+    encoding: 'utf8',
+  });
+  const verifyStep = evaluateStep('verify', verifyResult);
+
+  const steps = { validate: validateStep.ok, verify: verifyStep.ok };
+  const issues = [];
+  if (!validateStep.ok) {
+    issues.push(...validateStep.issues);
+  }
+  if (!verifyStep.ok) {
+    issues.push(...verifyStep.issues);
+  }
+
+  const report = {
+    ok: validateStep.ok && verifyStep.ok,
+    steps,
+    paths: {
+      ir: displayPath(irPath),
+      manifest: displayPath(manifestPath),
+      status: displayPath(statusPath),
+      trace: displayPath(tracePath),
+    },
+    hashes: {
+      ir: irHash,
+      manifest: manifestHash,
+      catalog: catalogDigest,
+    },
+  };
+
+  if (issues.length > 0) {
+    report.issues = issues;
+  }
+
+  await mkdir(dirname(outPath), { recursive: true });
+  const canonical = canonicalStringify(report) + '\n';
+  await writeFile(outPath, canonical);
+
+  if (!report.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv).catch((err) => {
+    process.stderr.write(`${err?.message || err}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/runtime-verify.test.mjs
+++ b/tests/runtime-verify.test.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { strict as assert } from 'node:assert';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const runtimeVerifyCli = fileURLToPath(new URL('../scripts/runtime-verify.mjs', import.meta.url));
+const pilotBuildScript = fileURLToPath(new URL('../scripts/pilot-build-run.mjs', import.meta.url));
+
+function mutateHash(hash) {
+  if (typeof hash !== 'string' || hash.length === 0) return 'sha256:deadbeef';
+  const last = hash.slice(-1);
+  const replacement = last === '0' ? '1' : last === '1' ? '2' : '0';
+  return hash.slice(0, -1) + replacement;
+}
+
+test('runtime verify pipeline is deterministic and detects provenance drift', { concurrency: false }, async () => {
+  let originalStatusRaw = null;
+  const pilotOutDir = 'out/0.4/pilot-l0/runtime-verify-test';
+  const statusPath = join(pilotOutDir, 'status.json');
+  const env = {
+    ...process.env,
+    TF_PROVENANCE: '1',
+    TF_FIXED_TS: '1750000000000',
+    PILOT_OUT_DIR: pilotOutDir,
+  };
+  const verifyDir = 'out/0.4/verify/pilot-runtime-test';
+  try {
+    const build = spawnSync(process.execPath, [pilotBuildScript], {
+      stdio: 'pipe',
+      encoding: 'utf8',
+      env,
+    });
+    assert.equal(build.status, 0, build.stderr);
+
+    const reportPath = join(verifyDir, 'report.json');
+    const runVerify = () =>
+      spawnSync(process.execPath, [runtimeVerifyCli, '--flow', 'pilot', '--out', reportPath], {
+        stdio: 'pipe',
+        encoding: 'utf8',
+        env,
+      });
+
+    const first = runVerify();
+    assert.equal(first.status, 0, first.stderr);
+    const reportRaw1 = readFileSync(reportPath, 'utf8');
+    const report1 = JSON.parse(reportRaw1);
+    assert.equal(report1.ok, true);
+    assert.deepEqual(report1.steps, { validate: true, verify: true });
+
+    const second = runVerify();
+    assert.equal(second.status, 0, second.stderr);
+    const reportRaw2 = readFileSync(reportPath, 'utf8');
+    assert.equal(reportRaw2, reportRaw1);
+
+    originalStatusRaw = readFileSync(statusPath, 'utf8');
+    const status = JSON.parse(originalStatusRaw);
+    if (status?.provenance && typeof status.provenance.manifest_hash === 'string') {
+      status.provenance.manifest_hash = mutateHash(status.provenance.manifest_hash);
+      writeFileSync(statusPath, JSON.stringify(status, null, 2) + '\n');
+    } else {
+      throw new Error('status missing provenance.manifest_hash');
+    }
+
+    const failReportPath = join(verifyDir, 'report-fail.json');
+    const failure = spawnSync(process.execPath, [runtimeVerifyCli, '--flow', 'pilot', '--out', failReportPath], {
+      stdio: 'pipe',
+      encoding: 'utf8',
+      env,
+    });
+    assert.notEqual(failure.status, 0, failure.stderr);
+    const failReportRaw = readFileSync(failReportPath, 'utf8');
+    const failReport = JSON.parse(failReportRaw);
+    assert.equal(failReport.ok, false);
+    assert.equal(failReport.steps.verify, false);
+    assert.ok(JSON.stringify(failReport.issues || []).includes('manifest_hash'));
+  } finally {
+    if (originalStatusRaw !== null) {
+      writeFileSync(statusPath, originalStatusRaw);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a "L0 Runtime Verify" workflow that builds pilot artifacts, runs the new runtime verify script, and uploads reports
- implement scripts/runtime-verify.mjs to validate trace metadata, run composition checks, and emit canonical reports with optional PILOT_OUT_DIR overrides
- cover the new CLI with runtime-verify.test.mjs and document local/CI usage in docs/pilot-l0.md

## Testing
- pnpm -w -r build
- TF_PROVENANCE=1 TF_FIXED_TS=1750000000000 node scripts/pilot-build-run.mjs
- node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d05cd8b9a88320ba95f741f8e88216