### PR TITLE
feat: add rust runtime templates and parity tooling

### DIFF
--- a/docs/l0-rust.md
+++ b/docs/l0-rust.md
@@ -1,0 +1,25 @@
+# L0 Rust runtime quickstart
+
+## Generate Rust code for an IR
+
+```bash
+node scripts/generate-rs-run.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing
+```
+
+This writes a standalone crate with in-memory adapters, a baked IR snapshot, and a `run` binary.
+
+## Execute the generated runner (local Rust only)
+
+```bash
+LOCAL_RUST=1 cargo run --manifest-path out/0.4/codegen-rs/signing/Cargo.toml -- --ir out/0.4/ir/signing.ir.json
+```
+
+The runner prints JSONL trace lines to stdout and mirrors them to `out/trace.jsonl` inside the crate directory.
+
+## Cross-runtime parity
+
+```bash
+node scripts/cross-parity-ts-rs.mjs examples/flows/run_publish.tf
+```
+
+When `LOCAL_RUST=1` is set, this script runs both TS and Rust runners and records their trace comparison at `out/0.4/parity/ts-rs/report.json`.

--- a/packages/tf-l0-codegen-rs/Cargo.toml
+++ b/packages/tf-l0-codegen-rs/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/generate.rs"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/packages/tf-l0-codegen-rs/src/lib.rs
+++ b/packages/tf-l0-codegen-rs/src/lib.rs
@@ -1,219 +1,103 @@
 use anyhow::{Context, Result};
 use serde_json::Value;
-use std::{collections::BTreeSet, fs, path::Path};
+use std::{fs, path::Path};
 
-pub trait Network {
-    fn publish(&self, topic: &str, key: &str, payload: &str) -> anyhow::Result<()>;
-}
-
-pub trait Observability {
-    fn emit_metric(&self, name: &str) -> anyhow::Result<()>;
-}
-
-pub trait Storage {
-    fn write_object(&self, uri: &str, key: &str, value: &str) -> anyhow::Result<()>;
-}
-
-pub trait Crypto {
-    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;
-}
+const TEMPLATE_CARGO: &str = include_str!("../templates/Cargo.toml");
+const TEMPLATE_LIB: &str = include_str!("../templates/lib.rs");
+const TEMPLATE_ADAPTERS: &str = include_str!("../templates/adapters.rs");
+const TEMPLATE_PIPELINE: &str = include_str!("../templates/pipeline.rs");
+const TEMPLATE_RUN: &str = include_str!("../templates/run.rs");
 
 pub fn generate_workspace(ir: &Value, out_dir: &Path, package_name: &str) -> Result<()> {
-    fs::create_dir_all(out_dir.join("src")).context("creating src directory")?;
+    let crate_name = sanitize_crate_name(package_name);
+    let src_dir = out_dir.join("src");
+    fs::create_dir_all(&src_dir).context("creating src directory")?;
 
-    let cargo_toml = render_cargo_toml(package_name);
-    fs::write(out_dir.join("Cargo.toml"), cargo_toml).context("writing Cargo.toml")?;
+    let cargo_toml = TEMPLATE_CARGO.replace("{{package_name}}", &crate_name);
+    fs::write(out_dir.join("Cargo.toml"), ensure_newline(&cargo_toml)).context("writing Cargo.toml")?;
 
-    let pipeline_rs = render_pipeline(ir);
-    fs::write(out_dir.join("src/pipeline.rs"), pipeline_rs).context("writing src/pipeline.rs")?;
+    fs::write(src_dir.join("lib.rs"), ensure_newline(TEMPLATE_LIB)).context("writing src/lib.rs")?;
+    fs::write(src_dir.join("adapters.rs"), ensure_newline(TEMPLATE_ADAPTERS))
+        .context("writing src/adapters.rs")?;
+    fs::write(src_dir.join("pipeline.rs"), ensure_newline(TEMPLATE_PIPELINE))
+        .context("writing src/pipeline.rs")?;
 
-    let lib_rs = render_lib_rs();
-    fs::write(out_dir.join("src/lib.rs"), lib_rs).context("writing src/lib.rs")?;
+    let run_rs = TEMPLATE_RUN.replace("{{crate_name}}", &crate_name);
+    fs::write(src_dir.join("run.rs"), ensure_newline(&run_rs)).context("writing src/run.rs")?;
+
+    let ir_json = format!("{}\n", serde_json::to_string_pretty(ir).context("serializing IR")?);
+    fs::write(out_dir.join("ir.json"), ir_json).context("writing ir.json")?;
 
     Ok(())
 }
 
-struct TraitInfo {
-    name: &'static str,
-    definition: &'static str,
-    keywords: &'static [&'static str],
-}
-
-static TRAITS: &[TraitInfo] = &[
-    TraitInfo {
-        name: "Network",
-        definition: "pub trait Network {\n    fn publish(&self, topic: &str, key: &str, payload: &str) -> anyhow::Result<()>;\n}\n\n",
-        keywords: &["publish"],
-    },
-    TraitInfo {
-        name: "Observability",
-        definition: "pub trait Observability {\n    fn emit_metric(&self, name: &str) -> anyhow::Result<()>;\n}\n\n",
-        keywords: &["emit-metric"],
-    },
-    TraitInfo {
-        name: "Storage",
-        definition: "pub trait Storage {\n    fn write_object(&self, uri: &str, key: &str, value: &str) -> anyhow::Result<()>;\n}\n\n",
-        keywords: &["write-object", "delete-object", "compare-and-swap"],
-    },
-    TraitInfo {
-        name: "Crypto",
-        definition: "pub trait Crypto {\n    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;\n}\n\n",
-        keywords: &["sign-data", "verify-signature", "encrypt", "decrypt"],
-    },
-];
-
-fn render_cargo_toml(package_name: &str) -> String {
-    format!(
-        "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\nlicense = \"MIT OR Apache-2.0\"\ndescription = \"Generated TF pipeline\"\n\n[dependencies]\nanyhow = \"1\"\n",
-        name = package_name
-    )
-}
-
-fn render_lib_rs() -> String {
-    "pub mod pipeline;\n\npub use pipeline::run_pipeline;\n".to_string()
-}
-
-fn render_pipeline(ir: &Value) -> String {
-    let mut traits = BTreeSet::new();
-    let mut steps = Vec::new();
-    collect_primitives(ir, &mut traits, &mut steps);
-
-    let mut output = String::new();
-    output.push_str("use anyhow::Result;\n\n");
-
-    for trait_info in TRAITS {
-        output.push_str(trait_info.definition);
-    }
-
-    output.push_str("pub fn run_pipeline<A>(adapters: &A) -> Result<()>\nwhere\n    A: ?Sized");
-    for name in &traits {
-        output.push_str(" + ");
-        output.push_str(name);
-    }
-    output.push_str(",\n{\n");
-    output.push_str("    let _ = adapters;\n");
-
-    for step in steps {
-        output.push_str("    ");
-        output.push_str(&format_step_comment(&step));
-        output.push('\n');
-    }
-
-    output.push_str("    Ok(())\n}\n");
-
-    output
-}
-
-struct StepNote {
-    prim: String,
-    trait_name: Option<&'static str>,
-}
-
-fn format_step_comment(step: &StepNote) -> String {
-    match step.trait_name {
-        Some(name) => format!("// Prim: {} (requires {})", step.prim, name),
-        None => format!("// Prim: {}", step.prim),
+fn ensure_newline(content: &str) -> String {
+    if content.ends_with('\n') {
+        content.to_string()
+    } else {
+        format!("{content}\n")
     }
 }
 
-fn collect_primitives(value: &Value, traits: &mut BTreeSet<&'static str>, steps: &mut Vec<StepNote>) {
-    match value {
-        Value::Object(map) => {
-            let is_prim = matches!(map.get("node"), Some(Value::String(node)) if node == "Prim");
-            if is_prim {
-                if let Some(Value::String(prim)) = map.get("prim") {
-                    if let Some(info) = trait_for_primitive(prim) {
-                        traits.insert(info.name);
-                        steps.push(StepNote {
-                            prim: prim.clone(),
-                            trait_name: Some(info.name),
-                        });
-                    } else {
-                        steps.push(StepNote {
-                            prim: prim.clone(),
-                            trait_name: None,
-                        });
-                    }
+fn sanitize_crate_name(value: &str) -> String {
+    let lower = value.to_ascii_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut last_was_underscore = false;
+
+    for ch in lower.chars() {
+        let allowed = matches!(ch, 'a'..='z' | '0'..='9' | '_');
+        if allowed {
+            if ch == '_' {
+                if !last_was_underscore {
+                    out.push(ch);
                 }
+                last_was_underscore = true;
+            } else {
+                out.push(ch);
+                last_was_underscore = false;
             }
-
-            if let Some(Value::Array(children)) = map.get("children") {
-                for child in children {
-                    collect_primitives(child, traits, steps);
-                }
-            }
-
-            let mut keys: Vec<&str> = map
-                .keys()
-                .map(|key| key.as_str())
-                .filter(|key| *key != "children")
-                .collect();
-            keys.sort_unstable();
-
-            for key in keys {
-                if let Some(child) = map.get(key) {
-                    collect_primitives(child, traits, steps);
-                }
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                collect_primitives(item, traits, steps);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn trait_for_primitive(name: &str) -> Option<&'static TraitInfo> {
-    let base = primitive_base(name);
-    let base_lower = base.to_ascii_lowercase();
-
-    TRAITS.iter().find(|info| info.keywords.iter().any(|keyword| *keyword == base_lower))
-}
-
-fn primitive_base(name: &str) -> &str {
-    let without_suffix = name.split('@').next().unwrap_or(name);
-    let mut candidate = without_suffix;
-    for delimiter in ['/', '.', ':'] {
-        if let Some(index) = candidate.rfind(delimiter) {
-            candidate = &candidate[index + 1..];
+        } else if !last_was_underscore {
+            out.push('_');
+            last_was_underscore = true;
         }
     }
-    candidate
+
+    let trimmed = out.trim_matches('_');
+    if trimmed.is_empty() {
+        "tf_generated".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
-    fn detects_traits_from_mixed_primitives() {
-        let ir = json!({
-            "node": "Seq",
-            "children": [
-                {"node": "Prim", "prim": "tf:network/publish@1"},
-                {"node": "Prim", "prim": "storage.write-object"},
-                {"node": "Prim", "prim": "sign-data"},
-                {"node": "Prim", "prim": "emit-metric"}
-            ]
-        });
+    fn writes_expected_files() {
+        let dir = tempdir().unwrap();
+        let ir = json!({ "node": "Seq", "children": [] });
+        generate_workspace(&ir, dir.path(), "Example-Flow").unwrap();
 
-        let mut traits = BTreeSet::new();
-        let mut steps = Vec::new();
-        collect_primitives(&ir, &mut traits, &mut steps);
+        let cargo = fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("name = \"example_flow\""));
 
-        let names: Vec<&str> = traits.into_iter().collect();
-        assert_eq!(names, vec!["Crypto", "Network", "Observability", "Storage"]);
-        assert_eq!(steps.len(), 4);
-        assert!(steps.iter().any(|step| step.prim == "tf:network/publish@1"));
+        let run = fs::read_to_string(dir.path().join("src/run.rs")).unwrap();
+        assert!(run.contains("include_str!(\"../ir.json\")"));
+
+        let ir_json = fs::read_to_string(dir.path().join("ir.json")).unwrap();
+        assert!(ir_json.starts_with("{\n"));
+        assert!(ir_json.ends_with("\n"));
     }
 
     #[test]
-    fn primitive_base_handles_compound_names() {
-        assert_eq!(primitive_base("tf:network/publish@1"), "publish");
-        assert_eq!(primitive_base("storage.write-object"), "write-object");
-        assert_eq!(primitive_base("encrypt"), "encrypt");
+    fn sanitizes_crate_names() {
+        assert_eq!(sanitize_crate_name("My-Crate"), "my_crate");
+        assert_eq!(sanitize_crate_name("__"), "tf_generated");
+        assert_eq!(sanitize_crate_name("Flow 01"), "flow_01");
     }
 }

--- a/packages/tf-l0-codegen-rs/templates/Cargo.toml
+++ b/packages/tf-l0-codegen-rs/templates/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "{{package_name}}"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Generated TF pipeline"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "run"
+path = "src/run.rs"
+
+[dependencies]
+anyhow = "1"
+serde_json = "1"
+sha2 = "0.10"
+hex = "0.4"

--- a/packages/tf-l0-codegen-rs/templates/adapters.rs
+++ b/packages/tf-l0-codegen-rs/templates/adapters.rs
@@ -1,0 +1,142 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+
+pub trait Network {
+    fn publish(&mut self, topic: &str, key: &str, payload: &str) -> Result<()>;
+}
+
+pub trait Observability {
+    fn emit_metric(&mut self, name: &str, value: Option<f64>) -> Result<()>;
+}
+
+pub trait Storage {
+    fn write_object(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<()>;
+}
+
+pub trait Crypto {
+    fn sign(&mut self, key_id: &str, payload: &[u8]) -> Result<Vec<u8>>;
+    fn verify(&mut self, key_id: &str, payload: &[u8], signature: &[u8]) -> Result<bool>;
+    fn hash(&mut self, payload: &[u8]) -> Result<String>;
+}
+
+fn keyed_digest(key_id: &str, payload: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(key_id.as_bytes());
+    hasher.update(payload);
+    hasher.finalize().to_vec()
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PublishedMessage {
+    pub topic: String,
+    pub key: String,
+    pub payload: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryAdapters {
+    published: Vec<PublishedMessage>,
+    storage: HashMap<String, HashMap<String, String>>,
+    idempotency_tokens: HashSet<String>,
+    metrics: HashMap<String, f64>,
+}
+
+impl InMemoryAdapters {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn published(&self) -> &[PublishedMessage] {
+        &self.published
+    }
+
+    pub fn storage_snapshot(&self) -> HashMap<String, HashMap<String, String>> {
+        self.storage.clone()
+    }
+
+    pub fn metric_totals(&self) -> HashMap<String, f64> {
+        self.metrics.clone()
+    }
+
+    pub fn reset(&mut self) {
+        self.published.clear();
+        self.storage.clear();
+        self.idempotency_tokens.clear();
+        self.metrics.clear();
+    }
+
+    fn idempotency_token(uri: &str, key: &str, idempotency: Option<&str>) -> Option<String> {
+        idempotency
+            .filter(|value| !value.is_empty())
+            .map(|value| format!("{uri}#{key}#{value}"))
+    }
+}
+
+impl Network for InMemoryAdapters {
+    fn publish(&mut self, topic: &str, key: &str, payload: &str) -> Result<()> {
+        self.published.push(PublishedMessage {
+            topic: topic.to_string(),
+            key: key.to_string(),
+            payload: payload.to_string(),
+        });
+        Ok(())
+    }
+}
+
+impl Observability for InMemoryAdapters {
+    fn emit_metric(&mut self, name: &str, value: Option<f64>) -> Result<()> {
+        let increment = value.unwrap_or(1.0);
+        let entry = self.metrics.entry(name.to_string()).or_insert(0.0);
+        *entry += increment;
+        Ok(())
+    }
+}
+
+impl Storage for InMemoryAdapters {
+    fn write_object(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<()> {
+        let bucket = self
+            .storage
+            .entry(uri.to_string())
+            .or_insert_with(HashMap::new);
+
+        if let Some(token) = Self::idempotency_token(uri, key, idempotency_key) {
+            if self.idempotency_tokens.contains(&token) {
+                return Ok(());
+            }
+            self.idempotency_tokens.insert(token);
+        }
+
+        bucket.insert(key.to_string(), value.to_string());
+        Ok(())
+    }
+}
+
+impl Crypto for InMemoryAdapters {
+    fn sign(&mut self, key_id: &str, payload: &[u8]) -> Result<Vec<u8>> {
+        Ok(keyed_digest(key_id, payload))
+    }
+
+    fn verify(&mut self, key_id: &str, payload: &[u8], signature: &[u8]) -> Result<bool> {
+        Ok(keyed_digest(key_id, payload) == signature)
+    }
+
+    fn hash(&mut self, payload: &[u8]) -> Result<String> {
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        Ok(format!("sha256:{:x}", hasher.finalize()))
+    }
+}

--- a/packages/tf-l0-codegen-rs/templates/lib.rs
+++ b/packages/tf-l0-codegen-rs/templates/lib.rs
@@ -1,0 +1,5 @@
+pub mod adapters;
+pub mod pipeline;
+
+pub use adapters::InMemoryAdapters;
+pub use pipeline::{run_pipeline, TraceEntry};

--- a/packages/tf-l0-codegen-rs/templates/pipeline.rs
+++ b/packages/tf-l0-codegen-rs/templates/pipeline.rs
@@ -1,0 +1,450 @@
+use anyhow::{anyhow, Context, Result};
+use serde_json::{Map, Number, Value};
+
+use crate::adapters::{Crypto, Network, Observability, Storage};
+
+#[derive(Clone, Debug)]
+pub struct TraceEntry {
+    pub ts: i64,
+    pub prim_id: String,
+    pub args: Value,
+    pub region: String,
+    pub effect: String,
+}
+
+impl TraceEntry {
+    pub fn to_json_value(&self) -> Value {
+        let mut map = Map::new();
+        map.insert("ts".to_string(), Value::Number(Number::from(self.ts)));
+        map.insert("prim_id".to_string(), Value::String(self.prim_id.clone()));
+        map.insert("args".to_string(), self.args.clone());
+        map.insert("region".to_string(), Value::String(self.region.clone()));
+        map.insert("effect".to_string(), Value::String(self.effect.clone()));
+        Value::Object(map)
+    }
+}
+
+struct Clock {
+    next: i64,
+}
+
+impl Clock {
+    fn new() -> Self {
+        Self { next: 1_690_000_000_000 }
+    }
+
+    fn tick(&mut self) -> i64 {
+        let current = self.next;
+        self.next += 1;
+        current
+    }
+}
+
+enum PrimitiveKind {
+    Publish,
+    EmitMetric,
+    WriteObject,
+    SignData,
+    Hash,
+    VerifySignature,
+}
+
+struct PrimitiveSpec {
+    base: &'static str,
+    canonical: &'static str,
+    effect: &'static str,
+    kind: PrimitiveKind,
+}
+
+const PRIMITIVES: &[PrimitiveSpec] = &[
+    PrimitiveSpec {
+        base: "publish",
+        canonical: "tf:network/publish@1",
+        effect: "Network.Out",
+        kind: PrimitiveKind::Publish,
+    },
+    PrimitiveSpec {
+        base: "emit-metric",
+        canonical: "tf:observability/emit-metric@1",
+        effect: "Observability",
+        kind: PrimitiveKind::EmitMetric,
+    },
+    PrimitiveSpec {
+        base: "write-object",
+        canonical: "tf:resource/write-object@1",
+        effect: "Storage.Write",
+        kind: PrimitiveKind::WriteObject,
+    },
+    PrimitiveSpec {
+        base: "sign-data",
+        canonical: "tf:security/sign-data@1",
+        effect: "Crypto",
+        kind: PrimitiveKind::SignData,
+    },
+    PrimitiveSpec {
+        base: "hash",
+        canonical: "tf:information/hash@1",
+        effect: "Crypto",
+        kind: PrimitiveKind::Hash,
+    },
+    PrimitiveSpec {
+        base: "verify-signature",
+        canonical: "tf:security/verify-signature@1",
+        effect: "Crypto",
+        kind: PrimitiveKind::VerifySignature,
+    },
+];
+
+pub fn run_pipeline<A>(ir: &Value, adapters: &mut A) -> Result<Vec<TraceEntry>>
+where
+    A: ?Sized + Network + Observability + Storage + Crypto,
+{
+    let mut runner = Runner::new(adapters);
+    runner.exec(ir)?;
+    Ok(runner.finish())
+}
+
+struct Runner<'a, A> {
+    adapters: &'a mut A,
+    clock: Clock,
+    trace: Vec<TraceEntry>,
+}
+
+impl<'a, A> Runner<'a, A>
+where
+    A: Network + Observability + Storage + Crypto,
+{
+    fn new(adapters: &'a mut A) -> Self {
+        Self {
+            adapters,
+            clock: Clock::new(),
+            trace: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> Vec<TraceEntry> {
+        self.trace
+    }
+
+    fn exec(&mut self, node: &Value) -> Result<()> {
+        match node {
+            Value::Null => Ok(()),
+            Value::Array(items) => {
+                for item in items {
+                    self.exec(item)?;
+                }
+                Ok(())
+            }
+            Value::Object(map) => {
+                match map.get("node").and_then(Value::as_str) {
+                    Some("Prim") => self.exec_prim(map),
+                    Some("Seq") | Some("Region") | Some("Authorize") => {
+                        if let Some(children) = map.get("children").and_then(Value::as_array) {
+                            for child in children {
+                                self.exec(child)?;
+                            }
+                        }
+                        Ok(())
+                    }
+                    Some("Par") => {
+                        if let Some(children) = map.get("children").and_then(Value::as_array) {
+                            for child in children {
+                                self.exec(child)?;
+                            }
+                        }
+                        Ok(())
+                    }
+                    _ => {
+                        if let Some(children) = map.get("children").and_then(Value::as_array) {
+                            for child in children {
+                                self.exec(child)?;
+                            }
+                        }
+                        Ok(())
+                    }
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn exec_prim(&mut self, map: &Map<String, Value>) -> Result<()> {
+        let prim = map
+            .get("prim")
+            .and_then(Value::as_str)
+            .context("primitive missing prim identifier")?;
+        let spec = resolve_primitive(prim)?;
+        let args = map.get("args").cloned().unwrap_or_else(|| Value::Object(Map::new()));
+        self.invoke(spec, &args)?;
+        let region = extract_region(map);
+        let effect = extract_effect(map).unwrap_or_else(|| spec.effect.to_string());
+        let entry = TraceEntry {
+            ts: self.clock.tick(),
+            prim_id: spec.canonical.to_string(),
+            args,
+            region,
+            effect,
+        };
+        self.trace.push(entry);
+        Ok(())
+    }
+
+    fn invoke(&mut self, spec: &PrimitiveSpec, args: &Value) -> Result<()> {
+        match spec.kind {
+            PrimitiveKind::Publish => self.invoke_publish(args),
+            PrimitiveKind::EmitMetric => self.invoke_emit_metric(args),
+            PrimitiveKind::WriteObject => self.invoke_write_object(args),
+            PrimitiveKind::SignData => self.invoke_sign_data(args),
+            PrimitiveKind::Hash => self.invoke_hash(args),
+            PrimitiveKind::VerifySignature => self.invoke_verify_signature(args),
+        }
+    }
+
+    fn invoke_publish(&mut self, args: &Value) -> Result<()> {
+        let topic = arg_string(args, "topic");
+        let key = arg_string(args, "key");
+        let payload = arg_payload(args)?;
+        self.adapters.publish(&topic, &key, &payload)
+    }
+
+    fn invoke_emit_metric(&mut self, args: &Value) -> Result<()> {
+        let name = arg_string(args, "name");
+        let value = arg_number(args, "value");
+        self.adapters.emit_metric(&name, value)
+    }
+
+    fn invoke_write_object(&mut self, args: &Value) -> Result<()> {
+        let uri = arg_string(args, "uri");
+        let key = arg_string(args, "key");
+        let value = arg_value_string(args)?;
+        let idempotency = arg_optional_string(args, "idempotency_key")
+            .or_else(|| arg_optional_string(args, "idempotencyKey"));
+        self.adapters
+            .write_object(&uri, &key, &value, idempotency.as_deref())
+    }
+
+    fn invoke_sign_data(&mut self, args: &Value) -> Result<()> {
+        let key_id = arg_string_any(&["key", "key_ref", "keyId"], args);
+        let payload = arg_bytes(args, &["payload", "value"])?;
+        let _ = self.adapters.sign(&key_id, &payload)?;
+        Ok(())
+    }
+
+    fn invoke_hash(&mut self, args: &Value) -> Result<()> {
+        let target = hash_target(args);
+        let canonical = canonicalize_value(&target);
+        let serialized = serde_json::to_string(&canonical).context("serializing hash target")?;
+        let _ = self.adapters.hash(serialized.as_bytes())?;
+        Ok(())
+    }
+
+    fn invoke_verify_signature(&mut self, args: &Value) -> Result<()> {
+        let key_id = arg_string_any(&["key", "key_ref", "keyId"], args);
+        let payload = arg_bytes(args, &["payload", "value"])?;
+        let signature = arg_signature(args)?;
+        let ok = self
+            .adapters
+            .verify(&key_id, &payload, &signature)?;
+        if !ok {
+            return Err(anyhow!("signature verification failed"));
+        }
+        Ok(())
+    }
+}
+
+fn resolve_primitive(name: &str) -> Result<&'static PrimitiveSpec> {
+    if let Some(spec) = PRIMITIVES.iter().find(|spec| spec.canonical == name) {
+        return Ok(spec);
+    }
+    let base = primitive_base(name);
+    PRIMITIVES
+        .iter()
+        .find(|spec| spec.base == base)
+        .ok_or_else(|| anyhow!("unsupported primitive: {name}"))
+}
+
+fn primitive_base(name: &str) -> &str {
+    let without_version = name.split('@').next().unwrap_or(name);
+    let mut candidate = without_version;
+    for delimiter in ['/', '.', ':'] {
+        if let Some(index) = candidate.rfind(delimiter) {
+            candidate = &candidate[index + 1..];
+        }
+    }
+    candidate
+}
+
+fn extract_region(map: &Map<String, Value>) -> String {
+    map.get("meta")
+        .and_then(Value::as_object)
+        .and_then(|meta| meta.get("region"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn extract_effect(map: &Map<String, Value>) -> Option<String> {
+    let meta = map.get("meta").and_then(Value::as_object)?;
+    if let Some(effect) = meta.get("effect").and_then(Value::as_str) {
+        return Some(effect.to_string());
+    }
+    if let Some(effects) = meta.get("effects").and_then(Value::as_array) {
+        for entry in effects {
+            if let Some(effect) = entry.as_str() {
+                if !effect.is_empty() {
+                    return Some(effect.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn args_object(args: &Value) -> Option<&Map<String, Value>> {
+    args.as_object()
+}
+
+fn arg_value<'a>(args: &'a Value, key: &str) -> Option<&'a Value> {
+    args_object(args).and_then(|map| map.get(key))
+}
+
+fn arg_string(args: &Value, key: &str) -> String {
+    arg_optional_string(args, key).unwrap_or_default()
+}
+
+fn arg_optional_string(args: &Value, key: &str) -> Option<String> {
+    arg_value(args, key).map(value_to_string)
+}
+
+fn arg_string_any(keys: &[&str], args: &Value) -> String {
+    for key in keys {
+        if let Some(value) = arg_optional_string(args, key) {
+            if !value.is_empty() {
+                return value;
+            }
+        }
+    }
+    String::new()
+}
+
+fn arg_payload(args: &Value) -> Result<String> {
+    if let Some(value) = arg_value(args, "payload") {
+        return value_to_payload(value);
+    }
+    Ok(String::new())
+}
+
+fn arg_value_string(args: &Value) -> Result<String> {
+    if let Some(value) = arg_value(args, "value") {
+        return value_to_payload(value);
+    }
+    Ok(String::new())
+}
+
+fn value_to_payload(value: &Value) -> Result<String> {
+    if let Some(text) = value.as_str() {
+        Ok(text.to_string())
+    } else {
+        Ok(serde_json::to_string(value).context("stringifying payload")?)
+    }
+}
+
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Number(num) => num.to_string(),
+        Value::Bool(flag) => flag.to_string(),
+        Value::Null => String::new(),
+        _ => serde_json::to_string(value).unwrap_or_default(),
+    }
+}
+
+fn arg_number(args: &Value, key: &str) -> Option<f64> {
+    let value = arg_value(args, key)?;
+    if let Some(number) = value.as_f64() {
+        return Some(number);
+    }
+    if let Some(int) = value.as_i64() {
+        return Some(int as f64);
+    }
+    if let Some(uint) = value.as_u64() {
+        return Some(uint as f64);
+    }
+    None
+}
+
+fn arg_bytes(args: &Value, keys: &[&str]) -> Result<Vec<u8>> {
+    for key in keys {
+        if let Some(value) = arg_value(args, key) {
+            return value_to_bytes(value);
+        }
+    }
+    Ok(Vec::new())
+}
+
+fn value_to_bytes(value: &Value) -> Result<Vec<u8>> {
+    if let Some(text) = value.as_str() {
+        return Ok(text.as_bytes().to_vec());
+    }
+    if let Some(array) = value.as_array() {
+        let mut bytes = Vec::with_capacity(array.len());
+        for entry in array {
+            let number = entry
+                .as_u64()
+                .ok_or_else(|| anyhow!("array payload must be numeric"))?;
+            if number > 255 {
+                return Err(anyhow!("array payload out of range"));
+            }
+            bytes.push(number as u8);
+        }
+        return Ok(bytes);
+    }
+    serde_json::to_vec(value).context("serializing payload bytes")
+}
+
+fn arg_signature(args: &Value) -> Result<Vec<u8>> {
+    if let Some(value) = arg_value(args, "signature") {
+        return signature_to_bytes(value);
+    }
+    if let Some(value) = arg_value(args, "sig") {
+        return signature_to_bytes(value);
+    }
+    Ok(Vec::new())
+}
+
+fn signature_to_bytes(value: &Value) -> Result<Vec<u8>> {
+    if let Some(text) = value.as_str() {
+        if text.len() % 2 == 0 && text.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            let decoded = hex::decode(text).context("decoding hex signature")?;
+            return Ok(decoded);
+        }
+        return Ok(text.as_bytes().to_vec());
+    }
+    value_to_bytes(value)
+}
+
+fn hash_target(args: &Value) -> Value {
+    if let Some(value) = arg_value(args, "value") {
+        value.clone()
+    } else {
+        args.clone()
+    }
+}
+
+fn canonicalize_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => {
+            Value::Array(items.iter().map(canonicalize_value).collect())
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<_> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let mut canonical = Map::new();
+            for (key, val) in entries {
+                canonical.insert(key.clone(), canonicalize_value(val));
+            }
+            Value::Object(canonical)
+        }
+        _ => value.clone(),
+    }
+}

--- a/packages/tf-l0-codegen-rs/templates/run.rs
+++ b/packages/tf-l0-codegen-rs/templates/run.rs
@@ -1,0 +1,69 @@
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+
+use {{crate_name}}::{run_pipeline, InMemoryAdapters};
+
+const BAKED_IR: &str = include_str!("../ir.json");
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("error: {err:?}");
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let mut ir_path: Option<PathBuf> = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--ir" => {
+                let value = args.next().context("--ir requires a value")?;
+                ir_path = Some(PathBuf::from(value));
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            other => return Err(anyhow!("unexpected argument: {other}")),
+        }
+    }
+
+    let ir_source = if let Some(path) = ir_path {
+        fs::read_to_string(&path).with_context(|| format!("reading IR from {path:?}"))?
+    } else {
+        BAKED_IR.to_string()
+    };
+
+    let ir: Value = serde_json::from_str(&ir_source).context("parsing IR JSON")?;
+    let mut adapters = InMemoryAdapters::default();
+    let trace = run_pipeline(&ir, &mut adapters)?;
+
+    let out_dir = PathBuf::from("out");
+    fs::create_dir_all(&out_dir).context("creating out directory")?;
+    let trace_path = out_dir.join("trace.jsonl");
+    let file = File::create(&trace_path).context("creating trace.jsonl")?;
+    let mut file_writer = BufWriter::new(file);
+    let stdout = io::stdout();
+    let mut stdout_writer = BufWriter::new(stdout);
+
+    for entry in trace {
+        let line = serde_json::to_string(&entry.to_json_value()).context("serializing trace entry")?;
+        writeln!(file_writer, "{line}").context("writing trace file")?;
+        writeln!(stdout_writer, "{line}").context("writing trace stdout")?;
+    }
+
+    file_writer.flush().context("flushing trace file")?;
+    stdout_writer.flush().context("flushing stdout")?;
+    Ok(())
+}
+
+fn print_usage() {
+    eprintln!("Usage: run [--ir <path>]");
+}

--- a/scripts/cross-parity-ts-rs.mjs
+++ b/scripts/cross-parity-ts-rs.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { generateRustCrate } from './generate-rs.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const OUT_ROOT = join(ROOT, 'out', '0.4');
+const CAP_DEFAULT = {
+  effects: ['Network.Out', 'Storage.Write', 'Storage.Read', 'Crypto', 'Observability', 'Pure'],
+  allow_writes_prefixes: [''],
+};
+
+function printUsage() {
+  console.log('Usage: node scripts/cross-parity-ts-rs.mjs <flow.tf>');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const flowPath = resolve(args[0]);
+  const flowName = basename(flowPath).replace(/\.tf$/i, '');
+  if (!flowName) {
+    throw new Error('Unable to derive flow name');
+  }
+
+  const irPath = join(OUT_ROOT, 'ir', `${flowName}.ir.json`);
+  const tsOutDir = join(OUT_ROOT, 'codegen-ts', flowName);
+  const rsOutDir = join(OUT_ROOT, 'codegen-rs', flowName);
+  const parityDir = join(OUT_ROOT, 'parity', 'ts-rs');
+  const traceTsPath = join(parityDir, 'trace.ts.jsonl');
+  const traceRsPath = join(parityDir, 'trace.rs.jsonl');
+  const reportPath = join(parityDir, 'report.json');
+
+  await mkdir(parityDir, { recursive: true });
+
+  await emitIr(flowPath, irPath);
+  await emitTs(flowPath, tsOutDir);
+  await runTsTrace(tsOutDir, traceTsPath);
+
+  await mkdir(rsOutDir, { recursive: true });
+  await generateRustCrate(irPath, rsOutDir);
+
+  let rustTrace = [];
+  if (process.env.LOCAL_RUST) {
+    await runRustTrace(rsOutDir, irPath);
+    const produced = join(rsOutDir, 'out', 'trace.jsonl');
+    if (existsSync(produced)) {
+      const data = await readFile(produced, 'utf8');
+      await writeFile(traceRsPath, data, 'utf8');
+      rustTrace = parseTracePairs(data);
+    }
+  } else {
+    await rm(traceRsPath, { force: true });
+  }
+
+  const tsTraceRaw = existsSync(traceTsPath) ? await readFile(traceTsPath, 'utf8') : '';
+  const tsTrace = parseTracePairs(tsTraceRaw);
+  if (!rustTrace.length && existsSync(traceRsPath)) {
+    const data = await readFile(traceRsPath, 'utf8');
+    rustTrace = parseTracePairs(data);
+  }
+
+  const comparison = comparePairs(tsTrace, rustTrace);
+  const report = {
+    equal: comparison.equal,
+    diff: comparison.diff,
+    counts: { ts: tsTrace.length, rust: rustTrace.length },
+    traces: { ts: traceTsPath, rust: traceRsPath },
+    flow: flowName,
+  };
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  console.log(`wrote parity report ${reportPath}`);
+}
+
+async function emitIr(flowPath, irPath) {
+  const result = spawnSync(process.execPath, [
+    'packages/tf-compose/bin/tf.mjs',
+    'parse',
+    flowPath,
+    '-o',
+    irPath,
+  ], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    throw new Error('tf parse failed');
+  }
+}
+
+async function emitTs(flowPath, tsOutDir) {
+  const result = spawnSync(process.execPath, [
+    'packages/tf-compose/bin/tf.mjs',
+    'emit',
+    '--lang',
+    'ts',
+    flowPath,
+    '--out',
+    tsOutDir,
+  ], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    throw new Error('tf emit failed');
+  }
+}
+
+async function runTsTrace(tsOutDir, tracePath) {
+  await rm(tracePath, { force: true });
+  const runScript = join(tsOutDir, 'run.mjs');
+  const env = {
+    ...process.env,
+    TF_CAPS: JSON.stringify(CAP_DEFAULT),
+    TF_TRACE_PATH: tracePath,
+  };
+  const result = spawnSync(process.execPath, [runScript], {
+    cwd: tsOutDir,
+    stdio: 'inherit',
+    env,
+  });
+  if (result.status !== 0) {
+    throw new Error('ts run failed');
+  }
+}
+
+async function runRustTrace(rsOutDir, irPath) {
+  const result = spawnSync('cargo', ['run', '--', '--ir', irPath], {
+    cwd: rsOutDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error('rust run failed');
+  }
+}
+
+function parseTracePairs(raw) {
+  if (!raw) return [];
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const entries = [];
+  for (const line of lines) {
+    try {
+      const record = JSON.parse(line);
+      if (record && typeof record.prim_id === 'string') {
+        entries.push({
+          prim_id: record.prim_id,
+          effect: typeof record.effect === 'string' ? record.effect : '',
+        });
+      }
+    } catch {}
+  }
+  return entries;
+}
+
+function comparePairs(tsPairs, rustPairs) {
+  const max = Math.max(tsPairs.length, rustPairs.length);
+  for (let i = 0; i < max; i += 1) {
+    const tsEntry = tsPairs[i] ?? null;
+    const rustEntry = rustPairs[i] ?? null;
+    if (!entriesEqual(tsEntry, rustEntry)) {
+      return {
+        equal: false,
+        diff: { index: i, ts: tsEntry, rust: rustEntry },
+      };
+    }
+  }
+  return { equal: true, diff: null };
+}
+
+function entriesEqual(a, b) {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return a.prim_id === b.prim_id && a.effect === b.effect;
+}
+
+main().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/scripts/generate-rs-run.mjs
+++ b/scripts/generate-rs-run.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { generateRustCrate } from './generate-rs.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function printUsage() {
+  console.log('Usage: node scripts/generate-rs-run.mjs <ir.json> -o <output dir>');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const irPath = resolve(args[0]);
+  let outDir = null;
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
+      i += 1;
+      outDir = args[i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!outDir) {
+    throw new Error('Output directory required via -o or --out');
+  }
+
+  const resolvedOutDir = resolve(outDir);
+  await mkdir(resolvedOutDir, { recursive: true });
+
+  const { crateName } = await generateRustCrate(irPath, resolvedOutDir);
+  console.log(`generated crate ${crateName} at ${resolvedOutDir}`);
+
+  if (process.env.LOCAL_RUST) {
+    const cargoResult = spawnSync('cargo', ['run', '--', '--ir', irPath], {
+      cwd: resolvedOutDir,
+      stdio: 'inherit',
+      env: process.env,
+    });
+    if (cargoResult.status !== 0) {
+      throw new Error('cargo run failed');
+    }
+    const traceSrc = join(resolvedOutDir, 'out', 'trace.jsonl');
+    if (existsSync(traceSrc)) {
+      const outTrace = join(resolvedOutDir, 'out', 'trace.jsonl');
+      const data = await readFile(traceSrc, 'utf8');
+      await writeFile(outTrace, data, 'utf8');
+      console.log(`wrote trace ${outTrace}`);
+    }
+  } else {
+    const tracePath = join(resolvedOutDir, 'out', 'trace.jsonl');
+    await rm(tracePath, { force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/scripts/generate-rs.mjs
+++ b/scripts/generate-rs.mjs
@@ -1,43 +1,47 @@
 #!/usr/bin/env node
 import { readFile, mkdir, writeFile } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-async function main() {
-  const args = process.argv.slice(2);
-  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
-    printUsage();
-    return;
-  }
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const TEMPLATE_DIR = join(ROOT, 'packages', 'tf-l0-codegen-rs', 'templates');
 
-  const irPath = args[0];
+export async function generateRustCrate(irPath, outDir) {
   if (!irPath) {
     throw new Error('IR path is required');
   }
-
-  let outDir = null;
-  for (let i = 1; i < args.length; i += 1) {
-    const arg = args[i];
-    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
-      i += 1;
-      outDir = args[i];
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
   if (!outDir) {
-    throw new Error('Output directory required via -o or --out');
+    throw new Error('Output directory is required');
   }
 
   const raw = await readFile(irPath, 'utf8');
   const ir = JSON.parse(raw);
-
   const resolvedOutDir = resolve(outDir);
-  await mkdir(resolvedOutDir, { recursive: true });
+  const srcDir = join(resolvedOutDir, 'src');
+  await mkdir(srcDir, { recursive: true });
 
   const crateName = deriveCrateName(ir, resolvedOutDir, irPath);
-  await runGenerator(ir, resolvedOutDir, crateName);
-  console.log(`wrote ${resolvedOutDir} (crate ${crateName})`);
+  const cargoTemplate = await loadTemplate('Cargo.toml');
+  const libTemplate = await loadTemplate('lib.rs');
+  const adaptersTemplate = await loadTemplate('adapters.rs');
+  const pipelineTemplate = await loadTemplate('pipeline.rs');
+  const runTemplate = await loadTemplate('run.rs');
+
+  await writeFile(join(resolvedOutDir, 'Cargo.toml'), ensureNewline(cargoTemplate.replace(/\{\{package_name\}\}/g, crateName)), 'utf8');
+  await writeFile(join(srcDir, 'lib.rs'), ensureNewline(libTemplate), 'utf8');
+  await writeFile(join(srcDir, 'adapters.rs'), ensureNewline(adaptersTemplate), 'utf8');
+  await writeFile(join(srcDir, 'pipeline.rs'), ensureNewline(pipelineTemplate), 'utf8');
+  await writeFile(join(srcDir, 'run.rs'), ensureNewline(runTemplate.replace(/\{\{crate_name\}\}/g, crateName)), 'utf8');
+
+  const irJson = `${JSON.stringify(ir, null, 2)}\n`;
+  await writeFile(join(resolvedOutDir, 'ir.json'), irJson, 'utf8');
+
+  return { crateName, outDir: resolvedOutDir };
+}
+
+async function loadTemplate(name) {
+  return readFile(join(TEMPLATE_DIR, name), 'utf8');
 }
 
 function deriveCrateName(ir, outDir, irPath) {
@@ -58,145 +62,47 @@ function sanitizeCrateName(value) {
   return safe || 'tf_generated';
 }
 
-async function runGenerator(ir, outDir, packageName) {
-  const srcDir = join(outDir, 'src');
-  await mkdir(srcDir, { recursive: true });
-
-  await writeFile(join(outDir, 'Cargo.toml'), renderCargoToml(packageName), 'utf8');
-  await writeFile(join(srcDir, 'pipeline.rs'), renderPipeline(ir), 'utf8');
-  await writeFile(join(srcDir, 'lib.rs'), renderLibRs(), 'utf8');
-}
-
-function renderCargoToml(packageName) {
-  return `[package]\nname = "${packageName}"\nversion = "0.1.0"\nedition = "2021"\nlicense = "MIT OR Apache-2.0"\ndescription = "Generated TF pipeline"\n\n[dependencies]\nanyhow = "1"\n`;
-}
-
-function renderLibRs() {
-  return 'pub mod pipeline;\n\npub use pipeline::run_pipeline;\n';
-}
-
-function renderPipeline(ir) {
-  const traits = new Set();
-  const steps = [];
-  collectPrimitives(ir, traits, steps);
-  const orderedTraits = Array.from(traits).sort();
-
-  let output = 'use anyhow::Result;\n\n';
-  for (const trait of TRAITS) {
-    output += trait.definition;
-  }
-
-  output += 'pub fn run_pipeline<A>(adapters: &A) -> Result<()>\n';
-  output += 'where\n';
-  output += '    A: ?Sized';
-  for (const name of orderedTraits) {
-    output += ` + ${name}`;
-  }
-  output += ',\n{\n';
-  output += '    let _ = adapters;\n';
-
-  for (const step of steps) {
-    output += `    ${formatStepComment(step)}\n`;
-  }
-
-  output += '    Ok(())\n';
-  output += '}\n';
-  return output;
-}
-
-const TRAITS = [
-  {
-    name: 'Network',
-    definition:
-      'pub trait Network {\n    fn publish(&self, topic: &str, key: &str, payload: &str) -> anyhow::Result<()>;\n}\n\n',
-    keywords: ['publish'],
-  },
-  {
-    name: 'Observability',
-    definition:
-      'pub trait Observability {\n    fn emit_metric(&self, name: &str) -> anyhow::Result<()>;\n}\n\n',
-    keywords: ['emit-metric'],
-  },
-  {
-    name: 'Storage',
-    definition:
-      'pub trait Storage {\n    fn write_object(&self, uri: &str, key: &str, value: &str) -> anyhow::Result<()>;\n}\n\n',
-    keywords: ['write-object', 'delete-object', 'compare-and-swap'],
-  },
-  {
-    name: 'Crypto',
-    definition:
-      'pub trait Crypto {\n    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;\n}\n\n',
-    keywords: ['sign-data', 'verify-signature', 'encrypt', 'decrypt'],
-  },
-];
-
-function collectPrimitives(value, traits, steps) {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectPrimitives(item, traits, steps);
-    }
-    return;
-  }
-
-  if (!value || typeof value !== 'object') {
-    return;
-  }
-
-  if (value.node === 'Prim' && typeof value.prim === 'string') {
-    const traitInfo = traitForPrimitive(value.prim);
-    if (traitInfo) {
-      traits.add(traitInfo.name);
-      steps.push({ prim: value.prim, traitName: traitInfo.name });
-    } else {
-      steps.push({ prim: value.prim, traitName: null });
-    }
-  }
-
-  if (Array.isArray(value.children)) {
-    for (const child of value.children) {
-      collectPrimitives(child, traits, steps);
-    }
-  }
-
-  const keys = Object.keys(value)
-    .filter((key) => key !== 'children')
-    .sort();
-
-  for (const key of keys) {
-    collectPrimitives(value[key], traits, steps);
-  }
-}
-
-function traitForPrimitive(name) {
-  const base = primitiveBase(name).toLowerCase();
-  return TRAITS.find((trait) => trait.keywords.includes(base)) ?? null;
-}
-
-function primitiveBase(name) {
-  const withoutVersion = String(name).split('@')[0] ?? String(name);
-  let candidate = withoutVersion;
-  for (const delimiter of ['/', '.', ':']) {
-    const index = candidate.lastIndexOf(delimiter);
-    if (index !== -1) {
-      candidate = candidate.slice(index + 1);
-    }
-  }
-  return candidate;
-}
-
-function formatStepComment(step) {
-  if (step.traitName) {
-    return `// Prim: ${step.prim} (requires ${step.traitName})`;
-  }
-  return `// Prim: ${step.prim}`;
+function ensureNewline(content) {
+  return content.endsWith('\n') ? content : `${content}\n`;
 }
 
 function printUsage() {
   console.log('Usage: node scripts/generate-rs.mjs <ir.json> -o <output dir>');
 }
 
-main().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  process.exit(1);
-});
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const irPath = args[0];
+  let outDir = null;
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
+      i += 1;
+      outDir = args[i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!outDir) {
+    throw new Error('Output directory required via -o or --out');
+  }
+
+  const { crateName, outDir: resolvedOutDir } = await generateRustCrate(irPath, outDir);
+  console.log(`wrote ${resolvedOutDir} (crate ${crateName})`);
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err && err.stack ? err.stack : err);
+    process.exit(1);
+  });
+}

--- a/tests/codegen-rs.test.mjs
+++ b/tests/codegen-rs.test.mjs
@@ -4,14 +4,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { generateRustCrate } from '../scripts/generate-rs.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const IR_PATH = path.join(ROOT, 'out/0.4/ir/signing.ir.json');
 const OUT_DIR = path.join(ROOT, 'out/0.4/codegen-rs/signing');
 
-function ensureSigningIr() {
+async function ensureSigningIr() {
   if (fs.existsSync(IR_PATH)) return;
-
   fs.mkdirSync(path.dirname(IR_PATH), { recursive: true });
   const result = spawnSync(process.execPath, [
     'packages/tf-compose/bin/tf.mjs',
@@ -20,60 +20,61 @@ function ensureSigningIr() {
     '-o',
     IR_PATH,
   ], { cwd: ROOT, stdio: 'inherit' });
-
   assert.equal(result.status, 0, 'failed to generate signing IR fixture');
   assert.ok(fs.existsSync(IR_PATH), 'expected signing IR fixture after generation');
 }
 
-function runGenerator() {
-  return spawnSync(process.execPath, ['scripts/generate-rs.mjs', IR_PATH, '-o', OUT_DIR], {
-    cwd: ROOT,
-    stdio: 'inherit',
-  });
-}
-
-test('rust codegen emits deterministic scaffold', () => {
-  // ensure we have the IR fixture available
-  ensureSigningIr();
-  assert.ok(fs.existsSync(IR_PATH), 'expected signing IR fixture');
-
-  // clean output dir
+test('rust codegen emits deterministic scaffold', async () => {
+  await ensureSigningIr();
   fs.rmSync(OUT_DIR, { recursive: true, force: true });
 
-  // first generate
-  const firstRun = runGenerator();
-  assert.equal(firstRun.status, 0, 'generator should exit 0 without cargo');
+  await generateRustCrate(IR_PATH, OUT_DIR);
+  const paths = {
+    cargo: path.join(OUT_DIR, 'Cargo.toml'),
+    pipeline: path.join(OUT_DIR, 'src/pipeline.rs'),
+    adapters: path.join(OUT_DIR, 'src/adapters.rs'),
+    run: path.join(OUT_DIR, 'src/run.rs'),
+    lib: path.join(OUT_DIR, 'src/lib.rs'),
+    ir: path.join(OUT_DIR, 'ir.json'),
+  };
 
-  const cargoPath = path.join(OUT_DIR, 'Cargo.toml');
-  const pipelinePath = path.join(OUT_DIR, 'src', 'pipeline.rs');
-
-  assert.ok(fs.existsSync(cargoPath), 'Cargo.toml should exist');
-  assert.ok(fs.existsSync(pipelinePath), 'pipeline.rs should exist');
+  for (const key of Object.keys(paths)) {
+    assert.ok(fs.existsSync(paths[key]), `missing ${key}`);
+  }
 
   const first = {
-    cargo: fs.readFileSync(cargoPath, 'utf8'),
-    pipe: fs.readFileSync(pipelinePath, 'utf8'),
+    cargo: fs.readFileSync(paths.cargo, 'utf8'),
+    pipeline: fs.readFileSync(paths.pipeline, 'utf8'),
+    adapters: fs.readFileSync(paths.adapters, 'utf8'),
+    run: fs.readFileSync(paths.run, 'utf8'),
+    lib: fs.readFileSync(paths.lib, 'utf8'),
+    ir: fs.readFileSync(paths.ir, 'utf8'),
   };
 
-  // pipeline function and trait bound presence (signing → Crypto)
-  assert.ok(first.pipe.includes('pub fn run_pipeline'), 'pipeline should expose run_pipeline');
-  assert.ok(first.pipe.includes('Crypto'), 'signing flow should require Crypto trait');
+  assert.ok(first.pipeline.includes('TraceEntry'), 'pipeline should define TraceEntry');
+  assert.ok(first.run.includes('include_str!("../ir.json")'), 'run.rs should include baked IR');
 
-  // second generate (determinism)
-  const secondRun = runGenerator();
-  assert.equal(secondRun.status, 0, 'second generate should also exit 0');
-
+  await generateRustCrate(IR_PATH, OUT_DIR);
   const second = {
-    cargo: fs.readFileSync(cargoPath, 'utf8'),
-    pipe: fs.readFileSync(pipelinePath, 'utf8'),
+    cargo: fs.readFileSync(paths.cargo, 'utf8'),
+    pipeline: fs.readFileSync(paths.pipeline, 'utf8'),
+    adapters: fs.readFileSync(paths.adapters, 'utf8'),
+    run: fs.readFileSync(paths.run, 'utf8'),
+    lib: fs.readFileSync(paths.lib, 'utf8'),
+    ir: fs.readFileSync(paths.ir, 'utf8'),
   };
 
-  assert.equal(first.cargo, second.cargo, 'Cargo.toml must be byte-identical');
-  assert.equal(first.pipe, second.pipe, 'pipeline.rs must be byte-identical');
+  assert.equal(first.cargo, second.cargo, 'Cargo.toml must be deterministic');
+  assert.equal(first.pipeline, second.pipeline, 'pipeline.rs must be deterministic');
+  assert.equal(first.adapters, second.adapters, 'adapters.rs must be deterministic');
+  assert.equal(first.run, second.run, 'run.rs must be deterministic');
+  assert.equal(first.lib, second.lib, 'lib.rs must be deterministic');
+  assert.equal(first.ir, second.ir, 'ir.json must be deterministic');
 
-  // optional local cargo build (not required in CI)
   if (process.env.LOCAL_RUST) {
-    const result = spawnSync('cargo', ['build'], { cwd: OUT_DIR, stdio: 'inherit' });
-    assert.equal(result.status, 0, 'cargo build should succeed locally');
+    const result = spawnSync('cargo', ['run', '--', '--ir', IR_PATH], { cwd: OUT_DIR, stdio: 'inherit' });
+    assert.equal(result.status, 0, 'cargo run should succeed locally');
+    const tracePath = path.join(OUT_DIR, 'out', 'trace.jsonl');
+    assert.ok(fs.existsSync(tracePath), 'trace.jsonl should exist after cargo run');
   }
 });

--- a/tests/cross-parity-ts-rs.test.mjs
+++ b/tests/cross-parity-ts-rs.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'scripts/cross-parity-ts-rs.mjs');
+const FLOW = path.join(ROOT, 'examples/flows/run_publish.tf');
+const REPORT = path.join(ROOT, 'out/0.4/parity/ts-rs/report.json');
+
+test('cross parity script produces report', () => {
+  fs.rmSync(REPORT, { force: true });
+  const env = { ...process.env };
+  delete env.LOCAL_RUST;
+  const result = spawnSync(process.execPath, [SCRIPT, FLOW], { cwd: ROOT, stdio: 'inherit', env });
+  assert.equal(result.status, 0, 'cross parity script should exit 0');
+  assert.ok(fs.existsSync(REPORT), 'parity report should exist');
+  const report = JSON.parse(fs.readFileSync(REPORT, 'utf8'));
+  assert.ok(Object.prototype.hasOwnProperty.call(report, 'equal'), 'report must include equal field');
+  assert.ok(report.counts && typeof report.counts.ts === 'number');
+});
+
+test('cross parity matches under LOCAL_RUST', { skip: !process.env.LOCAL_RUST }, () => {
+  const env = { ...process.env, LOCAL_RUST: '1' };
+  const result = spawnSync(process.execPath, [SCRIPT, FLOW], { cwd: ROOT, stdio: 'inherit', env });
+  assert.equal(result.status, 0, 'cross parity script should exit 0 with LOCAL_RUST');
+  const report = JSON.parse(fs.readFileSync(REPORT, 'utf8'));
+  assert.equal(report.equal, true, 'ts and rust traces should match');
+});


### PR DESCRIPTION
## Summary
- generate Rust crates from templates with adapters, pipeline runner, and baked IR support
- add scripts to emit/run Rust code and compare TS vs Rust traces, with new parity tests
- document local Rust workflow and parity usage

## Testing
- pnpm -w -r build *(fails: coverage generator workspace lacks node_modules)*
- pnpm -w -r test *(fails: coverage generator vitest run missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68d071eeb31c83209125c9624f3147ca