### PR TITLE
Add runtime verify workflow and CLI

### DIFF
--- a/.github/workflows/l0-runtime-verify.yml
+++ b/.github/workflows/l0-runtime-verify.yml
@@ -1,0 +1,48 @@
+name: L0 Runtime Verify
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            **/pnpm-lock.yaml
+
+      - name: Build
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Pilot build & run w/ provenance
+        env:
+          TF_PROVENANCE: '1'
+          TF_FIXED_TS: '1750000000000'
+        run: node scripts/pilot-build-run.mjs
+
+      - name: Verify (schema + meta + composition)
+        run: node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json
+
+      - name: List reports
+        run: |
+          echo "::group::verify reports"
+          find out/0.4/verify -type f -print
+          echo "::endgroup::"
+
+      - name: Upload verify artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: l0-runtime-verify
+          path: out/0.4/verify/**

--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -55,3 +55,7 @@ TF_FIXED_TS=1750000000000 pnpm run pilot:all && cat out/0.4/parity/report.json
 ```
 
 The parity harness exits non-zero if any artifact digests differ and is covered by `tests/pilot-parity.test.mjs`, which reruns the harness to ensure byte-for-byte determinism.
+
+### Runtime verify (schema + meta + composition)
+- Local: `node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json`
+- CI: workflow **"L0 Runtime Verify"** runs the same steps and uploads `l0-runtime-verify` artifacts.

--- a/scripts/runtime-verify.mjs
+++ b/scripts/runtime-verify.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import { hashJsonLike } from './hash-jsonl.mjs';
+import { sha256OfCanonicalJson } from '../packages/tf-l0-tools/lib/digest.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(here, '..');
+
+function toRelative(path) {
+  if (!path) return null;
+  const rel = relative(rootDir, path);
+  return rel && !rel.startsWith('..') ? rel : path;
+}
+
+async function loadStatus(path) {
+  const raw = await readFile(path, 'utf8');
+  return JSON.parse(raw);
+}
+
+function spawnJson(commandArgs, options = {}) {
+  const { input } = options;
+  const proc = spawnSync(process.execPath, commandArgs, {
+    encoding: 'utf8',
+    cwd: rootDir,
+    input,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const stdout = proc.stdout || '';
+  const stderr = proc.stderr || '';
+  let parsed = null;
+  const text = stdout.trim();
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      if (!commandArgs.includes('--help')) {
+        parsed = null;
+      }
+    }
+  }
+  return { status: proc.status, error: proc.error, stdout, stderr, parsed };
+}
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      flow: { type: 'string' },
+      ir: { type: 'string' },
+      manifest: { type: 'string' },
+      status: { type: 'string' },
+      trace: { type: 'string' },
+      out: { type: 'string' },
+      catalog: { type: 'string' },
+    },
+    allowPositionals: true,
+  });
+
+  if (positionals.length > 0) {
+    console.error(`unexpected positional argument: ${positionals[0]}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const outPath = values.out ? resolve(rootDir, values.out) : null;
+  if (!outPath) {
+    console.error('missing required --out path');
+    process.exitCode = 1;
+    return;
+  }
+
+  let irPath = values.ir ? resolve(rootDir, values.ir) : null;
+  let manifestPath = values.manifest ? resolve(rootDir, values.manifest) : null;
+  let statusPath = values.status ? resolve(rootDir, values.status) : null;
+  let tracePath = values.trace ? resolve(rootDir, values.trace) : null;
+  let catalogPath = values.catalog ? resolve(rootDir, values.catalog) : null;
+
+  if (values.flow) {
+    if (values.flow !== 'pilot') {
+      console.error(`unsupported flow: ${values.flow}`);
+      process.exitCode = 1;
+      return;
+    }
+    const flowDir = join(rootDir, 'out', '0.4', 'pilot-l0');
+    irPath = join(flowDir, 'pilot_min.ir.json');
+    manifestPath = join(flowDir, 'pilot_min.manifest.json');
+    statusPath = join(flowDir, 'status.json');
+    tracePath = join(flowDir, 'trace.jsonl');
+  }
+
+  if (!irPath || !manifestPath || !statusPath || !tracePath) {
+    console.error('missing required artifact paths');
+    process.exitCode = 1;
+    return;
+  }
+
+  const traceContent = await readFile(tracePath, 'utf8');
+  const status = await loadStatus(statusPath);
+  const provenance = status && typeof status.provenance === 'object' && !Array.isArray(status.provenance)
+    ? status.provenance
+    : null;
+
+  const irSource = await readFile(irPath, 'utf8');
+  const irHash = sha256OfCanonicalJson(JSON.parse(irSource));
+  const manifestHash = await hashJsonLike(manifestPath);
+
+  let catalogHash = null;
+  if (catalogPath) {
+    catalogHash = await hashJsonLike(catalogPath);
+  }
+  if (!catalogHash && provenance && typeof provenance.catalog_hash === 'string') {
+    catalogHash = provenance.catalog_hash;
+  }
+
+  const validateArgs = [
+    join('scripts', 'validate-trace.mjs'),
+    '--require-meta',
+    '--ir',
+    irHash,
+    '--manifest',
+    manifestHash,
+  ];
+  if (catalogHash) {
+    validateArgs.push('--catalog', catalogHash);
+  }
+
+  const validateResult = spawnJson(validateArgs, { input: traceContent });
+  const validateOk = validateResult.status === 0;
+  const validateIssues = validateResult.parsed?.issues;
+
+  const verifyArgs = [
+    join('packages', 'tf-compose', 'bin', 'tf-verify-trace.mjs'),
+    '--ir',
+    irPath,
+    '--manifest',
+    manifestPath,
+    '--status',
+    statusPath,
+    '--trace',
+    tracePath,
+    '--ir-hash',
+    irHash,
+    '--manifest-hash',
+    manifestHash,
+  ];
+  if (catalogPath) {
+    verifyArgs.push('--catalog', catalogPath);
+  }
+  if (catalogHash) {
+    verifyArgs.push('--catalog-hash', catalogHash);
+  }
+
+  const verifyResult = spawnJson(verifyArgs);
+  const verifyOk = verifyResult.status === 0;
+  const verifyIssues = verifyResult.parsed?.issues;
+
+  const ok = validateOk && verifyOk;
+  const report = {
+    ok,
+    steps: {
+      validate: validateOk,
+      verify: verifyOk,
+    },
+    paths: {
+      ir: toRelative(irPath),
+      manifest: toRelative(manifestPath),
+      status: toRelative(statusPath),
+      trace: toRelative(tracePath),
+    },
+    hashes: {
+      ir: irHash,
+      manifest: manifestHash,
+      catalog: catalogHash || null,
+    },
+  };
+
+  const issues = [];
+  if (!validateOk) {
+    if (Array.isArray(validateIssues) && validateIssues.length > 0) {
+      issues.push(...validateIssues);
+    } else {
+      issues.push({ step: 'validate', stderr: validateResult.stderr?.trim() || 'validate failed' });
+    }
+  }
+  if (!verifyOk) {
+    if (Array.isArray(verifyIssues) && verifyIssues.length > 0) {
+      issues.push(...verifyIssues);
+    } else {
+      issues.push({ step: 'verify', stderr: verifyResult.stderr?.trim() || 'verify failed' });
+    }
+  }
+  if (issues.length > 0) {
+    report.issues = issues;
+  }
+
+  await mkdir(dirname(outPath), { recursive: true });
+  const payload = JSON.stringify(report) + '\n';
+  await writeFile(outPath, payload);
+
+  if (!ok) {
+    process.exitCode = 1;
+  }
+}
+
+main(process.argv).catch((err) => {
+  console.error(err?.stack || err?.message || String(err));
+  process.exitCode = 1;
+});

--- a/tests/runtime-verify.test.mjs
+++ b/tests/runtime-verify.test.mjs
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile, writeFile, mkdir, open as openFile, unlink } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const rootDir = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
+const lockPath = join(rootDir, 'out', '0.4', 'pilot-l0', '.test-lock');
+const lockDelayMs = 50;
+const lockMaxAttempts = 200;
+
+function runNode(args, { env } = {}) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: rootDir,
+    env: env ? { ...process.env, ...env } : process.env,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return {
+    status: typeof result.status === 'number' ? result.status : result.error?.code ?? -1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function flipHash(value) {
+  if (typeof value !== 'string' || value.length === 0) return value;
+  const last = value[value.length - 1];
+  const replacement = last === '0' ? '1' : '0';
+  return value.slice(0, -1) + replacement;
+}
+
+async function acquirePilotLock() {
+  await mkdir(join(rootDir, 'out', '0.4', 'pilot-l0'), { recursive: true });
+  for (let attempt = 0; attempt < lockMaxAttempts; attempt += 1) {
+    try {
+      const handle = await openFile(lockPath, 'wx');
+      await handle.close();
+      return async () => {
+        try {
+          await unlink(lockPath);
+        } catch (err) {
+          if (err?.code !== 'ENOENT') throw err;
+        }
+      };
+    } catch (err) {
+      if (err?.code !== 'EEXIST') throw err;
+    }
+    await delay(lockDelayMs);
+  }
+  throw new Error('unable to acquire pilot lock');
+}
+
+test('runtime verify pilot flow', async () => {
+  const releaseLock = await acquirePilotLock();
+  const pilotOutDir = join(rootDir, 'out', '0.4', 'verify-test', 'pilot');
+  const statusPath = join(pilotOutDir, 'status.json');
+  let statusOriginal = null;
+  const pilotEnv = {
+    TF_PROVENANCE: '1',
+    TF_FIXED_TS: '1750000000000',
+    PILOT_OUT_DIR: pilotOutDir,
+  };
+  try {
+    const pilotRun = runNode(['scripts/pilot-build-run.mjs'], { env: pilotEnv });
+    assert.equal(pilotRun.status, 0, pilotRun.stderr || pilotRun.stdout);
+
+    const irPath = join(pilotOutDir, 'pilot_min.ir.json');
+    const manifestPath = join(pilotOutDir, 'pilot_min.manifest.json');
+    const tracePath = join(pilotOutDir, 'trace.jsonl');
+
+    const reportPath = join(rootDir, 'out', '0.4', 'verify', 'pilot-test', 'report.json');
+    const verifyOk = runNode([
+      'scripts/runtime-verify.mjs',
+      '--ir',
+      irPath,
+      '--manifest',
+      manifestPath,
+      '--status',
+      statusPath,
+      '--trace',
+      tracePath,
+      '--out',
+      reportPath,
+    ]);
+    const reportRaw = await readFile(reportPath, 'utf8');
+    const report = JSON.parse(reportRaw);
+    assert.equal(verifyOk.status, 0, verifyOk.stderr || verifyOk.stdout || reportRaw);
+    assert.equal(report.ok, true);
+    assert.equal(report.steps?.validate, true);
+    assert.equal(report.steps?.verify, true);
+
+    const verifyAgain = runNode([
+      'scripts/runtime-verify.mjs',
+      '--ir',
+      irPath,
+      '--manifest',
+      manifestPath,
+      '--status',
+      statusPath,
+      '--trace',
+      tracePath,
+      '--out',
+      reportPath,
+    ]);
+    const reportRawAgain = await readFile(reportPath, 'utf8');
+    assert.equal(verifyAgain.status, 0, verifyAgain.stderr || verifyAgain.stdout || reportRawAgain);
+    assert.equal(reportRawAgain, reportRaw);
+
+    statusOriginal = await readFile(statusPath, 'utf8');
+    const status = JSON.parse(statusOriginal);
+    assert.ok(status?.provenance?.manifest_hash, 'expected provenance.manifest_hash');
+    status.provenance.manifest_hash = flipHash(status.provenance.manifest_hash);
+    await writeFile(statusPath, JSON.stringify(status, null, 2) + '\n');
+
+    const tamperedPath = join(rootDir, 'out', '0.4', 'verify', 'pilot-test', 'report-tampered.json');
+    const verifyTampered = runNode([
+      'scripts/runtime-verify.mjs',
+      '--ir',
+      irPath,
+      '--manifest',
+      manifestPath,
+      '--status',
+      statusPath,
+      '--trace',
+      tracePath,
+      '--out',
+      tamperedPath,
+    ]);
+    const tamperedRaw = await readFile(tamperedPath, 'utf8');
+    const tampered = JSON.parse(tamperedRaw);
+    assert.notEqual(verifyTampered.status, 0, verifyTampered.stderr || verifyTampered.stdout || tamperedRaw);
+    assert.equal(tampered.ok, false);
+    assert.equal(tampered.steps?.validate, true);
+    assert.equal(tampered.steps?.verify, false);
+    const issues = Array.isArray(tampered.issues) ? tampered.issues : [];
+    const hit = issues.some((entry) => {
+      const text = typeof entry === 'string' ? entry : JSON.stringify(entry);
+      return text.includes('manifest_hash');
+    });
+    assert.equal(hit, true, `expected manifest_hash in issues, saw ${JSON.stringify(issues)}`);
+  } finally {
+    if (statusOriginal !== null) {
+      await writeFile(statusPath, statusOriginal);
+    }
+    await releaseLock();
+  }
+});


### PR DESCRIPTION
## Summary
- add an L0 Runtime Verify workflow that builds artifacts, runs the pilot with provenance, and uploads verification reports
- introduce scripts/runtime-verify.mjs to validate trace schema/meta, enforce composition checks, and emit canonical reports
- cover the new CLI with runtime verification tests and document local/CI usage in the pilot guide

## Testing
- pnpm -w -r build
- TF_PROVENANCE=1 TF_FIXED_TS=1750000000000 node scripts/pilot-build-run.mjs
- node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json
- pnpm -w -r test

------
https://chatgpt.com/codex/tasks/task_e_68d05cd8b9a88320ba95f741f8e88216