### PR TITLE
Add test metadata headers and runner scripts

### DIFF
--- a/crates/oracles/conservation/tests/oracle.meta
+++ b/crates/oracles/conservation/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=heavy
+deps=rust

--- a/crates/oracles/core/tests/core.meta
+++ b/crates/oracles/core/tests/core.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=heavy
+deps=rust

--- a/crates/oracles/determinism/tests/oracle.meta
+++ b/crates/oracles/determinism/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=infra
+area=oracles
+speed=heavy
+deps=rust

--- a/crates/oracles/idempotence/tests/oracle.meta
+++ b/crates/oracles/idempotence/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=heavy
+deps=rust

--- a/crates/oracles/transport/tests/oracle.meta
+++ b/crates/oracles/transport/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=heavy
+deps=rust

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "t5:rerun": "node scripts/t5-run.mjs --force",
     "t5:clean": "node -e \"require('fs').rmSync('out/t5',{recursive:true,force:true}); console.log('cleaned out/t5')\"",
     "t5:run:obsolete": "echo 'Use node scripts/t5-run.mjs (or t5:rerun) instead' && exit 1",
-    "test:workspace": "pnpm run --recursive test",
-    "test:l0": "node --test tests/*.test.mjs",
-    "test": "pnpm run test:workspace && pnpm run test:l0",
     "pilot:build-run": "node scripts/pilot-build-run.mjs",
     "a0": "node packages/tf-l0-spec/scripts/build-ids.mjs && node packages/tf-l0-spec/scripts/finalize-a0.mjs",
     "a1": "node packages/tf-l0-spec/scripts/build-catalog.mjs && node packages/tf-l0-spec/scripts/derive-effects.mjs && node packages/tf-l0-spec/scripts/build-laws.mjs && node packages/tf-l0-spec/scripts/finalize-a1.mjs",
@@ -56,7 +53,15 @@
     "policy:auth": "node packages/tf-compose/bin/tf-policy-auth.mjs",
     "policy:auth:samples": "node -e \"(async()=>{const {spawnSync}=require('node:child_process');const runs=[['ok','examples/flows/auth_ok.tf'],['wrong','examples/flows/auth_wrong_scope.tf'],['missing','examples/flows/auth_missing.tf']];for(const [label,file] of runs){const r=spawnSync('node',['packages/tf-compose/bin/tf-policy-auth.mjs','--','check',file],{stdio:'inherit'}); if(r.status!==0) console.error(`[auth smoke] ${label} -> nonzero (expected for wrong/missing)`);} process.exit(0)})();\"",
     "docs:gen": "node scripts/docgen/catalog.mjs && node scripts/docgen/dsl.mjs && node scripts/docgen/effects.mjs",
-    "docs:check": "node scripts/docgen/check.mjs"
+    "docs:check": "node scripts/docgen/check.mjs",
+    "test": "node scripts/test/run.mjs --kind product --kind infra --speed fast",
+    "test:product": "node scripts/test/run.mjs --kind product",
+    "test:infra": "node scripts/test/run.mjs --kind infra",
+    "test:proofs": "node scripts/test/run.mjs --kind proofs",
+    "test:parity": "node scripts/test/run.mjs --kind parity --allow-missing-deps",
+    "test:fast": "node scripts/test/run.mjs --speed fast",
+    "test:heavy": "node scripts/test/run.mjs --speed heavy --allow-missing-deps",
+    "tests:list": "node scripts/test/list.mjs && cat out/0.4/tests/available.json"
   },
   "devDependencies": {
     "typescript": "5.9.2",

--- a/packages/adapters/ts/execution/tests/execution.test.ts
+++ b/packages/adapters/ts/execution/tests/execution.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=adapters speed=fast deps=node
 import { readFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/coverage/generator/tests/coverage.test.ts
+++ b/packages/coverage/generator/tests/coverage.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=coverage speed=medium deps=node
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/explorer-test/claims-explorer.test.ts
+++ b/packages/explorer-test/claims-explorer.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=pages speed=fast deps=node
 import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';

--- a/packages/explorer-test/pages-workflow.test.ts
+++ b/packages/explorer-test/pages-workflow.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=pages speed=fast deps=node
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';

--- a/packages/explorer-test/test/source-label.test.ts
+++ b/packages/explorer-test/test/source-label.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=pages speed=fast deps=node
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 

--- a/packages/host-lite/test/c1.apply-persists.test.ts
+++ b/packages/host-lite/test/c1.apply-persists.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeHandler, createHost } from 'host-lite-ts';
 

--- a/packages/host-lite/test/c1.byte-determinism.test.ts
+++ b/packages/host-lite/test/c1.byte-determinism.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeRawHandler, makeHandler, createHost } from 'host-lite-ts';
 import { canonicalJsonBytes } from 'tf-lang-l0';

--- a/packages/host-lite/test/c1.http-400-404.test.ts
+++ b/packages/host-lite/test/c1.http-400-404.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeRawHandler, makeHandler, createHost } from 'host-lite-ts';
 import { canonicalJsonBytes } from 'tf-lang-l0';

--- a/packages/host-lite/test/c1.import-hygiene.test.ts
+++ b/packages/host-lite/test/c1.import-hygiene.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/packages/host-lite/test/c1.lru-multiworld.test.ts
+++ b/packages/host-lite/test/c1.lru-multiworld.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeHandler, createHost } from 'host-lite-ts';
 

--- a/packages/host-lite/test/c1.proofs-gating-count.test.ts
+++ b/packages/host-lite/test/c1.proofs-gating-count.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeRawHandler, makeHandler, createHost } from 'host-lite-ts';
 import { canonicalJsonBytes, blake3hex } from 'tf-lang-l0';

--- a/packages/mapper/trace2tags/tests/mapper.test.ts
+++ b/packages/mapper/trace2tags/tests/mapper.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=trace speed=fast deps=node
 import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/oracles-core-ts/tests/oracles.test.ts
+++ b/packages/oracles-core-ts/tests/oracles.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { describe, it, expect } from "vitest";
 import { equals, subsetOf, inRange, matchesRegex, nonEmpty } from "../src/index.js";
 import { MESSAGES } from "../src/messages.js";

--- a/packages/oracles/conservation/tests/oracle.spec.ts
+++ b/packages/oracles/conservation/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/oracles/core/tests/core.spec.ts
+++ b/packages/oracles/core/tests/core.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/oracles/determinism/tests/oracle.spec.ts
+++ b/packages/oracles/determinism/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=oracles speed=fast deps=node
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/oracles/idempotence/tests/oracle.spec.ts
+++ b/packages/oracles/idempotence/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/oracles/transport/tests/oracle.spec.ts
+++ b/packages/oracles/transport/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/pilot-core/tests/index.test.ts
+++ b/packages/pilot-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=pilot speed=medium deps=node
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/pilot-replay/tests/index.test.ts
+++ b/packages/pilot-replay/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=pilot speed=medium deps=node
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/pilot-risk/tests/index.test.ts
+++ b/packages/pilot-risk/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=pilot speed=medium deps=node
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/pilot-strategy/tests/index.test.ts
+++ b/packages/pilot-strategy/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=pilot speed=medium deps=node
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/tf-check/tests/trace.test.ts
+++ b/packages/tf-check/tests/trace.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { parseFilters } from '../src/filters.js';
 

--- a/packages/tf-check/tests/validator.test.ts
+++ b/packages/tf-check/tests/validator.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/tf-lang-l0-rs/tests/canon.meta
+++ b/packages/tf-lang-l0-rs/tests/canon.meta
@@ -1,0 +1,4 @@
+kind=product
+area=l0
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/laws.meta
+++ b/packages/tf-lang-l0-rs/tests/laws.meta
@@ -1,0 +1,4 @@
+kind=product
+area=l0
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/proof.meta
+++ b/packages/tf-lang-l0-rs/tests/proof.meta
@@ -1,0 +1,4 @@
+kind=proofs
+area=proofs
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/proof_dev.meta
+++ b/packages/tf-lang-l0-rs/tests/proof_dev.meta
@@ -1,0 +1,4 @@
+kind=proofs
+area=proofs
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/proof_vector.meta
+++ b/packages/tf-lang-l0-rs/tests/proof_vector.meta
@@ -1,0 +1,4 @@
+kind=proofs
+area=proofs
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/spec_adapter.meta
+++ b/packages/tf-lang-l0-rs/tests/spec_adapter.meta
@@ -1,0 +1,4 @@
+kind=product
+area=l0
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/vectors.meta
+++ b/packages/tf-lang-l0-rs/tests/vectors.meta
@@ -1,0 +1,4 @@
+kind=product
+area=l0
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-ts/tests/canon.test.ts
+++ b/packages/tf-lang-l0-ts/tests/canon.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=l0 speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { canonicalJsonBytes, blake3hex } from '../src/canon/index.js';
 

--- a/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=proofs speed=medium deps=node
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import type { Program } from '../src/model/bytecode.js';
 

--- a/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=proofs speed=medium deps=node
 import { describe, it, expect } from 'vitest';
 import type { Witness, Normalization, Transport, Refutation, Conservativity, ProofTag } from '../src/proof/index.js';
 

--- a/packages/tf-lang-l0-ts/tests/proof-vector.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-vector.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=proofs speed=medium deps=node
 import { it, expect, afterEach, beforeEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
+++ b/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=l0 speed=fast deps=node
 import { readFileSync, readdirSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";

--- a/packages/tf-lang-l0-ts/tests/vm.test.ts
+++ b/packages/tf-lang-l0-ts/tests/vm.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=l0 speed=fast deps=node
 
 import { describe, it, expect } from 'vitest';
 import { VM, Host } from '../src/vm/index.js';

--- a/packages/tf-plan-compare-core/tests/index.test.ts
+++ b/packages/tf-plan-compare-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { PlanNode } from '@tf-lang/tf-plan-core';
 import { ScaffoldPlan } from '@tf-lang/tf-plan-scaffold-core';

--- a/packages/tf-plan-compare-render/tests/index.test.ts
+++ b/packages/tf-plan-compare-render/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { CompareReport } from '@tf-lang/tf-plan-compare-core';
 import { renderHtml, renderMarkdown } from '../src/index.js';

--- a/packages/tf-plan-compare-render/tests/render.test.ts
+++ b/packages/tf-plan-compare-render/tests/render.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };
 import { enumeratePlan } from '@tf-lang/tf-plan-enum';

--- a/packages/tf-plan-compare-render/tests/xss.test.ts
+++ b/packages/tf-plan-compare-render/tests/xss.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import type { CompareReport } from '@tf-lang/tf-plan-compare-core';
 import { renderHtml, renderMarkdown } from '../src/index.js';

--- a/packages/tf-plan-compare/tests/index.test.ts
+++ b/packages/tf-plan-compare/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/tf-plan-core/tests/index.test.ts
+++ b/packages/tf-plan-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import {
   PLAN_GRAPH_VERSION,

--- a/packages/tf-plan-enum/tests/index.test.ts
+++ b/packages/tf-plan-enum/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { enumeratePlan } from '../src/index.js';
 import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };

--- a/packages/tf-plan-scaffold-core/tests/index.test.ts
+++ b/packages/tf-plan-scaffold-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { PlanNode } from '@tf-lang/tf-plan-core';
 import { createScaffoldPlan } from '../src/index.js';

--- a/packages/tf-plan-scaffold/tests/index.test.ts
+++ b/packages/tf-plan-scaffold/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/tf-plan-scoring/tests/index.test.ts
+++ b/packages/tf-plan-scoring/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { scorePlanNode } from '../src/index.js';
 

--- a/packages/tf-plan/tests/index.test.ts
+++ b/packages/tf-plan/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/packages/utils/tests/index.test.ts
+++ b/packages/utils/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=utils speed=fast deps=node
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/scripts/test/common.mjs
+++ b/scripts/test/common.mjs
@@ -1,0 +1,153 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const TEST_EXTENSIONS = new Set(['.test.mjs', '.test.js', '.test.ts', '.spec.ts']);
+const IGNORE_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'out',
+  'dist',
+  'build',
+  'target',
+  '.pnpm',
+  '.pnpm-store',
+  '.turbo',
+]);
+
+function parseKeyValueLine(line) {
+  const data = {};
+  const parts = line.trim().split(/\s+/);
+  for (const part of parts) {
+    if (!part) continue;
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq);
+    const value = part.slice(eq + 1);
+    data[key] = value;
+  }
+  return data;
+}
+
+function parseMetaContent(content) {
+  const data = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq);
+    const value = line.slice(eq + 1);
+    data[key] = value;
+  }
+  return data;
+}
+
+function normalizeDeps(value) {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(dep => dep.trim())
+    .filter(Boolean);
+}
+
+function normalizeEntry({ file, runner, meta, source, sidecar }) {
+  const { kind, area, speed, deps } = meta;
+  return {
+    file,
+    runner,
+    kind,
+    area,
+    speed,
+    deps: normalizeDeps(deps),
+    source,
+    sidecar,
+  };
+}
+
+async function readHeaderMeta(filePath) {
+  const data = await fs.readFile(filePath, 'utf8');
+  const firstLine = data.split(/\r?\n/, 1)[0] ?? '';
+  const match = firstLine.match(/^\/\/\s*@tf-test\s+(.*)$/);
+  if (!match) {
+    throw new Error(`Missing @tf-test header in ${filePath}`);
+  }
+  return parseKeyValueLine(match[1]);
+}
+
+async function discoverFromDirectory(dir, results) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (IGNORE_DIRS.has(entry.name)) continue;
+      await discoverFromDirectory(entryPath, results);
+      continue;
+    }
+    if (entry.isFile()) {
+      if (entry.name.endsWith('.meta')) {
+        results.metaFiles.push(entryPath);
+        continue;
+      }
+      for (const ext of TEST_EXTENSIONS) {
+        if (entry.name.endsWith(ext)) {
+          results.testFiles.push(entryPath);
+          break;
+        }
+      }
+    }
+  }
+}
+
+export async function discoverTests({ root = process.cwd() } = {}) {
+  const results = { testFiles: [], metaFiles: [] };
+  await discoverFromDirectory(root, results);
+
+  const entries = [];
+  for (const absolute of results.testFiles) {
+    const meta = await readHeaderMeta(absolute);
+    const relative = path.relative(root, absolute);
+    const ext = path.extname(absolute);
+    const runner = ext === '.mjs' || ext === '.js' ? 'node' : 'vitest';
+    entries.push(
+      normalizeEntry({
+        file: relative,
+        runner,
+        meta,
+        source: 'header',
+      })
+    );
+  }
+
+  for (const metaPath of results.metaFiles) {
+    const meta = parseMetaContent(await fs.readFile(metaPath, 'utf8'));
+    const base = metaPath.slice(0, -'.meta'.length);
+    const rsPath = base.endsWith('.rs') ? base : `${base}.rs`;
+    const absolute = rsPath;
+    if (!(await fileExists(absolute))) {
+      continue;
+    }
+    const relative = path.relative(root, absolute);
+    entries.push(
+      normalizeEntry({
+        file: relative,
+        runner: 'cargo',
+        meta,
+        source: 'sidecar',
+        sidecar: path.relative(root, metaPath),
+      })
+    );
+  }
+
+  entries.sort((a, b) => a.file.localeCompare(b.file));
+  return entries;
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    throw err;
+  }
+}

--- a/scripts/test/list.mjs
+++ b/scripts/test/list.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { discoverTests } from './common.mjs';
+
+const root = process.cwd();
+const outDir = path.join(root, 'out', '0.4', 'tests');
+const outFile = path.join(outDir, 'available.json');
+
+const tests = await discoverTests({ root });
+
+const manifest = {
+  tests: tests.map(test => ({
+    file: test.file,
+    kind: test.kind,
+    area: test.area,
+    speed: test.speed,
+    deps: test.deps,
+    runner: test.runner,
+  })),
+};
+
+await fs.mkdir(outDir, { recursive: true });
+await fs.writeFile(outFile, JSON.stringify(manifest, null, 2) + '\n');

--- a/scripts/test/run.mjs
+++ b/scripts/test/run.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { discoverTests } from './common.mjs';
+
+const root = process.cwd();
+const outDir = path.join(root, 'out', '0.4', 'tests');
+const manifestPath = path.join(outDir, 'manifest.json');
+
+const filters = { kind: [], area: [], speed: [], deps: [] };
+let allowMissingDeps = false;
+const availabilityCache = new Map();
+
+parseArgs(process.argv.slice(2));
+
+const tests = await discoverTests({ root });
+const selected = tests.filter(test => matchesFilters(test, filters));
+
+const runCounts = { node: 0, vitest: 0, cargo: 0 };
+const skipped = [];
+const failures = [];
+let ok = true;
+
+if (!selected.length) {
+  console.log('No tests selected.');
+}
+
+for (const test of selected) {
+  const missing = missingDependencies(test);
+  if (missing.length) {
+    const reason = `missing ${missing.join(', ')}`;
+    if (allowMissingDeps) {
+      skipped.push({ file: test.file, reason });
+      continue;
+    }
+    ok = false;
+    failures.push({ file: test.file, reason });
+    console.error(`Cannot run ${test.file}: ${reason}`);
+    break;
+  }
+
+  const success = await runTest(test);
+  if (!success) {
+    ok = false;
+    failures.push({ file: test.file, reason: 'command failed' });
+    break;
+  }
+}
+
+await fs.mkdir(outDir, { recursive: true });
+const manifest = {
+  ok,
+  selected: selected.length,
+  run: runCounts,
+  skipped,
+};
+if (failures.length) {
+  manifest.failures = failures;
+}
+await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+
+if (!ok) {
+  process.exitCode = 1;
+}
+
+function parseArgs(args) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--allow-missing-deps') {
+      allowMissingDeps = true;
+      continue;
+    }
+    if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    if (!(key in filters)) {
+      throw new Error(`Unknown filter: ${key}`);
+    }
+    const value = args[i + 1];
+    if (!value) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    filters[key].push(value);
+    i += 1;
+  }
+}
+
+function printHelp() {
+  console.log('Usage: node scripts/test/run.mjs [filters]');
+  console.log('Filters: --kind <value>, --area <value>, --speed <value>, --deps <value>');
+  console.log('Options: --allow-missing-deps');
+}
+
+function matchesFilters(test, { kind, area, speed, deps }) {
+  if (kind.length && !kind.includes(test.kind)) return false;
+  if (area.length && !area.includes(test.area)) return false;
+  if (speed.length && !speed.includes(test.speed)) return false;
+  if (deps.length && !deps.every(dep => test.deps.includes(dep))) return false;
+  return true;
+}
+
+function missingDependencies(test) {
+  const missing = [];
+  for (const dep of test.deps) {
+    if (!hasDependency(dep)) {
+      missing.push(dep);
+    }
+  }
+  return missing;
+}
+
+function hasDependency(dep) {
+  if (availabilityCache.has(dep)) {
+    return availabilityCache.get(dep);
+  }
+  let available = true;
+  if (dep === 'node') {
+    available = true;
+  } else if (dep === 'rust') {
+    try {
+      const result = spawnSync('cargo', ['--version'], { stdio: 'ignore' });
+      available = result.status === 0;
+    } catch (err) {
+      available = false;
+    }
+  }
+  availabilityCache.set(dep, available);
+  return available;
+}
+
+async function runTest(test) {
+  console.log(`[${test.runner}] ${test.file}`);
+  if (test.runner === 'node') {
+    runCounts.node += 1;
+    return runCommand(process.execPath, ['--test', test.file], { cwd: root });
+  }
+  if (test.runner === 'vitest') {
+    const pkgDir = await findPackageRoot(path.join(root, test.file));
+    const pkgRelative = path.relative(root, pkgDir) || '.';
+    const relTest = path.relative(pkgDir, path.join(root, test.file));
+    const args = ['--dir', pkgDir, 'exec', 'vitest', 'run', relTest];
+    runCounts.vitest += 1;
+    return runCommand('pnpm', args, { cwd: root });
+  }
+  if (test.runner === 'cargo') {
+    const crateDir = await findCargoRoot(path.join(root, test.file));
+    const manifest = path.join(crateDir, 'Cargo.toml');
+    const testName = path.basename(test.file).replace(/\.[^.]+$/, '');
+    const args = ['test', '--manifest-path', manifest, '--test', testName];
+    runCounts.cargo += 1;
+    return runCommand('cargo', args, { cwd: root });
+  }
+  throw new Error(`Unknown runner: ${test.runner}`);
+}
+
+async function findPackageRoot(startPath) {
+  let dir = await fs.realpath(path.dirname(startPath));
+  const rootReal = await fs.realpath(root);
+  while (dir.startsWith(rootReal)) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (await exists(pkgPath)) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`Unable to locate package.json for ${startPath}`);
+}
+
+async function findCargoRoot(startPath) {
+  let dir = await fs.realpath(path.dirname(startPath));
+  const rootReal = await fs.realpath(root);
+  while (dir.startsWith(rootReal)) {
+    const manifest = path.join(dir, 'Cargo.toml');
+    if (await exists(manifest)) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`Unable to locate Cargo.toml for ${startPath}`);
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+function runCommand(cmd, args, { cwd }) {
+  return new Promise(resolve => {
+    const child = spawn(cmd, args, { cwd, stdio: 'inherit' });
+    child.on('exit', code => {
+      resolve(typeof code === 'number' && code === 0);
+    });
+    child.on('error', () => resolve(false));
+  });
+}

--- a/services/claims-api-ts/test/sqlite.test.ts
+++ b/services/claims-api-ts/test/sqlite.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=services speed=heavy deps=node
 import { execSync, spawnSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';

--- a/tests/adapters-inmem.test.mjs
+++ b/tests/adapters-inmem.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=adapters speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/adapters-misconfig.test.mjs
+++ b/tests/adapters-misconfig.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=adapters speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/alloy-auth.test.mjs
+++ b/tests/alloy-auth.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=alloy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/alloy-emit.test.mjs
+++ b/tests/alloy-emit.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=alloy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/app-order-publish.test.mjs
+++ b/tests/app-order-publish.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=audit speed=fast deps=node
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile, unlink, access, writeFile, mkdir } from 'node:fs/promises';

--- a/tests/catalog-seed.test.mjs
+++ b/tests/catalog-seed.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=catalog speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/checker.test.mjs
+++ b/tests/checker.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 const parse = await import('../packages/tf-compose/src/parser.mjs').catch(()=>import('../packages/tf-compose/src/parser.with-regions.mjs'));

--- a/tests/codegen-adapters-wireup.test.mjs
+++ b/tests/codegen-adapters-wireup.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=codegen speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/tests/codegen-rs.test.mjs
+++ b/tests/codegen-rs.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=parity area=codegen speed=heavy deps=node,rust
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/tests/docgen.test.mjs
+++ b/tests/docgen.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=docs speed=fast deps=node
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { readFile, stat } from 'node:fs/promises';

--- a/tests/dsl-fmt.test.mjs
+++ b/tests/dsl-fmt.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/dsl-literals.test.mjs
+++ b/tests/dsl-literals.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/dsl-show.test.mjs
+++ b/tests/dsl-show.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/effect-lattice.test.mjs
+++ b/tests/effect-lattice.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=schema speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/normalize-commute.test.mjs
+++ b/tests/normalize-commute.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/normalize-laws.test.mjs
+++ b/tests/normalize-laws.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/parser-and-normalizer.test.mjs
+++ b/tests/parser-and-normalizer.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=parser speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/pilot-full-parity.test.mjs
+++ b/tests/pilot-full-parity.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=parity area=runtime speed=heavy deps=node
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, rmSync, writeFileSync } from 'node:fs';

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, mkdirSync, openSync, closeSync, unlinkSync } from 'node:fs';

--- a/tests/pilot-parity.test.mjs
+++ b/tests/pilot-parity.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=parity area=runtime speed=medium deps=node
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, rmSync, writeFileSync } from 'node:fs';

--- a/tests/policy-authorize.test.mjs
+++ b/tests/policy-authorize.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=policy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';

--- a/tests/proofs-coverage.test.mjs
+++ b/tests/proofs-coverage.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=coverage speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/tests/provenance-status-trace.test.mjs
+++ b/tests/provenance-status-trace.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import test from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';

--- a/tests/regions.test.mjs
+++ b/tests/regions.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/run-ir.test.mjs
+++ b/tests/run-ir.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/runner-caps.test.mjs
+++ b/tests/runner-caps.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/tests/runtime-verify.test.mjs
+++ b/tests/runtime-verify.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import test from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';

--- a/tests/smt-emit.test.mjs
+++ b/tests/smt-emit.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/smt-laws-extend.test.mjs
+++ b/tests/smt-laws-extend.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile } from 'node:fs/promises';

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/smt-props.test.mjs
+++ b/tests/smt-props.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/trace-filter.test.mjs
+++ b/tests/trace-filter.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawn } from 'node:child_process';

--- a/tests/trace-schema.test.mjs
+++ b/tests/trace-schema.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=schema speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/tests/trace-summary.test.mjs
+++ b/tests/trace-summary.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawn } from 'node:child_process';

--- a/tests/txn-policy.test.mjs
+++ b/tests/txn-policy.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=policy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/types-unify.test.mjs
+++ b/tests/types-unify.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=types speed=fast deps=node
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {

--- a/tests/verify-trace.test.mjs
+++ b/tests/verify-trace.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawn } from 'node:child_process';


### PR DESCRIPTION
## Summary
- add @tf-test metadata headers to the JS/TS test suite and .meta sidecars for Rust integration tests to capture kind/area/speed/deps information
- add shared discovery utilities plus list/run scripts that emit canonical manifests and execute tests by metadata, with new pnpm aliases
- write selection results to out/0.4/tests manifests so filtered jobs can see what ran and why

## Testing
- pnpm -w -r build
- pnpm run tests:list
- pnpm run test
- pnpm run test:parity

------
https://chatgpt.com/codex/tasks/task_e_68d14b755b94832089f9811fbce770ef