### PR TITLE
feat: add rust trace parity tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ npm run tf -- check examples/flows/signing.tf -o out/0.4/flows/signing.verdict.j
 npm run tf -- canon examples/flows/signing.tf -o out/0.4/ir/signing.canon.json
 
 # Generate Rust scaffold for the flow
-node scripts/generate-rs.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing
+node scripts/generate-rs-run.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing
 # (optional) LOCAL_RUST=1 cargo build -Z unstable-options --manifest-path out/0.4/codegen-rs/signing/Cargo.toml
 
 # Generate TS skeleton for the flow

--- a/docs/l0-rust.md
+++ b/docs/l0-rust.md
@@ -1,0 +1,21 @@
+# L0 Rust backend
+
+This repo can emit a runnable Rust crate for an L0 IR. Generation is deterministic and works without requiring a local Rust toolchain. Running the binary is optional and only needed when you want to compare traces locally.
+
+## Generating a crate
+
+```bash
+node scripts/generate-rs-run.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing
+```
+
+The command writes a Cargo workspace under the requested output directory. By default it skips executing the compiled binary.
+
+## Running the crate (optional)
+
+Set `LOCAL_RUST=1` to enable the cargo run step. The helper respects `RUST_TRACE_PATH` if you want to override the trace location; otherwise it writes to `<crate>/out/trace.jsonl`.
+
+```bash
+LOCAL_RUST=1 cargo run --manifest-path out/0.4/codegen-rs/signing/Cargo.toml -- --ir out/0.4/ir/signing.ir.json
+```
+
+The binary reads the baked IR (or the `--ir` override) and emits trace records conforming to `trace.v0.4` (without provenance metadata).

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "proofs:laws:axioms": "node scripts/emit-smt-laws.mjs --law idempotent:hash -o out/0.4/proofs/laws/idempotent_hash.smt2 && node scripts/emit-smt-laws.mjs --law inverse:serialize-deserialize -o out/0.4/proofs/laws/inverse_roundtrip.smt2 && node scripts/emit-smt-laws.mjs --law commute:emit-metric-with-pure -o out/0.4/proofs/laws/emit_commute.smt2",
     "proofs:laws:equiv": "node scripts/emit-smt-laws.mjs --equiv examples/flows/info_roundtrip.tf examples/flows/info_roundtrip.tf --laws idempotent:hash,inverse:serialize-deserialize -o out/0.4/proofs/laws/roundtrip_equiv.smt2",
     "tf": "node packages/tf-compose/bin/tf.mjs",
-    "codegen:rs:signing": "node scripts/generate-rs.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing",
+    "codegen:rs:signing": "node scripts/generate-rs-run.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing",
     "trace:filter": "node packages/tf-l0-tools/trace-filter.mjs",
     "traces:validate": "node scripts/validate-trace.mjs",
     "traces:sample": "node packages/tf-l0-tools/trace-summary.mjs --top=5 --pretty < tests/fixtures/trace-sample.jsonl",

--- a/packages/tf-l0-codegen-rs/src/lib.rs
+++ b/packages/tf-l0-codegen-rs/src/lib.rs
@@ -1,22 +1,6 @@
 use anyhow::{Context, Result};
-use serde_json::Value;
-use std::{collections::BTreeSet, fs, path::Path};
-
-pub trait Network {
-    fn publish(&self, topic: &str, key: &str, payload: &str) -> anyhow::Result<()>;
-}
-
-pub trait Observability {
-    fn emit_metric(&self, name: &str) -> anyhow::Result<()>;
-}
-
-pub trait Storage {
-    fn write_object(&self, uri: &str, key: &str, value: &str) -> anyhow::Result<()>;
-}
-
-pub trait Crypto {
-    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;
-}
+use serde_json::{Map, Value};
+use std::{fs, path::Path};
 
 pub fn generate_workspace(ir: &Value, out_dir: &Path, package_name: &str) -> Result<()> {
     fs::create_dir_all(out_dir.join("src")).context("creating src directory")?;
@@ -24,196 +8,639 @@ pub fn generate_workspace(ir: &Value, out_dir: &Path, package_name: &str) -> Res
     let cargo_toml = render_cargo_toml(package_name);
     fs::write(out_dir.join("Cargo.toml"), cargo_toml).context("writing Cargo.toml")?;
 
-    let pipeline_rs = render_pipeline(ir);
-    fs::write(out_dir.join("src/pipeline.rs"), pipeline_rs).context("writing src/pipeline.rs")?;
-
     let lib_rs = render_lib_rs();
     fs::write(out_dir.join("src/lib.rs"), lib_rs).context("writing src/lib.rs")?;
+
+    let adapters_rs = render_adapters_rs();
+    fs::write(out_dir.join("src/adapters.rs"), adapters_rs).context("writing src/adapters.rs")?;
+
+    let pipeline_rs = render_pipeline_rs();
+    fs::write(out_dir.join("src/pipeline.rs"), pipeline_rs).context("writing src/pipeline.rs")?;
+
+    let run_rs = render_run_rs(package_name);
+    fs::write(out_dir.join("src/run.rs"), run_rs).context("writing src/run.rs")?;
+
+    let ir_literal = render_ir_json(ir);
+    fs::write(out_dir.join("src/ir.json"), ir_literal).context("writing src/ir.json")?;
 
     Ok(())
 }
 
-struct TraitInfo {
-    name: &'static str,
-    definition: &'static str,
-    keywords: &'static [&'static str],
-}
-
-static TRAITS: &[TraitInfo] = &[
-    TraitInfo {
-        name: "Network",
-        definition: "pub trait Network {\n    fn publish(&self, topic: &str, key: &str, payload: &str) -> anyhow::Result<()>;\n}\n\n",
-        keywords: &["publish"],
-    },
-    TraitInfo {
-        name: "Observability",
-        definition: "pub trait Observability {\n    fn emit_metric(&self, name: &str) -> anyhow::Result<()>;\n}\n\n",
-        keywords: &["emit-metric"],
-    },
-    TraitInfo {
-        name: "Storage",
-        definition: "pub trait Storage {\n    fn write_object(&self, uri: &str, key: &str, value: &str) -> anyhow::Result<()>;\n}\n\n",
-        keywords: &["write-object", "delete-object", "compare-and-swap"],
-    },
-    TraitInfo {
-        name: "Crypto",
-        definition: "pub trait Crypto {\n    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;\n}\n\n",
-        keywords: &["sign-data", "verify-signature", "encrypt", "decrypt"],
-    },
-];
-
 fn render_cargo_toml(package_name: &str) -> String {
     format!(
-        "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\nlicense = \"MIT OR Apache-2.0\"\ndescription = \"Generated TF pipeline\"\n\n[dependencies]\nanyhow = \"1\"\n",
-        name = package_name
+        r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Generated TF pipeline"
+
+[dependencies]
+anyhow = "1"
+serde = {{ version = "1", features = ["derive"] }}
+serde_json = "1"
+sha2 = "0.10"
+
+[[bin]]
+name = "run"
+path = "src/run.rs"
+"#,
+        name = package_name,
     )
 }
 
 fn render_lib_rs() -> String {
-    "pub mod pipeline;\n\npub use pipeline::run_pipeline;\n".to_string()
+    r#"pub mod adapters;
+pub mod pipeline;
+
+pub use adapters::InMemoryAdapters;
+pub use pipeline::{run_pipeline, run_with_ir, TraceEvent};
+"#
+    .to_string()
 }
 
-fn render_pipeline(ir: &Value) -> String {
-    let mut traits = BTreeSet::new();
-    let mut steps = Vec::new();
-    collect_primitives(ir, &mut traits, &mut steps);
+fn render_adapters_rs() -> String {
+    r#"use std::collections::{HashMap, HashSet};
 
-    let mut output = String::new();
-    output.push_str("use anyhow::Result;\n\n");
+use anyhow::Result;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
-    for trait_info in TRAITS {
-        output.push_str(trait_info.definition);
-    }
-
-    output.push_str("pub fn run_pipeline<A>(adapters: &A) -> Result<()>\nwhere\n    A: ?Sized");
-    for name in &traits {
-        output.push_str(" + ");
-        output.push_str(name);
-    }
-    output.push_str(",\n{\n");
-    output.push_str("    let _ = adapters;\n");
-
-    for step in steps {
-        output.push_str("    ");
-        output.push_str(&format_step_comment(&step));
-        output.push('\n');
-    }
-
-    output.push_str("    Ok(())\n}\n");
-
-    output
+#[derive(Debug, Clone, Serialize)]
+pub struct PublishedMessage {
+    pub topic: String,
+    pub key: String,
+    pub payload: String,
 }
 
-struct StepNote {
-    prim: String,
-    trait_name: Option<&'static str>,
+#[derive(Debug, Default)]
+pub struct InMemoryAdapters {
+    published: Vec<PublishedMessage>,
+    storage: HashMap<String, HashMap<String, String>>,
+    idempotency: HashSet<String>,
+    metrics: HashMap<String, f64>,
 }
 
-fn format_step_comment(step: &StepNote) -> String {
-    match step.trait_name {
-        Some(name) => format!("// Prim: {} (requires {})", step.prim, name),
-        None => format!("// Prim: {}", step.prim),
+impl InMemoryAdapters {
+    pub fn new() -> Self {
+        Self::default()
     }
-}
 
-fn collect_primitives(value: &Value, traits: &mut BTreeSet<&'static str>, steps: &mut Vec<StepNote>) {
-    match value {
-        Value::Object(map) => {
-            let is_prim = matches!(map.get("node"), Some(Value::String(node)) if node == "Prim");
-            if is_prim {
-                if let Some(Value::String(prim)) = map.get("prim") {
-                    if let Some(info) = trait_for_primitive(prim) {
-                        traits.insert(info.name);
-                        steps.push(StepNote {
-                            prim: prim.clone(),
-                            trait_name: Some(info.name),
-                        });
-                    } else {
-                        steps.push(StepNote {
-                            prim: prim.clone(),
-                            trait_name: None,
-                        });
-                    }
-                }
-            }
+    pub fn published(&self) -> &[PublishedMessage] {
+        &self.published
+    }
 
-            if let Some(Value::Array(children)) = map.get("children") {
-                for child in children {
-                    collect_primitives(child, traits, steps);
-                }
-            }
+    pub fn storage_snapshot(&self) -> HashMap<String, HashMap<String, String>> {
+        self.storage.clone()
+    }
 
-            let mut keys: Vec<&str> = map
-                .keys()
-                .map(|key| key.as_str())
-                .filter(|key| *key != "children")
-                .collect();
-            keys.sort_unstable();
-
-            for key in keys {
-                if let Some(child) = map.get(key) {
-                    collect_primitives(child, traits, steps);
-                }
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                collect_primitives(item, traits, steps);
-            }
-        }
-        _ => {}
+    pub fn metric_totals(&self) -> HashMap<String, f64> {
+        self.metrics.clone()
     }
 }
 
-fn trait_for_primitive(name: &str) -> Option<&'static TraitInfo> {
-    let base = primitive_base(name);
-    let base_lower = base.to_ascii_lowercase();
-
-    TRAITS.iter().find(|info| info.keywords.iter().any(|keyword| *keyword == base_lower))
+pub trait Network {
+    fn publish(&mut self, topic: &str, key: &str, payload: &str) -> Result<()>;
 }
 
-fn primitive_base(name: &str) -> &str {
-    let without_suffix = name.split('@').next().unwrap_or(name);
-    let mut candidate = without_suffix;
-    for delimiter in ['/', '.', ':'] {
-        if let Some(index) = candidate.rfind(delimiter) {
-            candidate = &candidate[index + 1..];
-        }
-    }
-    candidate
+pub trait Storage {
+    fn write_object(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<()>;
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
+pub trait Observability {
+    fn emit_metric(&mut self, name: &str, value: Option<f64>) -> Result<()>;
+}
 
-    #[test]
-    fn detects_traits_from_mixed_primitives() {
-        let ir = json!({
-            "node": "Seq",
-            "children": [
-                {"node": "Prim", "prim": "tf:network/publish@1"},
-                {"node": "Prim", "prim": "storage.write-object"},
-                {"node": "Prim", "prim": "sign-data"},
-                {"node": "Prim", "prim": "emit-metric"}
-            ]
+pub trait Crypto {
+    fn sign(&mut self, key: &str, data: &[u8]) -> Result<Vec<u8>>;
+    fn verify(&mut self, key: &str, data: &[u8], signature: &[u8]) -> Result<bool>;
+    fn hash(&mut self, data: &[u8]) -> Result<String>;
+}
+
+pub trait AdapterSet: Network + Storage + Observability + Crypto {}
+
+impl<T> AdapterSet for T where T: Network + Storage + Observability + Crypto {}
+
+impl Network for InMemoryAdapters {
+    fn publish(&mut self, topic: &str, key: &str, payload: &str) -> Result<()> {
+        self.published.push(PublishedMessage {
+            topic: topic.to_string(),
+            key: key.to_string(),
+            payload: payload.to_string(),
         });
+        Ok(())
+    }
+}
 
-        let mut traits = BTreeSet::new();
-        let mut steps = Vec::new();
-        collect_primitives(&ir, &mut traits, &mut steps);
+impl Storage for InMemoryAdapters {
+    fn write_object(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<()> {
+        let token = idempotency_key.map(|tok| format!("{uri}::{key}::{tok}"));
+        if let Some(ref id) = token {
+            if self.idempotency.contains(id) {
+                return Ok(());
+            }
+        }
 
-        let names: Vec<&str> = traits.into_iter().collect();
-        assert_eq!(names, vec!["Crypto", "Network", "Observability", "Storage"]);
-        assert_eq!(steps.len(), 4);
-        assert!(steps.iter().any(|step| step.prim == "tf:network/publish@1"));
+        let bucket = self.storage.entry(uri.to_string()).or_insert_with(HashMap::new);
+        bucket.insert(key.to_string(), value.to_string());
+
+        if let Some(id) = token {
+            self.idempotency.insert(id);
+        }
+
+        Ok(())
+    }
+}
+
+impl Observability for InMemoryAdapters {
+    fn emit_metric(&mut self, name: &str, value: Option<f64>) -> Result<()> {
+        let increment = value.unwrap_or(1.0);
+        let entry = self.metrics.entry(name.to_string()).or_insert(0.0);
+        *entry += increment;
+        Ok(())
+    }
+}
+
+impl Crypto for InMemoryAdapters {
+    fn sign(&mut self, key: &str, data: &[u8]) -> Result<Vec<u8>> {
+        let mut hasher = Sha256::new();
+        hasher.update(key.as_bytes());
+        hasher.update(data);
+        Ok(hasher.finalize().to_vec())
     }
 
-    #[test]
-    fn primitive_base_handles_compound_names() {
-        assert_eq!(primitive_base("tf:network/publish@1"), "publish");
-        assert_eq!(primitive_base("storage.write-object"), "write-object");
-        assert_eq!(primitive_base("encrypt"), "encrypt");
+    fn verify(&mut self, key: &str, data: &[u8], signature: &[u8]) -> Result<bool> {
+        let expected = self.sign(key, data)?;
+        Ok(expected.as_slice() == signature)
+    }
+
+    fn hash(&mut self, data: &[u8]) -> Result<String> {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let digest = hasher.finalize();
+        Ok(to_hex(&digest))
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{:02x}", byte);
+    }
+    out
+}
+"#
+    .to_string()
+}
+
+fn render_pipeline_rs() -> String {
+    r#"use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::adapters::AdapterSet;
+
+const BAKED_IR: &str = include_str!("ir.json");
+const CLOCK_START_MS: i64 = 1_690_000_000_000;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceEvent {
+    pub ts: i64,
+    pub prim_id: String,
+    pub args: Value,
+    pub region: String,
+    pub effect: String,
+}
+
+pub fn run_pipeline<A>(adapters: &mut A) -> Result<Vec<TraceEvent>>
+where
+    A: AdapterSet,
+{
+    let ir: Value = serde_json::from_str(BAKED_IR).context("parsing baked IR JSON")?;
+    run_with_ir(&ir, adapters)
+}
+
+pub fn run_with_ir<A>(ir: &Value, adapters: &mut A) -> Result<Vec<TraceEvent>>
+where
+    A: AdapterSet,
+{
+    let mut ctx = ExecutionContext::new(adapters);
+    exec_node(ir, &mut ctx)?;
+    Ok(ctx.events)
+}
+
+struct ExecutionContext<'a, A> {
+    adapters: &'a mut A,
+    events: Vec<TraceEvent>,
+    clock: Clock,
+}
+
+impl<'a, A> ExecutionContext<'a, A>
+where
+    A: AdapterSet,
+{
+    fn new(adapters: &'a mut A) -> Self {
+        Self {
+            adapters,
+            events: Vec::new(),
+            clock: Clock::new(),
+        }
+    }
+
+    fn record(&mut self, prim_id: String, args: Value, region: String, effect: String) {
+        let ts = self.clock.next();
+        self.events.push(TraceEvent {
+            ts,
+            prim_id,
+            args,
+            region,
+            effect,
+        });
+    }
+}
+
+fn exec_node<A>(node: &Value, ctx: &mut ExecutionContext<A>) -> Result<Value>
+where
+    A: AdapterSet,
+{
+    match node.get("node").and_then(Value::as_str) {
+        Some("Prim") => exec_prim(node, ctx),
+        Some("Seq") | Some("Region") => {
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    exec_node(child, ctx)?;
+                }
+            }
+            Ok(Value::Null)
+        }
+        Some("Par") => {
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    exec_node(child, ctx)?;
+                }
+            }
+            Ok(Value::Null)
+        }
+        _ => {
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    exec_node(child, ctx)?;
+                }
+            }
+            Ok(Value::Null)
+        }
+    }
+}
+
+fn exec_prim<A>(node: &Value, ctx: &mut ExecutionContext<A>) -> Result<Value>
+where
+    A: AdapterSet,
+{
+    let raw_prim = node
+        .get("prim")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("prim node missing prim id"))?;
+    let prim_id = canonical_prim(raw_prim).to_string();
+    let args_map = normalize_args(node.get("args"));
+    let args_value = Value::Object(args_map.clone());
+    invoke_primitive(&prim_id, &args_map, ctx)?;
+
+    let region = node
+        .get("meta")
+        .and_then(|meta| meta.get("region"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let effect = effect_from_node(node, &prim_id);
+
+    ctx.record(prim_id, args_value, region, effect);
+    Ok(Value::Null)
+}
+
+fn invoke_primitive<A>(prim_id: &str, args: &Map<String, Value>, ctx: &mut ExecutionContext<A>) -> Result<Value>
+where
+    A: AdapterSet,
+{
+    match prim_id {
+        "tf:network/publish@1" => {
+            let topic = args
+                .get("topic")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let key = args
+                .get("key")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = stringify_payload(args.get("payload"));
+            ctx.adapters.publish(&topic, &key, &payload)?;
+            Ok(Value::Null)
+        }
+        "tf:observability/emit-metric@1" => {
+            let name = args
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let value = args.get("value").and_then(Value::as_f64);
+            ctx.adapters.emit_metric(&name, value)?;
+            Ok(Value::Null)
+        }
+        "tf:resource/write-object@1" => {
+            let uri = args
+                .get("uri")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let key = args
+                .get("key")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let value = stringify_payload(args.get("value"));
+            let idempotency_key = args
+                .get("idempotency_key")
+                .and_then(Value::as_str)
+                .or_else(|| args.get("idempotencyKey").and_then(Value::as_str));
+            ctx.adapters
+                .write_object(&uri, &key, &value, idempotency_key)?;
+            Ok(Value::Null)
+        }
+        "tf:security/sign-data@1" => {
+            let key = args
+                .get("key")
+                .or_else(|| args.get("key_ref"))
+                .or_else(|| args.get("keyId"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = stringify_payload(args.get("payload").or_else(|| args.get("value")));
+            let _sig = ctx.adapters.sign(&key, payload.as_bytes())?;
+            Ok(Value::Null)
+        }
+        "tf:security/verify-signature@1" => {
+            let key = args
+                .get("key")
+                .or_else(|| args.get("key_ref"))
+                .or_else(|| args.get("keyId"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = stringify_payload(args.get("payload").or_else(|| args.get("value")));
+            let signature = args
+                .get("signature")
+                .or_else(|| args.get("sig"))
+                .and_then(|value| match value {
+                    Value::String(s) => Some(s.as_bytes().to_vec()),
+                    Value::Array(items) => {
+                        let bytes: Vec<u8> = items
+                            .iter()
+                            .filter_map(|item| item.as_u64())
+                            .map(|byte| byte as u8)
+                            .collect();
+                        Some(bytes)
+                    }
+                    _ => None,
+                })
+                .unwrap_or_default();
+            let ok = ctx
+                .adapters
+                .verify(&key, payload.as_bytes(), &signature)?;
+            if !ok {
+                return Err(anyhow!("signature verification failed"));
+            }
+            Ok(Value::Null)
+        }
+        "tf:information/hash@1" => {
+            let target = args
+                .get("value")
+                .unwrap_or(&Value::Null);
+            let canonical = stable_string(target);
+            let _digest = ctx.adapters.hash(canonical.as_bytes())?;
+            Ok(Value::Null)
+        }
+        _ => Ok(Value::Null),
+    }
+}
+
+fn effect_from_node(node: &Value, prim_id: &str) -> String {
+    if let Some(Value::String(effect)) = node.get("meta").and_then(|meta| meta.get("effect")).and_then(Value::as_str) {
+        return effect.to_string();
+    }
+    if let Some(Value::Array(effects)) = node.get("meta").and_then(|meta| meta.get("effects")).and_then(Value::as_array) {
+        if let Some(effect) = effects.iter().find_map(Value::as_str) {
+            return effect.to_string();
+        }
+    }
+    let runtime_effect = effect_for(prim_id);
+    if !runtime_effect.is_empty() {
+        return runtime_effect.to_string();
+    }
+    String::new()
+}
+
+fn normalize_args(value: Option<&Value>) -> Map<String, Value> {
+    match value {
+        Some(Value::Object(map)) => map.clone(),
+        _ => Map::new(),
+    }
+}
+
+fn canonical_prim(name: &str) -> &'static str {
+    match name {
+        "tf:network/publish@1" | "publish" => "tf:network/publish@1",
+        "tf:observability/emit-metric@1" | "emit-metric" => "tf:observability/emit-metric@1",
+        "tf:resource/write-object@1" | "write-object" => "tf:resource/write-object@1",
+        "tf:security/sign-data@1" | "sign-data" => "tf:security/sign-data@1",
+        "tf:security/verify-signature@1" | "verify-signature" => "tf:security/verify-signature@1",
+        "tf:information/hash@1" | "hash" => "tf:information/hash@1",
+        other => other,
+    }
+}
+
+fn effect_for(prim: &str) -> &'static str {
+    match prim {
+        "tf:network/publish@1" => "Network.Out",
+        "tf:observability/emit-metric@1" => "Observability",
+        "tf:resource/write-object@1" => "Storage.Write",
+        "tf:security/sign-data@1" => "Crypto",
+        "tf:security/verify-signature@1" => "Crypto",
+        "tf:information/hash@1" => "Crypto",
+        _ => "",
+    }
+}
+
+fn stringify_payload(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(text)) => text.to_string(),
+        Some(other) => stable_string(other),
+        None => String::new(),
+    }
+}
+
+fn stable_string(value: &Value) -> String {
+    let canonical = canonical_value(value);
+    serde_json::to_string(&canonical).unwrap_or_else(|_| "".to_string())
+}
+
+fn canonical_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => {
+            let mapped: Vec<Value> = items.iter().map(canonical_value).collect();
+            Value::Array(mapped)
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let mut out = Map::new();
+            for (key, value) in entries {
+                out.insert(key.clone(), canonical_value(value));
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+struct Clock {
+    base: i64,
+    counter: i64,
+}
+
+impl Clock {
+    fn new() -> Self {
+        Self {
+            base: CLOCK_START_MS,
+            counter: 0,
+        }
+    }
+
+    fn next(&mut self) -> i64 {
+        let ts = self.base + self.counter;
+        self.counter += 1;
+        ts
+    }
+}
+"#
+    .to_string()
+}
+
+fn render_run_rs(package_name: &str) -> String {
+    let crate_ident = package_name.replace('-', "_");
+    format!(
+        r#"use std::{
+    env,
+    fs,
+    io::{self, Write},
+    path::PathBuf,
+};
+
+use anyhow::{anyhow, Context, Result};
+use {crate_name}::{{adapters::InMemoryAdapters, pipeline}};
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("error: {err:?}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let mut ir_path: Option<PathBuf> = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--ir" => {
+                let value = args.next().context("--ir requires a value")?;
+                ir_path = Some(PathBuf::from(value));
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            other => return Err(anyhow!("unexpected argument: {other}")),
+        }
+    }
+
+    let mut adapters = InMemoryAdapters::new();
+    let events = if let Some(path) = ir_path {
+        let data = fs::read_to_string(&path).context("reading IR file")?;
+        let ir: serde_json::Value = serde_json::from_str(&data).context("parsing IR JSON")?;
+        pipeline::run_with_ir(&ir, &mut adapters)?
+    } else {
+        pipeline::run_pipeline(&mut adapters)?
+    };
+
+    write_trace(&events)
+}
+
+fn write_trace(events: &[pipeline::TraceEvent]) -> Result<()> {
+    let trace_path = env::var("TF_TRACE_PATH").ok().map(PathBuf::from);
+    if let Some(path) = trace_path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).context("creating trace directory")?;
+        }
+        let mut file = fs::File::create(&path).context("creating trace file")?;
+        for event in events {
+            serde_json::to_writer(&mut file, event).context("serializing trace event")?;
+            file.write_all(b"\n").context("writing newline")?;
+        }
+        return Ok(());
+    }
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    for event in events {
+        serde_json::to_writer(&mut handle, event).context("serializing trace event")?;
+        handle.write_all(b"\n").context("writing newline")?;
+    }
+    Ok(())
+}
+
+fn print_usage() {
+    eprintln!("Usage: run [--ir <path>]");
+}
+"#,
+        crate_name = crate_ident,
+    )
+}
+
+fn render_ir_json(ir: &Value) -> String {
+    let canonical = canonical_value(ir);
+    let mut literal = serde_json::to_string_pretty(&canonical).expect("valid JSON");
+    literal.push('\n');
+    literal
+}
+
+fn canonical_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => {
+            Value::Array(items.iter().map(canonical_value).collect())
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let mut out = Map::new();
+            for (key, value) in entries {
+                out.insert(key.clone(), canonical_value(value));
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
     }
 }

--- a/scripts/cross-parity-ts-rs.mjs
+++ b/scripts/cross-parity-ts-rs.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { generateAndMaybeRun } from './generate-rs-run.mjs';
+
+const here = dirname(fileURLToPath(new URL(import.meta.url)));
+const repoRoot = resolve(here, '..');
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const flowPath = resolve(repoRoot, args[0]);
+  const flowName = basename(flowPath).replace(/\.tf$/i, '');
+  const irPath = args[1] ? resolve(repoRoot, args[1]) : join(repoRoot, 'out', '0.4', 'ir', `${flowName}.ir.json`);
+  const tsOutDir = join(repoRoot, 'out', '0.4', 'codegen-ts', flowName);
+  const rsOutDir = join(repoRoot, 'out', '0.4', 'codegen-rs', flowName);
+  const parityDir = join(repoRoot, 'out', '0.4', 'parity', 'ts-rs');
+  const reportPath = join(parityDir, 'report.json');
+  const tsTracePath = join(parityDir, 'trace.ts.jsonl');
+  const rsTracePath = join(parityDir, 'trace.rs.jsonl');
+
+  await mkdir(parityDir, { recursive: true });
+
+  await ensureIr(flowPath, irPath);
+  await emitTs(flowPath, tsOutDir);
+  await runTs(tsOutDir, tsTracePath);
+
+  const rustResult = await generateAndMaybeRun(irPath, rsOutDir, {
+    runRust: process.env.LOCAL_RUST === '1',
+    tracePath: process.env.LOCAL_RUST === '1' ? rsTracePath : null,
+  });
+
+  const tsSeq = await loadTrace(tsTracePath);
+  const rsSeq = rustResult.tracePath ? await loadTrace(rustResult.tracePath) : null;
+  const report = compareSequences(tsSeq, rsSeq);
+  report.meta = {
+    flow: flowPath,
+    ir: irPath,
+    tsTrace: tsTracePath,
+    rsTrace: rustResult.tracePath,
+    rustRan: Boolean(rustResult.tracePath),
+  };
+
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  if (!report.equal) {
+    console.warn('cross-parity: traces differ');
+  } else {
+    console.log('cross-parity: traces match');
+  }
+}
+
+async function ensureIr(flowPath, irPath) {
+  try {
+    await readFile(irPath, 'utf8');
+    return;
+  } catch {
+    await mkdir(dirname(irPath), { recursive: true });
+    await runCommand('pnpm', ['run', 'tf', '--', 'parse', flowPath, '-o', irPath]);
+  }
+}
+
+async function emitTs(flowPath, outDir) {
+  await mkdir(outDir, { recursive: true });
+  await runCommand('pnpm', ['run', 'tf', '--', 'emit', '--lang', 'ts', flowPath, '--out', outDir]);
+}
+
+async function runTs(outDir, tracePath) {
+  const traceDir = dirname(tracePath);
+  await mkdir(traceDir, { recursive: true });
+  const env = {
+    ...process.env,
+    TF_TRACE_PATH: tracePath,
+    TF_CAPS: JSON.stringify({
+      effects: ['Network.Out', 'Storage.Write', 'Storage.Read', 'Observability', 'Crypto'],
+      allow_writes_prefixes: ['res://', 'mem://'],
+    }),
+  };
+  const runScript = join(outDir, 'run.mjs');
+  await runCommand(process.execPath, [runScript], { cwd: outDir, env });
+}
+
+async function loadTrace(tracePath) {
+  const raw = await readFile(tracePath, 'utf8');
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      try {
+        const parsed = JSON.parse(line);
+        return { prim_id: parsed.prim_id || null, effect: parsed.effect || null };
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry) => entry && entry.prim_id);
+}
+
+function compareSequences(tsSeq, rsSeq) {
+  const report = { equal: true, diff: null };
+  if (!Array.isArray(tsSeq) || tsSeq.length === 0) {
+    report.equal = false;
+    report.diff = { reason: 'ts_trace_empty' };
+    return report;
+  }
+  if (!Array.isArray(rsSeq)) {
+    report.equal = false;
+    report.diff = { reason: 'rust_trace_missing' };
+    return report;
+  }
+  if (tsSeq.length !== rsSeq.length) {
+    report.equal = false;
+    report.diff = { reason: 'length', ts: tsSeq.length, rust: rsSeq.length };
+    return report;
+  }
+  for (let i = 0; i < tsSeq.length; i += 1) {
+    const left = tsSeq[i];
+    const right = rsSeq[i];
+    if (left.prim_id !== right.prim_id || (left.effect || '') !== (right.effect || '')) {
+      report.equal = false;
+      report.diff = { index: i, ts: left, rust: right };
+      return report;
+    }
+  }
+  return report;
+}
+
+function runCommand(cmd, args, options = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      ...options,
+    });
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited with ${code}`));
+      }
+    });
+  });
+}
+
+function printUsage() {
+  console.log('Usage: node scripts/cross-parity-ts-rs.mjs <flow.tf> [ir.json]');
+}
+
+const modulePath = fileURLToPath(new URL(import.meta.url));
+if (process.argv[1] === modulePath) {
+  main().catch((err) => {
+    console.error(err?.stack || err?.message || String(err));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/generate-rs-run.mjs
+++ b/scripts/generate-rs-run.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { dirname, join, resolve } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { generateCrateFromPath } from './generate-rs.mjs';
+
+export async function generateAndMaybeRun(irPath, outDir, options = {}) {
+  const resolvedOut = resolve(outDir);
+  const { packageName } = await generateCrateFromPath(irPath, resolvedOut, options.packageName);
+
+  let tracePath = null;
+  if (options.runRust) {
+    tracePath = options.tracePath || join(resolvedOut, 'out', 'trace.jsonl');
+    await mkdir(dirname(tracePath), { recursive: true });
+    await runCargo(resolvedOut, irPath, tracePath, packageName);
+  }
+
+  return { outDir: resolvedOut, packageName, tracePath };
+}
+
+async function runCargo(crateDir, irPath, tracePath, packageName) {
+  const env = { ...process.env, TF_TRACE_PATH: tracePath };
+  const args = ['run', '--manifest-path', join(crateDir, 'Cargo.toml'), '--', '--ir', irPath];
+  await new Promise((resolvePromise, reject) => {
+    const child = spawn('cargo', args, {
+      cwd: crateDir,
+      stdio: 'inherit',
+      env,
+    });
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        reject(new Error(`cargo run failed (crate ${packageName})`));
+      }
+    });
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const irPath = args[0];
+  let outDir = null;
+  let packageName = null;
+
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
+      i += 1;
+      outDir = args[i];
+    } else if (arg === '--package-name') {
+      i += 1;
+      packageName = args[i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!irPath) {
+    throw new Error('IR path is required');
+  }
+  if (!outDir) {
+    throw new Error('Output directory required via -o or --out');
+  }
+
+  const runRust = process.env.LOCAL_RUST === '1';
+  const traceOverride = process.env.RUST_TRACE_PATH || null;
+  const result = await generateAndMaybeRun(irPath, outDir, {
+    packageName,
+    runRust,
+    tracePath: traceOverride ? resolve(traceOverride) : null,
+  });
+
+  console.log(`generated crate ${result.packageName} at ${result.outDir}`);
+  if (runRust) {
+    console.log(`rust trace written to ${result.tracePath}`);
+  } else {
+    console.log('skipped rust run (set LOCAL_RUST=1 to enable)');
+  }
+}
+
+function printUsage() {
+  console.log('Usage: node scripts/generate-rs-run.mjs <ir.json> -o <output dir> [--package-name <name>]');
+}
+
+const modulePath = fileURLToPath(new URL(import.meta.url));
+if (process.argv[1] === modulePath) {
+  main().catch((err) => {
+    console.error(err?.stack || err?.message || String(err));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/generate-rs.mjs
+++ b/scripts/generate-rs.mjs
@@ -1,43 +1,26 @@
 #!/usr/bin/env node
-import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-async function main() {
-  const args = process.argv.slice(2);
-  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
-    printUsage();
-    return;
-  }
-
-  const irPath = args[0];
-  if (!irPath) {
-    throw new Error('IR path is required');
-  }
-
-  let outDir = null;
-  for (let i = 1; i < args.length; i += 1) {
-    const arg = args[i];
-    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
-      i += 1;
-      outDir = args[i];
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  if (!outDir) {
-    throw new Error('Output directory required via -o or --out');
-  }
-
+export async function generateCrateFromPath(irPath, outDir, packageName) {
   const raw = await readFile(irPath, 'utf8');
   const ir = JSON.parse(raw);
-
   const resolvedOutDir = resolve(outDir);
-  await mkdir(resolvedOutDir, { recursive: true });
+  const crateName = packageName || deriveCrateName(ir, resolvedOutDir, irPath);
+  await writeCrate(ir, { outDir: resolvedOutDir, packageName: crateName });
+  return { outDir: resolvedOutDir, packageName: crateName };
+}
 
-  const crateName = deriveCrateName(ir, resolvedOutDir, irPath);
-  await runGenerator(ir, resolvedOutDir, crateName);
-  console.log(`wrote ${resolvedOutDir} (crate ${crateName})`);
+export async function writeCrate(ir, { outDir, packageName }) {
+  const srcDir = join(outDir, 'src');
+  await mkdir(srcDir, { recursive: true });
+  await writeFile(join(outDir, 'Cargo.toml'), renderCargoToml(packageName), 'utf8');
+  await writeFile(join(srcDir, 'lib.rs'), renderLibRs(), 'utf8');
+  await writeFile(join(srcDir, 'adapters.rs'), renderAdaptersRs(), 'utf8');
+  await writeFile(join(srcDir, 'pipeline.rs'), renderPipelineRs(), 'utf8');
+  await writeFile(join(srcDir, 'run.rs'), renderRunRs(packageName), 'utf8');
+  await writeFile(join(srcDir, 'ir.json'), renderIrJson(ir), 'utf8');
 }
 
 function deriveCrateName(ir, outDir, irPath) {
@@ -51,152 +34,642 @@ function deriveCrateName(ir, outDir, irPath) {
 function sanitizeCrateName(value) {
   const safe = String(value || '')
     .toLowerCase()
-    .replace(/[^a-z0-9_]/g, '_')
+    .replace(/[^a-z0-9_\-]/g, '_')
     .replace(/_+/g, '_')
     .replace(/^_+/, '')
     .replace(/_+$/, '');
   return safe || 'tf_generated';
 }
 
-async function runGenerator(ir, outDir, packageName) {
-  const srcDir = join(outDir, 'src');
-  await mkdir(srcDir, { recursive: true });
-
-  await writeFile(join(outDir, 'Cargo.toml'), renderCargoToml(packageName), 'utf8');
-  await writeFile(join(srcDir, 'pipeline.rs'), renderPipeline(ir), 'utf8');
-  await writeFile(join(srcDir, 'lib.rs'), renderLibRs(), 'utf8');
-}
-
 function renderCargoToml(packageName) {
-  return `[package]\nname = "${packageName}"\nversion = "0.1.0"\nedition = "2021"\nlicense = "MIT OR Apache-2.0"\ndescription = "Generated TF pipeline"\n\n[dependencies]\nanyhow = "1"\n`;
+  return `[package]\nname = "${packageName}"\nversion = "0.1.0"\nedition = "2021"\nlicense = "MIT OR Apache-2.0"\ndescription = "Generated TF pipeline"\n\n[dependencies]\nanyhow = "1"\nserde = { version = "1", features = ["derive"] }\nserde_json = "1"\nsha2 = "0.10"\n\n[[bin]]\nname = "run"\npath = "src/run.rs"\n`;
 }
 
 function renderLibRs() {
-  return 'pub mod pipeline;\n\npub use pipeline::run_pipeline;\n';
+  return 'pub mod adapters;\npub mod pipeline;\n\npub use adapters::InMemoryAdapters;\npub use pipeline::{run_pipeline, run_with_ir, TraceEvent};\n';
 }
 
-function renderPipeline(ir) {
-  const traits = new Set();
-  const steps = [];
-  collectPrimitives(ir, traits, steps);
-  const orderedTraits = Array.from(traits).sort();
+function renderAdaptersRs() {
+  return `use std::collections::{HashMap, HashSet};
 
-  let output = 'use anyhow::Result;\n\n';
-  for (const trait of TRAITS) {
-    output += trait.definition;
-  }
+use anyhow::Result;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
-  output += 'pub fn run_pipeline<A>(adapters: &A) -> Result<()>\n';
-  output += 'where\n';
-  output += '    A: ?Sized';
-  for (const name of orderedTraits) {
-    output += ` + ${name}`;
-  }
-  output += ',\n{\n';
-  output += '    let _ = adapters;\n';
-
-  for (const step of steps) {
-    output += `    ${formatStepComment(step)}\n`;
-  }
-
-  output += '    Ok(())\n';
-  output += '}\n';
-  return output;
+#[derive(Debug, Clone, Serialize)]
+pub struct PublishedMessage {
+    pub topic: String,
+    pub key: String,
+    pub payload: String,
 }
 
-const TRAITS = [
-  {
-    name: 'Network',
-    definition:
-      'pub trait Network {\n    fn publish(&self, topic: &str, key: &str, payload: &str) -> anyhow::Result<()>;\n}\n\n',
-    keywords: ['publish'],
-  },
-  {
-    name: 'Observability',
-    definition:
-      'pub trait Observability {\n    fn emit_metric(&self, name: &str) -> anyhow::Result<()>;\n}\n\n',
-    keywords: ['emit-metric'],
-  },
-  {
-    name: 'Storage',
-    definition:
-      'pub trait Storage {\n    fn write_object(&self, uri: &str, key: &str, value: &str) -> anyhow::Result<()>;\n}\n\n',
-    keywords: ['write-object', 'delete-object', 'compare-and-swap'],
-  },
-  {
-    name: 'Crypto',
-    definition:
-      'pub trait Crypto {\n    fn sign(&self, key: &str, data: &[u8]) -> anyhow::Result<Vec<u8>>;\n}\n\n',
-    keywords: ['sign-data', 'verify-signature', 'encrypt', 'decrypt'],
-  },
-];
+#[derive(Debug, Default)]
+pub struct InMemoryAdapters {
+    published: Vec<PublishedMessage>,
+    storage: HashMap<String, HashMap<String, String>>,
+    idempotency: HashSet<String>,
+    metrics: HashMap<String, f64>,
+}
 
-function collectPrimitives(value, traits, steps) {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectPrimitives(item, traits, steps);
+impl InMemoryAdapters {
+    pub fn new() -> Self {
+        Self::default()
     }
-    return;
-  }
 
-  if (!value || typeof value !== 'object') {
-    return;
-  }
+    pub fn published(&self) -> &[PublishedMessage] {
+        &self.published
+    }
 
-  if (value.node === 'Prim' && typeof value.prim === 'string') {
-    const traitInfo = traitForPrimitive(value.prim);
-    if (traitInfo) {
-      traits.add(traitInfo.name);
-      steps.push({ prim: value.prim, traitName: traitInfo.name });
+    pub fn storage_snapshot(&self) -> HashMap<String, HashMap<String, String>> {
+        self.storage.clone()
+    }
+
+    pub fn metric_totals(&self) -> HashMap<String, f64> {
+        self.metrics.clone()
+    }
+}
+
+pub trait Network {
+    fn publish(&mut self, topic: &str, key: &str, payload: &str) -> Result<()>;
+}
+
+pub trait Storage {
+    fn write_object(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<()>;
+}
+
+pub trait Observability {
+    fn emit_metric(&mut self, name: &str, value: Option<f64>) -> Result<()>;
+}
+
+pub trait Crypto {
+    fn sign(&mut self, key: &str, data: &[u8]) -> Result<Vec<u8>>;
+    fn verify(&mut self, key: &str, data: &[u8], signature: &[u8]) -> Result<bool>;
+    fn hash(&mut self, data: &[u8]) -> Result<String>;
+}
+
+pub trait AdapterSet: Network + Storage + Observability + Crypto {}
+
+impl<T> AdapterSet for T where T: Network + Storage + Observability + Crypto {}
+
+impl Network for InMemoryAdapters {
+    fn publish(&mut self, topic: &str, key: &str, payload: &str) -> Result<()> {
+        self.published.push(PublishedMessage {
+            topic: topic.to_string(),
+            key: key.to_string(),
+            payload: payload.to_string(),
+        });
+        Ok(())
+    }
+}
+
+impl Storage for InMemoryAdapters {
+    fn write_object(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<()> {
+        let token = idempotency_key.map(|tok| format!("{uri}::{key}::{tok}"));
+        if let Some(ref id) = token {
+            if self.idempotency.contains(id) {
+                return Ok(());
+            }
+        }
+
+        let bucket = self.storage.entry(uri.to_string()).or_insert_with(HashMap::new);
+        bucket.insert(key.to_string(), value.to_string());
+
+        if let Some(id) = token {
+            self.idempotency.insert(id);
+        }
+
+        Ok(())
+    }
+}
+
+impl Observability for InMemoryAdapters {
+    fn emit_metric(&mut self, name: &str, value: Option<f64>) -> Result<()> {
+        let increment = value.unwrap_or(1.0);
+        let entry = self.metrics.entry(name.to_string()).or_insert(0.0);
+        *entry += increment;
+        Ok(())
+    }
+}
+
+impl Crypto for InMemoryAdapters {
+    fn sign(&mut self, key: &str, data: &[u8]) -> Result<Vec<u8>> {
+        let mut hasher = Sha256::new();
+        hasher.update(key.as_bytes());
+        hasher.update(data);
+        Ok(hasher.finalize().to_vec())
+    }
+
+    fn verify(&mut self, key: &str, data: &[u8], signature: &[u8]) -> Result<bool> {
+        let expected = self.sign(key, data)?;
+        Ok(expected.as_slice() == signature)
+    }
+
+    fn hash(&mut self, data: &[u8]) -> Result<String> {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let digest = hasher.finalize();
+        Ok(to_hex(&digest))
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{:02x}", byte);
+    }
+    out
+}
+`;
+}
+
+function renderPipelineRs() {
+  return `use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::adapters::AdapterSet;
+
+const BAKED_IR: &str = include_str!("ir.json");
+const CLOCK_START_MS: i64 = 1_690_000_000_000;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceEvent {
+    pub ts: i64,
+    pub prim_id: String,
+    pub args: Value,
+    pub region: String,
+    pub effect: String,
+}
+
+pub fn run_pipeline<A>(adapters: &mut A) -> Result<Vec<TraceEvent>>
+where
+    A: AdapterSet,
+{
+    let ir: Value = serde_json::from_str(BAKED_IR).context("parsing baked IR JSON")?;
+    run_with_ir(&ir, adapters)
+}
+
+pub fn run_with_ir<A>(ir: &Value, adapters: &mut A) -> Result<Vec<TraceEvent>>
+where
+    A: AdapterSet,
+{
+    let mut ctx = ExecutionContext::new(adapters);
+    exec_node(ir, &mut ctx)?;
+    Ok(ctx.events)
+}
+
+struct ExecutionContext<'a, A> {
+    adapters: &'a mut A,
+    events: Vec<TraceEvent>,
+    clock: Clock,
+}
+
+impl<'a, A> ExecutionContext<'a, A>
+where
+    A: AdapterSet,
+{
+    fn new(adapters: &'a mut A) -> Self {
+        Self {
+            adapters,
+            events: Vec::new(),
+            clock: Clock::new(),
+        }
+    }
+
+    fn record(&mut self, prim_id: String, args: Value, region: String, effect: String) {
+        let ts = self.clock.next();
+        self.events.push(TraceEvent {
+            ts,
+            prim_id,
+            args,
+            region,
+            effect,
+        });
+    }
+}
+
+fn exec_node<A>(node: &Value, ctx: &mut ExecutionContext<A>) -> Result<Value>
+where
+    A: AdapterSet,
+{
+    match node.get("node").and_then(Value::as_str) {
+        Some("Prim") => exec_prim(node, ctx),
+        Some("Seq") | Some("Region") => {
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    exec_node(child, ctx)?;
+                }
+            }
+            Ok(Value::Null)
+        }
+        Some("Par") => {
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    exec_node(child, ctx)?;
+                }
+            }
+            Ok(Value::Null)
+        }
+        _ => {
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    exec_node(child, ctx)?;
+                }
+            }
+            Ok(Value::Null)
+        }
+    }
+}
+
+fn exec_prim<A>(node: &Value, ctx: &mut ExecutionContext<A>) -> Result<Value>
+where
+    A: AdapterSet,
+{
+    let raw_prim = node
+        .get("prim")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("prim node missing prim id"))?;
+    let prim_id = canonical_prim(raw_prim).to_string();
+    let args_map = normalize_args(node.get("args"));
+    let args_value = Value::Object(args_map.clone());
+    invoke_primitive(&prim_id, &args_map, ctx)?;
+
+    let region = node
+        .get("meta")
+        .and_then(|meta| meta.get("region"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let effect = effect_from_node(node, &prim_id);
+
+    ctx.record(prim_id, args_value, region, effect);
+    Ok(Value::Null)
+}
+
+fn invoke_primitive<A>(prim_id: &str, args: &Map<String, Value>, ctx: &mut ExecutionContext<A>) -> Result<Value>
+where
+    A: AdapterSet,
+{
+    match prim_id {
+        "tf:network/publish@1" => {
+            let topic = args
+                .get("topic")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let key = args
+                .get("key")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = stringify_payload(args.get("payload"));
+            ctx.adapters.publish(&topic, &key, &payload)?;
+            Ok(Value::Null)
+        }
+        "tf:observability/emit-metric@1" => {
+            let name = args
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let value = args.get("value").and_then(Value::as_f64);
+            ctx.adapters.emit_metric(&name, value)?;
+            Ok(Value::Null)
+        }
+        "tf:resource/write-object@1" => {
+            let uri = args
+                .get("uri")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let key = args
+                .get("key")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let value = stringify_payload(args.get("value"));
+            let idempotency_key = args
+                .get("idempotency_key")
+                .and_then(Value::as_str)
+                .or_else(|| args.get("idempotencyKey").and_then(Value::as_str));
+            ctx.adapters
+                .write_object(&uri, &key, &value, idempotency_key)?;
+            Ok(Value::Null)
+        }
+        "tf:security/sign-data@1" => {
+            let key = args
+                .get("key")
+                .or_else(|| args.get("key_ref"))
+                .or_else(|| args.get("keyId"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = stringify_payload(args.get("payload").or_else(|| args.get("value")));
+            let _sig = ctx.adapters.sign(&key, payload.as_bytes())?;
+            Ok(Value::Null)
+        }
+        "tf:security/verify-signature@1" => {
+            let key = args
+                .get("key")
+                .or_else(|| args.get("key_ref"))
+                .or_else(|| args.get("keyId"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = stringify_payload(args.get("payload").or_else(|| args.get("value")));
+            let signature = args
+                .get("signature")
+                .or_else(|| args.get("sig"))
+                .and_then(|value| match value {
+                    Value::String(s) => Some(s.as_bytes().to_vec()),
+                    Value::Array(items) => {
+                        let bytes: Vec<u8> = items
+                            .iter()
+                            .filter_map(|item| item.as_u64())
+                            .map(|byte| byte as u8)
+                            .collect();
+                        Some(bytes)
+                    }
+                    _ => None,
+                })
+                .unwrap_or_default();
+            let ok = ctx
+                .adapters
+                .verify(&key, payload.as_bytes(), &signature)?;
+            if !ok {
+                return Err(anyhow!("signature verification failed"));
+            }
+            Ok(Value::Null)
+        }
+        "tf:information/hash@1" => {
+            let target = args
+                .get("value")
+                .unwrap_or(&Value::Null);
+            let canonical = stable_string(target);
+            let _digest = ctx.adapters.hash(canonical.as_bytes())?;
+            Ok(Value::Null)
+        }
+        _ => Ok(Value::Null),
+    }
+}
+
+fn effect_from_node(node: &Value, prim_id: &str) -> String {
+    if let Some(Value::String(effect)) = node.get("meta").and_then(|meta| meta.get("effect")).and_then(Value::as_str) {
+        return effect.to_string();
+    }
+    if let Some(Value::Array(effects)) = node.get("meta").and_then(|meta| meta.get("effects")).and_then(Value::as_array) {
+        if let Some(effect) = effects.iter().find_map(Value::as_str) {
+            return effect.to_string();
+        }
+    }
+    let runtime_effect = effect_for(prim_id);
+    if !runtime_effect.is_empty() {
+        return runtime_effect.to_string();
+    }
+    String::new()
+}
+
+fn normalize_args(value: Option<&Value>) -> Map<String, Value> {
+    match value {
+        Some(Value::Object(map)) => map.clone(),
+        _ => Map::new(),
+    }
+}
+
+fn canonical_prim(name: &str) -> &'static str {
+    match name {
+        "tf:network/publish@1" | "publish" => "tf:network/publish@1",
+        "tf:observability/emit-metric@1" | "emit-metric" => "tf:observability/emit-metric@1",
+        "tf:resource/write-object@1" | "write-object" => "tf:resource/write-object@1",
+        "tf:security/sign-data@1" | "sign-data" => "tf:security/sign-data@1",
+        "tf:security/verify-signature@1" | "verify-signature" => "tf:security/verify-signature@1",
+        "tf:information/hash@1" | "hash" => "tf:information/hash@1",
+        other => other,
+    }
+}
+
+fn effect_for(prim: &str) -> &'static str {
+    match prim {
+        "tf:network/publish@1" => "Network.Out",
+        "tf:observability/emit-metric@1" => "Observability",
+        "tf:resource/write-object@1" => "Storage.Write",
+        "tf:security/sign-data@1" => "Crypto",
+        "tf:security/verify-signature@1" => "Crypto",
+        "tf:information/hash@1" => "Crypto",
+        _ => "",
+    }
+}
+
+fn stringify_payload(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(text)) => text.to_string(),
+        Some(other) => stable_string(other),
+        None => String::new(),
+    }
+}
+
+fn stable_string(value: &Value) -> String {
+    let canonical = canonical_value(value);
+    serde_json::to_string(&canonical).unwrap_or_else(|_| "".to_string())
+}
+
+fn canonical_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => {
+            let mapped: Vec<Value> = items.iter().map(canonical_value).collect();
+            Value::Array(mapped)
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let mut out = Map::new();
+            for (key, value) in entries {
+                out.insert(key.clone(), canonical_value(value));
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+struct Clock {
+    base: i64,
+    counter: i64,
+}
+
+impl Clock {
+    fn new() -> Self {
+        Self {
+            base: CLOCK_START_MS,
+            counter: 0,
+        }
+    }
+
+    fn next(&mut self) -> i64 {
+        let ts = self.base + self.counter;
+        self.counter += 1;
+        ts
+    }
+}
+`;
+}
+
+function renderRunRs(packageName) {
+  const crateIdent = String(packageName || '').replace(/-/g, '_') || 'tf_generated';
+  return `use std::{
+    env,
+    fs,
+    io::{self, Write},
+    path::PathBuf,
+};
+
+use anyhow::{anyhow, Context, Result};
+use ${crateIdent}::{adapters::InMemoryAdapters, pipeline};
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("error: {err:?}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let mut ir_path: Option<PathBuf> = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--ir" => {
+                let value = args.next().context("--ir requires a value")?;
+                ir_path = Some(PathBuf::from(value));
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            other => return Err(anyhow!("unexpected argument: {other}")),
+        }
+    }
+
+    let mut adapters = InMemoryAdapters::new();
+    let events = if let Some(path) = ir_path {
+        let data = fs::read_to_string(&path).context("reading IR file")?;
+        let ir: serde_json::Value = serde_json::from_str(&data).context("parsing IR JSON")?;
+        pipeline::run_with_ir(&ir, &mut adapters)?
     } else {
-      steps.push({ prim: value.prim, traitName: null });
+        pipeline::run_pipeline(&mut adapters)?
+    };
+
+    write_trace(&events)
+}
+
+fn write_trace(events: &[pipeline::TraceEvent]) -> Result<()> {
+    let trace_path = env::var("TF_TRACE_PATH").ok().map(PathBuf::from);
+    if let Some(path) = trace_path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).context("creating trace directory")?;
+        }
+        let mut file = fs::File::create(&path).context("creating trace file")?;
+        for event in events {
+            serde_json::to_writer(&mut file, event).context("serializing trace event")?;
+            file.write_all(b"\n").context("writing newline")?;
+        }
+        return Ok(());
+    }
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    for event in events {
+        serde_json::to_writer(&mut handle, event).context("serializing trace event")?;
+        handle.write_all(b"\n").context("writing newline")?;
+    }
+    Ok(())
+}
+
+fn print_usage() {
+    eprintln!("Usage: run [--ir <path>]");
+}
+`;
+}
+
+function canonicalValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalValue(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const out = {};
+    for (const [key, val] of entries) {
+      out[key] = canonicalValue(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+function renderIrJson(ir) {
+  const canonical = canonicalValue(ir);
+  return `${JSON.stringify(canonical, null, 2)}\n`;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const irPath = args[0];
+  let outDir = null;
+  let packageName = null;
+
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-o' || arg === '--out' || arg === '--out-dir') {
+      i += 1;
+      outDir = args[i];
+    } else if (arg === '--package-name') {
+      i += 1;
+      packageName = args[i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
     }
   }
 
-  if (Array.isArray(value.children)) {
-    for (const child of value.children) {
-      collectPrimitives(child, traits, steps);
-    }
+  if (!irPath) {
+    throw new Error('IR path is required');
+  }
+  if (!outDir) {
+    throw new Error('Output directory required via -o or --out');
   }
 
-  const keys = Object.keys(value)
-    .filter((key) => key !== 'children')
-    .sort();
-
-  for (const key of keys) {
-    collectPrimitives(value[key], traits, steps);
-  }
-}
-
-function traitForPrimitive(name) {
-  const base = primitiveBase(name).toLowerCase();
-  return TRAITS.find((trait) => trait.keywords.includes(base)) ?? null;
-}
-
-function primitiveBase(name) {
-  const withoutVersion = String(name).split('@')[0] ?? String(name);
-  let candidate = withoutVersion;
-  for (const delimiter of ['/', '.', ':']) {
-    const index = candidate.lastIndexOf(delimiter);
-    if (index !== -1) {
-      candidate = candidate.slice(index + 1);
-    }
-  }
-  return candidate;
-}
-
-function formatStepComment(step) {
-  if (step.traitName) {
-    return `// Prim: ${step.prim} (requires ${step.traitName})`;
-  }
-  return `// Prim: ${step.prim}`;
+  await generateCrateFromPath(irPath, outDir, packageName);
+  console.log(`wrote ${resolve(outDir)}`);
 }
 
 function printUsage() {
-  console.log('Usage: node scripts/generate-rs.mjs <ir.json> -o <output dir>');
+  console.log('Usage: node scripts/generate-rs.mjs <ir.json> -o <output dir> [--package-name <name>]');
 }
 
-main().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  process.exit(1);
-});
+const modulePath = fileURLToPath(new URL(import.meta.url));
+if (process.argv[1] === modulePath) {
+  main().catch((err) => {
+    console.error(err?.stack || err?.message || String(err));
+    process.exitCode = 1;
+  });
+}

--- a/tests/codegen-rs.test.mjs
+++ b/tests/codegen-rs.test.mjs
@@ -8,6 +8,7 @@ import { spawnSync } from 'node:child_process';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const IR_PATH = path.join(ROOT, 'out/0.4/ir/signing.ir.json');
 const OUT_DIR = path.join(ROOT, 'out/0.4/codegen-rs/signing');
+const PARITY_REPORT = path.join(ROOT, 'out/0.4/parity/ts-rs/report.json');
 
 function ensureSigningIr() {
   if (fs.existsSync(IR_PATH)) return;
@@ -26,9 +27,12 @@ function ensureSigningIr() {
 }
 
 function runGenerator() {
-  return spawnSync(process.execPath, ['scripts/generate-rs.mjs', IR_PATH, '-o', OUT_DIR], {
+  const env = { ...process.env };
+  delete env.LOCAL_RUST;
+  return spawnSync(process.execPath, ['scripts/generate-rs-run.mjs', IR_PATH, '-o', OUT_DIR], {
     cwd: ROOT,
     stdio: 'inherit',
+    env,
   });
 }
 
@@ -46,18 +50,25 @@ test('rust codegen emits deterministic scaffold', () => {
 
   const cargoPath = path.join(OUT_DIR, 'Cargo.toml');
   const pipelinePath = path.join(OUT_DIR, 'src', 'pipeline.rs');
+  const adaptersPath = path.join(OUT_DIR, 'src', 'adapters.rs');
+  const runPath = path.join(OUT_DIR, 'src', 'run.rs');
+  const irJsonPath = path.join(OUT_DIR, 'src', 'ir.json');
 
   assert.ok(fs.existsSync(cargoPath), 'Cargo.toml should exist');
   assert.ok(fs.existsSync(pipelinePath), 'pipeline.rs should exist');
+  assert.ok(fs.existsSync(adaptersPath), 'adapters.rs should exist');
+  assert.ok(fs.existsSync(runPath), 'run.rs should exist');
+  assert.ok(fs.existsSync(irJsonPath), 'ir.json should exist');
 
   const first = {
     cargo: fs.readFileSync(cargoPath, 'utf8'),
     pipe: fs.readFileSync(pipelinePath, 'utf8'),
+    adapters: fs.readFileSync(adaptersPath, 'utf8'),
+    run: fs.readFileSync(runPath, 'utf8'),
+    ir: fs.readFileSync(irJsonPath, 'utf8'),
   };
 
-  // pipeline function and trait bound presence (signing → Crypto)
   assert.ok(first.pipe.includes('pub fn run_pipeline'), 'pipeline should expose run_pipeline');
-  assert.ok(first.pipe.includes('Crypto'), 'signing flow should require Crypto trait');
 
   // second generate (determinism)
   const secondRun = runGenerator();
@@ -66,10 +77,16 @@ test('rust codegen emits deterministic scaffold', () => {
   const second = {
     cargo: fs.readFileSync(cargoPath, 'utf8'),
     pipe: fs.readFileSync(pipelinePath, 'utf8'),
+    adapters: fs.readFileSync(adaptersPath, 'utf8'),
+    run: fs.readFileSync(runPath, 'utf8'),
+    ir: fs.readFileSync(irJsonPath, 'utf8'),
   };
 
   assert.equal(first.cargo, second.cargo, 'Cargo.toml must be byte-identical');
   assert.equal(first.pipe, second.pipe, 'pipeline.rs must be byte-identical');
+  assert.equal(first.adapters, second.adapters, 'adapters.rs must be byte-identical');
+  assert.equal(first.run, second.run, 'run.rs must be byte-identical');
+  assert.equal(first.ir, second.ir, 'ir.json must be byte-identical');
 
   // optional local cargo build (not required in CI)
   if (process.env.LOCAL_RUST) {
@@ -77,3 +94,23 @@ test('rust codegen emits deterministic scaffold', () => {
     assert.equal(result.status, 0, 'cargo build should succeed locally');
   }
 });
+
+test(
+  'cross parity matches TypeScript trace when LOCAL_RUST=1',
+  { skip: process.env.LOCAL_RUST !== '1' },
+  () => {
+    const result = spawnSync(
+      process.execPath,
+      ['scripts/cross-parity-ts-rs.mjs', 'examples/flows/run_publish.tf'],
+      {
+        cwd: ROOT,
+        stdio: 'inherit',
+        env: { ...process.env, LOCAL_RUST: '1' },
+      },
+    );
+    assert.equal(result.status, 0, 'cross parity script should succeed');
+    assert.ok(fs.existsSync(PARITY_REPORT), 'parity report should exist');
+    const report = JSON.parse(fs.readFileSync(PARITY_REPORT, 'utf8'));
+    assert.equal(report.equal, true, 'expected parity to hold when LOCAL_RUST=1');
+  },
+);


### PR DESCRIPTION
## Summary
- expand the Rust code generator to emit adapters, pipeline, run binary, and baked IR artifacts for runnable crates
- add helper scripts for deterministic crate generation plus optional cargo execution and cross-runtime trace parity reporting
- document the Rust workflow and extend tests to cover deterministic output and opt-in TS↔Rust parity validation

## Testing
- node --test tests/codegen-rs.test.mjs
- pnpm -w -r build *(fails: adapter-legal-ts build requires local installation assets)*
- pnpm -w -r test *(fails: coverage generator vitest cannot resolve @tf-lang/utils prior to workspace build)*

------
https://chatgpt.com/codex/tasks/task_e_68d071eeb31c83209125c9624f3147ca