### PR TITLE
Add repo-wide audit tooling and CI surface

### DIFF
--- a/.github/workflows/l0-audit.yml
+++ b/.github/workflows/l0-audit.yml
@@ -3,6 +3,10 @@ name: l0-audit
 on:
   pull_request:
 
+concurrency:
+  group: l0-audit-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: write

--- a/.github/workflows/l0-audit.yml
+++ b/.github/workflows/l0-audit.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   audit:
@@ -22,6 +23,9 @@ jobs:
       - run: pnpm run a1
       - run: pnpm -w -r build
       - run: node scripts/audit/run.mjs
+      - name: Print summary
+        if: always()
+        run: node -e "const r=require('fs').readFileSync('out/0.4/audit/report.json','utf8'); const j=JSON.parse(r); console.log('errors=%d warnings=%d ok=%s', j.summary?.errors||0, j.summary?.warnings||0, !!j.ok)"
       - name: Upload audit report
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/l0-audit.yml
+++ b/.github/workflows/l0-audit.yml
@@ -1,0 +1,30 @@
+name: l0-audit
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: L0 audit sweep
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: '20'
+          install: 'true'
+          frozen: 'true'
+      - run: pnpm run a0
+      - run: pnpm run a1
+      - run: pnpm -w -r build
+      - run: node scripts/audit/run.mjs
+      - name: Upload audit report
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: l0-audit-report
+          path: out/0.4/audit/report.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm run --recursive build",
     "preinstall": "corepack enable pnpm",
     "check:fixtures": "tsx .codex/scripts/check-fixtures-json.ts",
+    "audit": "node scripts/audit/run.mjs",
     "t5:build": "pnpm -w -r build",
     "t5:test": "pnpm -w -r test",
     "t5:run": "node scripts/t5-run.mjs",

--- a/scripts/audit/check-catalog.mjs
+++ b/scripts/audit/check-catalog.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// scripts/audit/check-catalog.mjs
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { CANONICAL_EFFECT_FAMILIES, normalizeFamily } from '../../packages/tf-l0-check/src/effect-lattice.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+
+async function loadJson(relPath) {
+  const absPath = path.join(ROOT, relPath);
+  try {
+    const raw = await readFile(absPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function effectRecognized(effect) {
+  if (typeof effect !== 'string') return false;
+  const trimmed = effect.trim();
+  if (trimmed.length === 0) return false;
+  const normalized = normalizeFamily(trimmed);
+  if (!CANONICAL_EFFECT_FAMILIES.includes(normalized)) {
+    return false;
+  }
+  if (normalized === 'Pure' && trimmed.toLowerCase() !== 'pure') {
+    return false;
+  }
+  return true;
+}
+
+export async function run() {
+  const catalog = (await loadJson('packages/tf-l0-spec/spec/catalog.json')) || {};
+  const laws = (await loadJson('packages/tf-l0-spec/spec/laws.json')) || {};
+
+  const primitives = Array.isArray(catalog.primitives) ? catalog.primitives : [];
+  const primitiveMap = new Map();
+  for (const primitive of primitives) {
+    if (primitive && typeof primitive === 'object' && typeof primitive.id === 'string') {
+      primitiveMap.set(primitive.id, primitive);
+    }
+  }
+
+  const primsMissingEffects = [];
+  const effectsUnrecognized = [];
+
+  for (const primitive of primitives) {
+    if (!primitive || typeof primitive !== 'object') continue;
+    const id = typeof primitive.id === 'string' ? primitive.id : '(unknown)';
+    const effects = Array.isArray(primitive.effects) ? primitive.effects : [];
+    if (effects.length === 0) {
+      primsMissingEffects.push(id);
+      continue;
+    }
+    for (const effect of effects) {
+      if (!effectRecognized(effect)) {
+        effectsUnrecognized.push(`${id}:${String(effect)}`);
+      }
+    }
+  }
+
+  const lawsList = Array.isArray(laws.laws) ? laws.laws : [];
+  const lawsRefMissingPrims = [];
+  for (const law of lawsList) {
+    if (!law || typeof law !== 'object') continue;
+    const appliesTo = Array.isArray(law.applies_to) ? law.applies_to : [];
+    const lawId = typeof law.id === 'string' ? law.id : 'law:unknown';
+    for (const entry of appliesTo) {
+      if (typeof entry !== 'string') continue;
+      if (!entry.startsWith('tf:')) continue;
+      if (!primitiveMap.has(entry)) {
+        lawsRefMissingPrims.push(`${lawId} -> ${entry}`);
+      }
+    }
+  }
+
+  effectsUnrecognized.sort();
+  primsMissingEffects.sort();
+  lawsRefMissingPrims.sort();
+
+  const ok =
+    effectsUnrecognized.length === 0 &&
+    primsMissingEffects.length === 0 &&
+    lawsRefMissingPrims.length === 0;
+
+  return {
+    ok,
+    effects_unrecognized: effectsUnrecognized,
+    prims_missing_effects: primsMissingEffects,
+    laws_ref_missing_prims: lawsRefMissingPrims
+  };
+}
+
+async function main() {
+  const result = await run();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const isCli = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`audit:check-catalog failed: ${err?.stack || err}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/audit/check-determinism.mjs
+++ b/scripts/audit/check-determinism.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// scripts/audit/check-determinism.mjs
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'out', '.pnpm', 'dist']);
+
+async function walk(dir, collector) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const absPath = path.join(dir, entry.name);
+    const rel = path.relative(ROOT, absPath);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      await walk(absPath, collector);
+    } else if (entry.isFile()) {
+      collector(path.posix.join(...rel.split(path.sep)));
+    }
+  }
+}
+
+function normalizeRel(relPath) {
+  return relPath.split(path.sep).join('/');
+}
+
+async function gatherWorkflowScripts() {
+  const workflowDir = path.join(ROOT, '.github/workflows');
+  const scripts = new Set();
+  try {
+    const entries = await readdir(workflowDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith('.yml') && !entry.name.endsWith('.yaml')) continue;
+      const rel = normalizeRel(path.join('.github/workflows', entry.name));
+      const absPath = path.join(ROOT, rel);
+      const content = await readFile(absPath, 'utf8');
+      const pattern = /(?:^|[\s"'`])(\.\/scripts\/[0-9A-Za-z._\/-]+)/g;
+      for (const match of content.matchAll(pattern)) {
+        const raw = match[1];
+        if (!raw.startsWith('./scripts/')) continue;
+        const cleaned = raw.slice(2);
+        scripts.add(cleaned);
+      }
+    }
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return scripts;
+    }
+    throw err;
+  }
+  return scripts;
+}
+
+async function fileText(relPath) {
+  const absPath = path.join(ROOT, relPath);
+  return readFile(absPath, 'utf8');
+}
+
+function hasTrailingNewline(text) {
+  return text.endsWith('\n');
+}
+
+function hasCRLF(text) {
+  return text.includes('\r\n');
+}
+
+async function ensureExecutable(relPath) {
+  try {
+    const info = await stat(path.join(ROOT, relPath));
+    return (info.mode & 0o111) !== 0;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function run() {
+  const scriptFiles = new Set();
+  const jsonLikeFiles = new Set();
+  const smtFiles = new Set();
+  const alsFiles = new Set();
+  const binFiles = new Set();
+
+  await walk(ROOT, (relPathRaw) => {
+    const relPath = normalizeRel(relPathRaw);
+    if (relPath.startsWith('out/')) return;
+    if (relPath.startsWith('node_modules/')) return;
+    if (relPath.startsWith('.git/')) return;
+    if (relPath.startsWith('.pnpm/')) return;
+    if (relPath.startsWith('dist/')) return;
+    if (relPath.startsWith('.codex/')) return;
+    if (relPath.startsWith('tmp/')) return;
+
+    if (relPath.startsWith('scripts/') && relPath.endsWith('.mjs')) {
+      scriptFiles.add(relPath);
+    }
+    if (relPath.endsWith('.json')) {
+      jsonLikeFiles.add(relPath);
+    }
+    if (relPath.endsWith('.smt2')) {
+      smtFiles.add(relPath);
+    }
+    if (relPath.endsWith('.als')) {
+      alsFiles.add(relPath);
+    }
+    if (
+      relPath.startsWith('packages/') &&
+      relPath.includes('/bin/') &&
+      relPath.endsWith('.mjs')
+    ) {
+      binFiles.add(relPath);
+    }
+  });
+
+  const workflowScripts = await gatherWorkflowScripts();
+  const issues = [];
+
+  for (const relPath of Array.from(scriptFiles).sort()) {
+    try {
+      const text = await fileText(relPath);
+      if (!hasTrailingNewline(text)) {
+        issues.push({ path: relPath, issue: 'missing_newline' });
+      }
+    } catch (err) {
+      issues.push({ path: relPath, issue: 'missing_newline', error: err?.message || String(err) });
+    }
+  }
+
+  const jsonTargets = new Set([...jsonLikeFiles, ...smtFiles, ...alsFiles]);
+  for (const relPath of Array.from(jsonTargets).sort()) {
+    try {
+      const text = await fileText(relPath);
+      if (!hasTrailingNewline(text)) {
+        issues.push({ path: relPath, issue: 'missing_newline' });
+      }
+      if (hasCRLF(text)) {
+        issues.push({ path: relPath, issue: 'has_crlf' });
+      }
+    } catch (err) {
+      issues.push({ path: relPath, issue: 'missing_newline', error: err?.message || String(err) });
+    }
+  }
+
+  for (const relPath of Array.from(binFiles).sort()) {
+    const executable = await ensureExecutable(relPath);
+    if (!executable) {
+      issues.push({ path: relPath, issue: 'missing_exec' });
+    }
+  }
+
+  for (const relPath of Array.from(workflowScripts).sort()) {
+    const absPath = path.join(ROOT, relPath);
+    let text = '';
+    try {
+      text = await readFile(absPath, 'utf8');
+    } catch (err) {
+      issues.push({ path: relPath, issue: 'missing_exec', workflow: true, error: err?.message || String(err) });
+      continue;
+    }
+    const executable = await ensureExecutable(relPath);
+    if (!executable) {
+      issues.push({ path: relPath, issue: 'missing_exec', workflow: true });
+    }
+    if (!text.startsWith('#!')) {
+      issues.push({ path: relPath, issue: 'missing_shebang', workflow: true });
+    }
+    if (!hasTrailingNewline(text)) {
+      issues.push({ path: relPath, issue: 'missing_newline', workflow: true });
+    }
+  }
+
+  const seen = new Set();
+  const unique = [];
+  for (const issue of issues) {
+    const key = `${issue.path}:${issue.issue}:${issue.workflow ? 1 : 0}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(issue);
+  }
+
+  unique.sort((a, b) => {
+    if (a.path === b.path) {
+      return a.issue.localeCompare(b.issue);
+    }
+    return a.path.localeCompare(b.path);
+  });
+
+  const ok = unique.length === 0;
+  return { ok, issues: unique };
+}
+
+async function main() {
+  const result = await run();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const isCli = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`audit:check-determinism failed: ${err?.stack || err}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/audit/check-determinism.mjs
+++ b/scripts/audit/check-determinism.mjs
@@ -93,7 +93,6 @@ export async function run() {
     if (relPath.startsWith('.pnpm/')) return;
     if (relPath.startsWith('dist/')) return;
     if (relPath.startsWith('.codex/')) return;
-    if (relPath.startsWith('tmp/')) return;
 
     if (relPath.startsWith('scripts/') && relPath.endsWith('.mjs')) {
       scriptFiles.add(relPath);

--- a/scripts/audit/check-links.mjs
+++ b/scripts/audit/check-links.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// scripts/audit/check-links.mjs
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+
+async function collectMarkdownFiles() {
+  const docsDir = path.join(ROOT, 'docs');
+  const files = [];
+
+  async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absPath);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        files.push(path.relative(ROOT, absPath).split(path.sep).join('/'));
+      }
+    }
+  }
+
+  try {
+    await walk(docsDir);
+  } catch (err) {
+    if (!(err && err.code === 'ENOENT')) {
+      throw err;
+    }
+  }
+
+  files.sort();
+  return files;
+}
+
+function extractLinks(markdown) {
+  const links = [];
+  const pattern = /!?(\[[^\]]*\])\(([^)]+)\)/g;
+  for (const match of markdown.matchAll(pattern)) {
+    const hrefWithMeta = match[2].trim();
+    const spaceIndex = hrefWithMeta.indexOf(' ');
+    const href = spaceIndex === -1 ? hrefWithMeta : hrefWithMeta.slice(0, spaceIndex);
+    links.push(href);
+  }
+  return links;
+}
+
+function isRelativeLink(href) {
+  if (!href) return false;
+  if (href.startsWith('#')) return false;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) return false;
+  return true;
+}
+
+async function existsRelative(baseFile, href) {
+  const anchorIndex = href.indexOf('#');
+  const target = anchorIndex === -1 ? href : href.slice(0, anchorIndex);
+  if (!target) {
+    return true;
+  }
+  let decoded = target;
+  try {
+    decoded = decodeURI(target);
+  } catch (err) {
+    decoded = target;
+  }
+  let resolved;
+  if (decoded.startsWith('/')) {
+    resolved = path.join(ROOT, decoded.replace(/^\/+/, ''));
+  } else {
+    const baseDir = path.dirname(path.join(ROOT, baseFile));
+    resolved = path.resolve(baseDir, decoded);
+  }
+  try {
+    await stat(resolved);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function run() {
+  const markdownFiles = await collectMarkdownFiles();
+  const targets = new Set(['README.md', ...markdownFiles]);
+
+  const broken = [];
+  const seen = new Set();
+
+  for (const relPath of Array.from(targets).sort()) {
+    const absPath = path.join(ROOT, relPath);
+    let content;
+    try {
+      content = await readFile(absPath, 'utf8');
+    } catch (err) {
+      if (relPath === 'README.md') {
+        throw err;
+      }
+      continue;
+    }
+    for (const href of extractLinks(content)) {
+      if (!isRelativeLink(href)) continue;
+      if (await existsRelative(relPath, href)) continue;
+      const key = `${relPath}::${href}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      broken.push({ from: relPath, href });
+    }
+  }
+
+  broken.sort((a, b) => {
+    if (a.from === b.from) {
+      return a.href.localeCompare(b.href);
+    }
+    return a.from.localeCompare(b.from);
+  });
+
+  const ok = broken.length === 0;
+  return { ok, broken };
+}
+
+async function main() {
+  const result = await run();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const isCli = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`audit:check-links failed: ${err?.stack || err}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/audit/check-schemas.mjs
+++ b/scripts/audit/check-schemas.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// scripts/audit/check-schemas.mjs
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const SCHEMA_DIR = path.join(ROOT, 'schemas');
+
+async function loadSchemaFiles() {
+  const entries = await readdir(SCHEMA_DIR, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => entry.name)
+    .sort();
+
+  const loaded = [];
+  const results = [];
+  for (const name of files) {
+    const relPath = path.posix.join('schemas', name);
+    const absPath = path.join(SCHEMA_DIR, name);
+    try {
+      const raw = await readFile(absPath, 'utf8');
+      const schema = JSON.parse(raw);
+      loaded.push({ name, schema, relPath });
+    } catch (err) {
+      const message = err?.message ? String(err.message) : String(err);
+      results.push({ file: relPath, ok: false, errors: [`parse_error: ${message}`] });
+    }
+  }
+
+  return { loaded, results };
+}
+
+function extractErrors(err) {
+  if (!err) return [];
+  const messages = [];
+  if (Array.isArray(err.errors)) {
+    for (const detail of err.errors) {
+      if (detail && typeof detail === 'object') {
+        const instancePath = detail.instancePath || detail.dataPath || '';
+        const keyword = detail.keyword ? ` (${detail.keyword})` : '';
+        const base = detail.message ? String(detail.message) : JSON.stringify(detail);
+        messages.push(`${instancePath || '<root>'}${keyword}: ${base}`);
+      } else {
+        messages.push(String(detail));
+      }
+    }
+  }
+  if (err.message) {
+    messages.push(String(err.message));
+  }
+  return messages.length > 0 ? messages : [String(err)];
+}
+
+export async function run() {
+  const { loaded, results } = await loadSchemaFiles();
+
+  for (const { name, schema, relPath } of loaded) {
+    const ajv = new Ajv2020({ strict: true, allErrors: true });
+    let failed = false;
+    for (const { schema: otherSchema, name: otherName } of loaded) {
+      const key = otherSchema && typeof otherSchema === 'object' && otherSchema.$id ? otherSchema.$id : otherName;
+      try {
+        ajv.addSchema(otherSchema, key);
+      } catch (err) {
+        // addSchema may throw if duplicate IDs; capture as compile error below
+        results.push({
+          file: relPath,
+          ok: false,
+          errors: [`add_schema_failed (${key}): ${err?.message || err}`]
+        });
+        failed = true;
+        break;
+      }
+    }
+    if (failed || results.some((entry) => entry.file === relPath && entry.ok === false)) {
+      continue;
+    }
+    try {
+      const identifier = schema && typeof schema === 'object' && schema.$id ? schema.$id : name;
+      const validate = ajv.getSchema(identifier) || ajv.compile(schema);
+      if (typeof validate !== 'function') {
+        results.push({ file: relPath, ok: false, errors: ['compile_failed: validator not created'] });
+      } else {
+        results.push({ file: relPath, ok: true });
+      }
+    } catch (err) {
+      const errors = extractErrors(err);
+      results.push({ file: relPath, ok: false, errors });
+    }
+  }
+
+  // Deduplicate entries when addSchema failure already pushed an error
+  const byFile = new Map();
+  for (const entry of results) {
+    const current = byFile.get(entry.file);
+    if (!current) {
+      byFile.set(entry.file, entry);
+      continue;
+    }
+    if (!current.ok) {
+      // keep first failure
+      continue;
+    }
+    byFile.set(entry.file, entry);
+  }
+
+  const entries = Array.from(byFile.values()).sort((a, b) => a.file.localeCompare(b.file));
+  const ok = entries.every((entry) => entry.ok);
+  return { ok, entries };
+}
+
+async function main() {
+  const result = await run();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const isCli = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`audit:check-schemas failed: ${err?.stack || err}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/audit/run.mjs
+++ b/scripts/audit/run.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// scripts/audit/run.mjs
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { run as checkSchemas } from './check-schemas.mjs';
+import { run as checkDeterminism } from './check-determinism.mjs';
+import { run as checkLinks } from './check-links.mjs';
+import { run as checkCatalog } from './check-catalog.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const REPORT_DIR = path.join(ROOT, 'out/0.4/audit');
+const REPORT_PATH = path.join(REPORT_DIR, 'report.json');
+
+function accumulateSummary(schemas, determinism, links, catalog) {
+  let errors = 0;
+  let warnings = 0;
+
+  const schemaFailures = schemas.entries.filter((entry) => !entry.ok).length;
+  errors += schemaFailures;
+
+  const brokenLinks = links.broken.length;
+  errors += brokenLinks;
+
+  for (const issue of determinism.issues) {
+    if (issue.issue === 'has_crlf') {
+      errors += 1;
+    } else if (issue.issue === 'missing_exec') {
+      if (issue.workflow) {
+        errors += 1;
+      } else {
+        warnings += 1;
+      }
+    } else if (issue.issue === 'missing_shebang') {
+      if (issue.workflow) {
+        errors += 1;
+      } else {
+        warnings += 1;
+      }
+    } else if (issue.issue === 'missing_newline') {
+      warnings += 1;
+    }
+  }
+
+  errors += catalog.prims_missing_effects.length;
+  warnings += catalog.effects_unrecognized.length;
+  errors += catalog.laws_ref_missing_prims.length;
+
+  return { errors, warnings };
+}
+
+export async function run() {
+  const schemas = await checkSchemas();
+  const determinism = await checkDeterminism();
+  const links = await checkLinks();
+  const catalog = await checkCatalog();
+
+  const summary = accumulateSummary(schemas, determinism, links, catalog);
+  const ok = summary.errors === 0;
+
+  const report = { ok, schemas, determinism, links, catalog, summary };
+
+  await mkdir(REPORT_DIR, { recursive: true });
+  await writeFile(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  const logLines = [
+    '=== Audit Summary ===',
+    `ok: ${ok}`,
+    `errors: ${summary.errors}`,
+    `warnings: ${summary.warnings}`,
+    `report: ${path.relative(ROOT, REPORT_PATH)}`
+  ];
+  for (const line of logLines) {
+    process.stdout.write(`${line}\n`);
+  }
+
+  return { report, path: REPORT_PATH };
+}
+
+async function main() {
+  await run();
+}
+
+const isCli = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (isCli) {
+  main().catch((err) => {
+    process.stderr.write(`audit:run failed: ${err?.stack || err}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, unlink, access, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const REPORT_PATH = path.join(ROOT, 'out/0.4/audit/report.json');
+
+async function fileExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+test('audit report is emitted deterministically', async () => {
+  await execFileAsync(process.execPath, ['scripts/audit/run.mjs'], { cwd: ROOT });
+  const first = await readFile(REPORT_PATH);
+  const report = JSON.parse(first);
+  assert.strictEqual(typeof report.ok, 'boolean');
+
+  await execFileAsync(process.execPath, ['scripts/audit/run.mjs'], { cwd: ROOT });
+  const second = await readFile(REPORT_PATH);
+  assert.ok(first.equals(second));
+});
+
+test('determinism check flags CRLF content', async () => {
+  const tempPath = path.join(ROOT, 'tests', 'tmp-crlf.json');
+  await writeFile(tempPath, '{\r\n}\r\n');
+  try {
+    const { run: runDeterminism } = await import('../scripts/audit/check-determinism.mjs');
+    const result = await runDeterminism();
+    const hit = result.issues.find((issue) => issue.path === 'tests/tmp-crlf.json' && issue.issue === 'has_crlf');
+    assert.ok(hit, 'expected CRLF issue to be reported');
+  } finally {
+    if (await fileExists(tempPath)) {
+      await unlink(tempPath);
+    }
+  }
+});

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile, unlink, access, writeFile } from 'node:fs/promises';
+import { readFile, unlink, access, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
@@ -33,12 +33,14 @@ test('audit report is emitted deterministically', async () => {
 });
 
 test('determinism check flags CRLF content', async () => {
-  const tempPath = path.join(ROOT, 'tests', 'tmp-crlf.json');
+  const tempDir = path.join(ROOT, 'tmp');
+  const tempPath = path.join(tempDir, 'audit-crlf.json');
+  await mkdir(tempDir, { recursive: true });
   await writeFile(tempPath, '{\r\n}\r\n');
   try {
     const { run: runDeterminism } = await import('../scripts/audit/check-determinism.mjs');
     const result = await runDeterminism();
-    const hit = result.issues.find((issue) => issue.path === 'tests/tmp-crlf.json' && issue.issue === 'has_crlf');
+    const hit = result.issues.find((issue) => issue.path === 'tmp/audit-crlf.json' && issue.issue === 'has_crlf');
     assert.ok(hit, 'expected CRLF issue to be reported');
   } finally {
     if (await fileExists(tempPath)) {


### PR DESCRIPTION
# T3 Oracles Epic — PR Report

> Fill all sections. CI will fail if required headings are missing.

## Summary
- Scope: Audit sweep groundwork
- Key outcomes in this PR:
  - [ ] Conservation oracle (TS/Rust) — N/A
  - [ ] Idempotence oracle (TS/Rust) — N/A
  - [ ] Transport oracle (TS/Rust) — N/A
  - [ ] Parity reports (equal = true) — N/A
  - [x] CI wiring + determinism re-run (added audit workflow and determinism checks)

## Evidence (artifacts)
- [ ] `out/t3/conservation/report.json`
- [ ] `out/t3/idempotence/report.json`
- [ ] `out/t3/transport/report.json`
- [ ] `out/t3/parity/conservation.json`
- [ ] `out/t3/parity/idempotence.json`
- [ ] `out/t3/parity/transport.json`
- Additional: `out/0.4/audit/report.json`

## Determinism & Seeds
- Repeats: 1
- Seeds: N/A
- Notes: New audit determinism check enforces newline/CRLF/shebang consistency and reports repo state.

## Tests & CI
- TS tests: passed 154 / failed 1 (`pnpm -w -r test`, existing failure in `tests/provenance-status-trace.test.mjs`)
- Rust tests: not run in this change
- CI jobs: Local `pnpm -w -r build`; new non-blocking `l0-audit` workflow surfaces audit report

## Implementation Notes
- ABI / paths unchanged? Y
- Runtime deps added? (**No**)
- Policy compliance: .js ESM suffixes, no deep imports, no `as any`, Rust panic-free

## Hurdles / Follow-ups
- Known gaps: Audit currently flags 37 errors (doc links, catalog references) and 32 warnings (newline hygiene) to be triaged separately.
- Suggested next steps: Address flagged documentation links and catalog coverage gaps so the audit can pass cleanly.

------
https://chatgpt.com/codex/tasks/task_e_68d081c1be6483208bc32c58bc753925