### PR TITLE
Add runtime verification workflow and CLI

### DIFF
--- a/.github/workflows/l0-runtime-verify.yml
+++ b/.github/workflows/l0-runtime-verify.yml
@@ -1,0 +1,48 @@
+name: L0 Runtime Verify
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            **/pnpm-lock.yaml
+
+      - name: Build
+        run: |
+          pnpm run a0
+          pnpm run a1
+          pnpm -w -r build
+
+      - name: Pilot build & run w/ provenance
+        env:
+          TF_PROVENANCE: '1'
+          TF_FIXED_TS: '1750000000000'
+        run: node scripts/pilot-build-run.mjs
+
+      - name: Verify (schema + meta + composition)
+        run: node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json
+
+      - name: List reports
+        run: |
+          echo "::group::verify reports"
+          find out/0.4/verify -type f -print
+          echo "::endgroup::"
+
+      - name: Upload verify artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: l0-runtime-verify
+          path: out/0.4/verify/**

--- a/docs/pilot-l0.md
+++ b/docs/pilot-l0.md
@@ -55,3 +55,7 @@ TF_FIXED_TS=1750000000000 pnpm run pilot:all && cat out/0.4/parity/report.json
 ```
 
 The parity harness exits non-zero if any artifact digests differ and is covered by `tests/pilot-parity.test.mjs`, which reruns the harness to ensure byte-for-byte determinism.
+
+### Runtime verify (schema + meta + composition)
+- Local: `node scripts/runtime-verify.mjs --flow pilot --out out/0.4/verify/pilot/report.json`
+- CI: workflow **“L0 Runtime Verify”** runs the same steps and uploads `l0-runtime-verify` artifacts.

--- a/scripts/runtime-verify.mjs
+++ b/scripts/runtime-verify.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join, resolve, relative, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { spawn } from 'node:child_process';
+
+import { sha256OfCanonicalJson } from '../packages/tf-l0-tools/lib/digest.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(here, '..');
+const validateTraceScript = join(rootDir, 'scripts', 'validate-trace.mjs');
+const verifyTraceScript = join(rootDir, 'packages', 'tf-compose', 'bin', 'tf-verify-trace.mjs');
+function resolvePilotOutDir() {
+  const override = process.env.PILOT_OUT_DIR;
+  if (override && override.trim()) {
+    return isAbsolute(override) ? override : join(rootDir, override);
+  }
+  return join(rootDir, 'out', '0.4', 'pilot-l0');
+}
+
+const pilotOutDir = resolvePilotOutDir();
+const pilotCatalogPath = join(rootDir, 'packages', 'tf-l0-spec', 'spec', 'catalog.json');
+
+function normalizePath(pathValue) {
+  const rel = relative(rootDir, pathValue);
+  if (!rel || rel.startsWith('..')) {
+    return pathValue;
+  }
+  return rel.split(/\\+/).join('/');
+}
+
+async function readJson(pathValue) {
+  const raw = await fs.readFile(pathValue, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function hashJson(pathValue) {
+  const raw = await fs.readFile(pathValue, 'utf8');
+  const parsed = JSON.parse(raw);
+  return sha256OfCanonicalJson(parsed);
+}
+
+function parseHashOption(value) {
+  if (!value) return { hash: null, path: null };
+  if (value.startsWith('sha256:')) {
+    return { hash: value, path: null };
+  }
+  return { hash: null, path: resolve(value) };
+}
+
+function runNode(scriptPath, args, { input } = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', (err) => {
+      rejectPromise(err);
+    });
+
+    child.on('close', (code) => {
+      resolvePromise({ code, stdout, stderr });
+    });
+
+    if (typeof input === 'string') {
+      child.stdin.write(input);
+    }
+    child.stdin.end();
+  });
+}
+
+async function main(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      flow: { type: 'string' },
+      ir: { type: 'string' },
+      manifest: { type: 'string' },
+      status: { type: 'string' },
+      trace: { type: 'string' },
+      catalog: { type: 'string' },
+      out: { type: 'string' },
+    },
+    allowPositionals: true,
+  });
+
+  if (positionals.length > 0) {
+    process.stderr.write(`unexpected positional argument: ${positionals[0]}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const outFlag = values.out;
+  if (!outFlag || typeof outFlag !== 'string') {
+    process.stderr.write('--out <file> is required\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  const flow = values.flow;
+  let resolved = null;
+  const catalogOption = parseHashOption(typeof values.catalog === 'string' ? values.catalog : '');
+
+  if (flow) {
+    if (flow !== 'pilot') {
+      process.stderr.write(`unsupported flow: ${flow}\n`);
+      process.exitCode = 2;
+      return;
+    }
+    resolved = {
+      ir: join(pilotOutDir, 'pilot_min.ir.json'),
+      manifest: join(pilotOutDir, 'pilot_min.manifest.json'),
+      status: join(pilotOutDir, 'status.json'),
+      trace: join(pilotOutDir, 'trace.jsonl'),
+      catalogPath: catalogOption.path || pilotCatalogPath,
+    };
+  } else {
+    const ir = values.ir;
+    const manifest = values.manifest;
+    const status = values.status;
+    const trace = values.trace;
+    if (!ir || !manifest || !status || !trace) {
+      process.stderr.write('--ir, --manifest, --status, and --trace are required without --flow\n');
+      process.exitCode = 2;
+      return;
+    }
+    resolved = {
+      ir: resolve(ir),
+      manifest: resolve(manifest),
+      status: resolve(status),
+      trace: resolve(trace),
+      catalogPath: catalogOption.path,
+    };
+  }
+
+  const outPath = resolve(outFlag);
+
+  const paths = {
+    ir: resolved.ir,
+    manifest: resolved.manifest,
+    status: resolved.status,
+    trace: resolved.trace,
+  };
+
+  const status = await readJson(paths.status);
+  const provenance = status && typeof status.provenance === 'object' && !Array.isArray(status.provenance)
+    ? status.provenance
+    : {};
+
+  const irHash = await hashJson(paths.ir);
+  const manifestHash = await hashJson(paths.manifest);
+
+  let catalogHash = catalogOption.hash || null;
+  let catalogSourcePath = resolved.catalogPath || null;
+
+  if (!catalogHash && catalogSourcePath) {
+    catalogHash = await hashJson(catalogSourcePath);
+  }
+
+  if (!catalogHash && typeof provenance.catalog_hash === 'string') {
+    catalogHash = provenance.catalog_hash;
+  }
+
+  if (!catalogHash) {
+    process.stderr.write('unable to determine catalog hash (provide --catalog or provenance)\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  if (typeof provenance.catalog_hash === 'string' && catalogHash !== provenance.catalog_hash) {
+    process.stderr.write('warning: catalog hash mismatch between status and provided value\n');
+  }
+
+  const traceInput = await fs.readFile(paths.trace, 'utf8');
+
+  const report = {
+    ok: false,
+    steps: { validate: false, verify: false },
+    paths: Object.fromEntries(
+      Object.entries(paths).map(([key, value]) => [key, normalizePath(value)]),
+    ),
+    hashes: {
+      ir: irHash,
+      manifest: manifestHash,
+      catalog: catalogHash,
+    },
+  };
+
+  const validateArgs = [
+    '--require-meta',
+    '--ir',
+    irHash,
+    '--manifest',
+    manifestHash,
+    '--catalog',
+    catalogHash,
+  ];
+
+  const validateResult = await runNode(validateTraceScript, validateArgs, { input: traceInput });
+
+  let validateSummary = null;
+  if (validateResult.stdout.trim()) {
+    try {
+      validateSummary = JSON.parse(validateResult.stdout.trim());
+    } catch (err) {
+      process.stderr.write(`unable to parse validate output: ${err?.message || err}\n`);
+    }
+  }
+
+  if (validateResult.code === 0 && validateSummary && validateSummary.ok) {
+    report.steps.validate = true;
+  } else {
+    report.ok = false;
+    if (validateSummary && Array.isArray(validateSummary.issues)) {
+      report.issues = validateSummary.issues;
+    } else if (validateResult.stderr) {
+      report.issues = [validateResult.stderr.trim()];
+    } else {
+      report.issues = ['validate_failed'];
+    }
+    await mkdir(dirname(outPath), { recursive: true });
+    await fs.writeFile(outPath, JSON.stringify(report) + '\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  const verifyArgs = [
+    '--ir',
+    paths.ir,
+    '--manifest',
+    paths.manifest,
+    '--status',
+    paths.status,
+    '--trace',
+    paths.trace,
+  ];
+
+  const verifyResult = await runNode(verifyTraceScript, verifyArgs);
+
+  let verifySummary = null;
+  if (verifyResult.stdout.trim()) {
+    try {
+      verifySummary = JSON.parse(verifyResult.stdout.trim());
+    } catch (err) {
+      process.stderr.write(`unable to parse verify output: ${err?.message || err}\n`);
+    }
+  }
+
+  if (verifyResult.code === 0 && verifySummary && verifySummary.ok) {
+    report.steps.verify = true;
+    report.ok = true;
+  } else {
+    report.ok = false;
+    if (verifySummary && Array.isArray(verifySummary.issues)) {
+      report.issues = verifySummary.issues;
+    } else if (verifyResult.stderr) {
+      report.issues = [verifyResult.stderr.trim()];
+    } else {
+      report.issues = ['verify_failed'];
+    }
+  }
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, JSON.stringify(report) + '\n');
+
+  if (!report.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main(process.argv).catch((err) => {
+  process.stderr.write(`${err?.stack || err?.message || err}\n`);
+  process.exitCode = 1;
+});

--- a/tests/runtime-verify.test.mjs
+++ b/tests/runtime-verify.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, mkdirSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import { promises as fsp } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const pilotOutDir = 'out/0.4/pilot-l0/runtime-verify';
+const pilotLockPath = `${pilotOutDir}/.test-lock`;
+const lockMaxAttempts = 200;
+const lockDelayMs = 50;
+
+async function acquirePilotLock() {
+  mkdirSync(pilotOutDir, { recursive: true });
+  for (let attempt = 0; attempt < lockMaxAttempts; attempt += 1) {
+    try {
+      const fd = openSync(pilotLockPath, 'wx');
+      closeSync(fd);
+      return () => {
+        try {
+          unlinkSync(pilotLockPath);
+        } catch (err) {
+          if (err?.code !== 'ENOENT') throw err;
+        }
+      };
+    } catch (err) {
+      if (err?.code !== 'EEXIST') throw err;
+    }
+    await delay(lockDelayMs);
+  }
+  throw new Error('unable to acquire pilot lock');
+}
+
+function mutateHash(hash) {
+  if (typeof hash !== 'string' || hash.length === 0) return 'sha256:deadbeef';
+  const last = hash.slice(-1);
+  const replacement = last === '0' ? '1' : last === '1' ? '2' : '0';
+  return hash.slice(0, -1) + replacement;
+}
+
+function withPilotEnv(extra = {}) {
+  return {
+    ...process.env,
+    TF_PROVENANCE: '1',
+    TF_FIXED_TS: '1750000000000',
+    PILOT_OUT_DIR: pilotOutDir,
+    ...extra,
+  };
+}
+
+function runPilotBuild() {
+  return spawnSync(process.execPath, ['scripts/pilot-build-run.mjs'], {
+    env: withPilotEnv(),
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+}
+
+function runRuntimeVerify(args = []) {
+  return spawnSync(process.execPath, ['scripts/runtime-verify.mjs', ...args], {
+    env: withPilotEnv(),
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+}
+
+const reportPath = 'out/0.4/verify/test/report.json';
+const statusPath = `${pilotOutDir}/status.json`;
+
+test('runtime verify CLI validates and verifies pilot flow', { concurrency: false }, async () => {
+  const releaseLock = await acquirePilotLock();
+  try {
+    const build = runPilotBuild();
+    assert.equal(build.status, 0, build.stderr);
+
+    const first = runRuntimeVerify(['--flow', 'pilot', '--out', reportPath]);
+    assert.equal(first.status, 0, first.stderr);
+    const reportRaw1 = readFileSync(reportPath, 'utf8');
+    const report1 = JSON.parse(reportRaw1);
+    assert.equal(report1.ok, true);
+    assert.equal(report1.steps.validate, true);
+    assert.equal(report1.steps.verify, true);
+
+    const second = runRuntimeVerify(['--flow', 'pilot', '--out', reportPath]);
+    assert.equal(second.status, 0, second.stderr);
+    const reportRaw2 = readFileSync(reportPath, 'utf8');
+    assert.equal(reportRaw2, reportRaw1);
+
+    const originalStatusRaw = await fsp.readFile(statusPath, 'utf8');
+    const status = JSON.parse(originalStatusRaw);
+    status.provenance.manifest_hash = mutateHash(status.provenance.manifest_hash);
+    await fsp.writeFile(statusPath, JSON.stringify(status, null, 2) + '\n');
+    try {
+      const failed = runRuntimeVerify(['--flow', 'pilot', '--out', reportPath]);
+      assert.notEqual(failed.status, 0);
+      const failedRaw = readFileSync(reportPath, 'utf8');
+      const failedReport = JSON.parse(failedRaw);
+      assert.equal(failedReport.ok, false);
+      assert.equal(failedReport.steps.validate, true);
+      assert.equal(failedReport.steps.verify, false);
+      assert.ok(Array.isArray(failedReport.issues));
+      assert.ok(failedReport.issues.some((issue) => typeof issue === 'string' && issue.includes('manifest_hash')));
+    } finally {
+      await fsp.writeFile(statusPath, originalStatusRaw);
+    }
+  } finally {
+    releaseLock();
+  }
+});


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

> Fill all sections. CI will fail if required headings are missing.

## Summary
- Scope: runtime verify gate
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust)
  - [ ] Idempotence oracle (TS/Rust)
  - [ ] Transport oracle (TS/Rust)
  - [ ] Parity reports (equal = true)
  - [x] CI wiring + determinism re-run

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`

## Determinism & Seeds
- Repeats: 2 (runtime-verify CLI test reruns the report generation and asserts byte-identical output)
- Seeds: TF_FIXED_TS=1750000000000, PILOT_OUT_DIR overrides for isolation
- Notes: CLI computes canonical JSON hashes and fails fast on validation/verification mismatches.

## Tests & CI
- TS tests: passed 152 / failed 0
- Rust tests: passed 0 / failed 0 (not run in this change)
- CI jobs: `pnpm -w -r build`, `TF_PROVENANCE=1 TF_FIXED_TS=1750000000000 node scripts/pilot-build-run.mjs`, `pnpm -w -r test`

## Implementation Notes
- ABI / paths unchanged? Y (added new workflow + CLI without changing existing APIs)
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`, Rust panic-free

## Hurdles / Follow-ups
- Known gaps: None
- Suggested next steps: Monitor new "L0 Runtime Verify" workflow results in CI

------
https://chatgpt.com/codex/tasks/task_e_68d05cd8b9a88320ba95f741f8e88216