### PR TITLE
Add test metadata headers and selection scripts

### DIFF
--- a/crates/oracles/conservation/tests/oracle.meta
+++ b/crates/oracles/conservation/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=fast
+deps=rust

--- a/crates/oracles/core/tests/core.meta
+++ b/crates/oracles/core/tests/core.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=fast
+deps=rust

--- a/crates/oracles/determinism/tests/oracle.meta
+++ b/crates/oracles/determinism/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=infra
+area=determinism
+speed=fast
+deps=rust

--- a/crates/oracles/idempotence/tests/oracle.meta
+++ b/crates/oracles/idempotence/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=fast
+deps=rust

--- a/crates/oracles/transport/tests/oracle.meta
+++ b/crates/oracles/transport/tests/oracle.meta
@@ -1,0 +1,4 @@
+kind=product
+area=oracles
+speed=fast
+deps=rust

--- a/out/0.4/tests/available.json
+++ b/out/0.4/tests/available.json
@@ -1,0 +1,1019 @@
+{
+  "tests": [
+    {
+      "file": "crates/oracles/conservation/tests/oracle.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "crates/oracles/conservation"
+    },
+    {
+      "file": "crates/oracles/core/tests/core.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "crates/oracles/core"
+    },
+    {
+      "file": "crates/oracles/determinism/tests/oracle.rs",
+      "runner": "cargo",
+      "kind": "infra",
+      "area": "determinism",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "crates/oracles/determinism"
+    },
+    {
+      "file": "crates/oracles/idempotence/tests/oracle.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "crates/oracles/idempotence"
+    },
+    {
+      "file": "crates/oracles/transport/tests/oracle.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "crates/oracles/transport"
+    },
+    {
+      "file": "packages/adapters/ts/execution/tests/execution.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "adapters",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/adapters/ts/execution"
+    },
+    {
+      "file": "packages/coverage/generator/tests/coverage.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "coverage",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/coverage/generator"
+    },
+    {
+      "file": "packages/explorer-test/claims-explorer.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "pages",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/explorer-test"
+    },
+    {
+      "file": "packages/explorer-test/pages-workflow.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "pages",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/explorer-test"
+    },
+    {
+      "file": "packages/explorer-test/test/source-label.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "pages",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/explorer-test"
+    },
+    {
+      "file": "packages/host-lite/test/c1.apply-persists.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "host",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/host-lite"
+    },
+    {
+      "file": "packages/host-lite/test/c1.byte-determinism.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "determinism",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/host-lite"
+    },
+    {
+      "file": "packages/host-lite/test/c1.http-400-404.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "host",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/host-lite"
+    },
+    {
+      "file": "packages/host-lite/test/c1.import-hygiene.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "deps",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/host-lite"
+    },
+    {
+      "file": "packages/host-lite/test/c1.lru-multiworld.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "host",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/host-lite"
+    },
+    {
+      "file": "packages/host-lite/test/c1.proofs-gating-count.test.ts",
+      "runner": "vitest",
+      "kind": "proofs",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/host-lite"
+    },
+    {
+      "file": "packages/mapper/trace2tags/tests/mapper.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "trace",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/mapper/trace2tags"
+    },
+    {
+      "file": "packages/oracles-core-ts/tests/oracles.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/oracles-core-ts"
+    },
+    {
+      "file": "packages/oracles/conservation/tests/oracle.spec.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/oracles/conservation"
+    },
+    {
+      "file": "packages/oracles/core/tests/core.spec.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/oracles/core"
+    },
+    {
+      "file": "packages/oracles/determinism/tests/oracle.spec.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "determinism",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/oracles/determinism"
+    },
+    {
+      "file": "packages/oracles/idempotence/tests/oracle.spec.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/oracles/idempotence"
+    },
+    {
+      "file": "packages/oracles/transport/tests/oracle.spec.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "oracles",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/oracles/transport"
+    },
+    {
+      "file": "packages/pilot-core/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/pilot-core"
+    },
+    {
+      "file": "packages/pilot-replay/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/pilot-replay"
+    },
+    {
+      "file": "packages/pilot-risk/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/pilot-risk"
+    },
+    {
+      "file": "packages/pilot-strategy/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/pilot-strategy"
+    },
+    {
+      "file": "packages/tf-check/tests/trace.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "checker",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-check"
+    },
+    {
+      "file": "packages/tf-check/tests/validator.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "checker",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-check"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/canon.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "canon",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/laws.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "medium",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/proof_dev.rs",
+      "runner": "cargo",
+      "kind": "proofs",
+      "area": "runtime",
+      "speed": "medium",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/proof_vector.rs",
+      "runner": "cargo",
+      "kind": "proofs",
+      "area": "proofs",
+      "speed": "heavy",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/proof.rs",
+      "runner": "cargo",
+      "kind": "proofs",
+      "area": "proofs",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/spec_adapter.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "spec",
+      "speed": "fast",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-rs/tests/vectors.rs",
+      "runner": "cargo",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "heavy",
+      "deps": [
+        "rust"
+      ],
+      "crate": "packages/tf-lang-l0-rs"
+    },
+    {
+      "file": "packages/tf-lang-l0-ts/tests/canon.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "canon",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-lang-l0-ts"
+    },
+    {
+      "file": "packages/tf-lang-l0-ts/tests/proof-dev.test.ts",
+      "runner": "vitest",
+      "kind": "proofs",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-lang-l0-ts"
+    },
+    {
+      "file": "packages/tf-lang-l0-ts/tests/proof-tags.test.ts",
+      "runner": "vitest",
+      "kind": "proofs",
+      "area": "proofs",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-lang-l0-ts"
+    },
+    {
+      "file": "packages/tf-lang-l0-ts/tests/proof-vector.test.ts",
+      "runner": "vitest",
+      "kind": "proofs",
+      "area": "proofs",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-lang-l0-ts"
+    },
+    {
+      "file": "packages/tf-lang-l0-ts/tests/spec.adapter.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "spec",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-lang-l0-ts"
+    },
+    {
+      "file": "packages/tf-lang-l0-ts/tests/vm.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-lang-l0-ts"
+    },
+    {
+      "file": "packages/tf-plan-compare-core/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-compare-core"
+    },
+    {
+      "file": "packages/tf-plan-compare-render/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-compare-render"
+    },
+    {
+      "file": "packages/tf-plan-compare-render/tests/render.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-compare-render"
+    },
+    {
+      "file": "packages/tf-plan-compare-render/tests/xss.test.ts",
+      "runner": "vitest",
+      "kind": "infra",
+      "area": "security",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-compare-render"
+    },
+    {
+      "file": "packages/tf-plan-compare/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-compare"
+    },
+    {
+      "file": "packages/tf-plan-core/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-core"
+    },
+    {
+      "file": "packages/tf-plan-enum/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-enum"
+    },
+    {
+      "file": "packages/tf-plan-scaffold-core/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-scaffold-core"
+    },
+    {
+      "file": "packages/tf-plan-scaffold/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-scaffold"
+    },
+    {
+      "file": "packages/tf-plan-scoring/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan-scoring"
+    },
+    {
+      "file": "packages/tf-plan/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "plan",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/tf-plan"
+    },
+    {
+      "file": "packages/utils/tests/index.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "utils",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "packages/utils"
+    },
+    {
+      "file": "services/claims-api-ts/test/sqlite.test.ts",
+      "runner": "vitest",
+      "kind": "product",
+      "area": "services",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ],
+      "package": "services/claims-api-ts"
+    },
+    {
+      "file": "tests/adapters-inmem.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "adapters",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/adapters-misconfig.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "adapters",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/alloy-auth.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "alloy",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/alloy-emit.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "alloy",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/app-order-publish.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "apps",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/audit.test.mjs",
+      "runner": "node",
+      "kind": "infra",
+      "area": "audit",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/catalog-seed.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "catalog",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/checker.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "checker",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/codegen-adapters-wireup.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "codegen",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/codegen-rs.test.mjs",
+      "runner": "node",
+      "kind": "parity",
+      "area": "codegen",
+      "speed": "heavy",
+      "deps": [
+        "rust"
+      ]
+    },
+    {
+      "file": "tests/docgen.test.mjs",
+      "runner": "node",
+      "kind": "infra",
+      "area": "docs",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/dsl-fmt.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "dsl",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/dsl-literals.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "dsl",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/dsl-show.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "dsl",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/effect-lattice.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "effects",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/effects-deriver.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "effects",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/manifest-schema.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "manifest",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/manifest.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "manifest",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/normalize-commute.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "dsl",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/normalize-laws.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "dsl",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/parser-and-normalizer.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "dsl",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/pilot-full-parity.test.mjs",
+      "runner": "node",
+      "kind": "parity",
+      "area": "runtime",
+      "speed": "heavy",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/pilot-min.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/pilot-parity.test.mjs",
+      "runner": "node",
+      "kind": "parity",
+      "area": "runtime",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/policy-authorize.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "policy",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/proofs-coverage.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "coverage",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/provenance-status-trace.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/regions.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "regions",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/run-ir.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/runner-caps.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/runtime-verify.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "runtime",
+      "speed": "heavy",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/smt-emit.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "smt",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/smt-laws-extend.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "smt",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/smt-laws.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "smt",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/smt-props.test.mjs",
+      "runner": "node",
+      "kind": "proofs",
+      "area": "smt",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/trace-filter.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "trace",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/trace-schema.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "trace",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/trace-summary.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "trace",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/txn-policy.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "policy",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/types-unify.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "types",
+      "speed": "fast",
+      "deps": [
+        "node"
+      ]
+    },
+    {
+      "file": "tests/verify-trace.test.mjs",
+      "runner": "node",
+      "kind": "product",
+      "area": "trace",
+      "speed": "medium",
+      "deps": [
+        "node"
+      ]
+    }
+  ]
+}

--- a/out/0.4/tests/manifest.json
+++ b/out/0.4/tests/manifest.json
@@ -1,0 +1,10 @@
+{
+  "ok": true,
+  "selected": 3,
+  "run": {
+    "node": 3,
+    "vitest": 0,
+    "cargo": 0
+  },
+  "skipped": []
+}

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "t5:rerun": "node scripts/t5-run.mjs --force",
     "t5:clean": "node -e \"require('fs').rmSync('out/t5',{recursive:true,force:true}); console.log('cleaned out/t5')\"",
     "t5:run:obsolete": "echo 'Use node scripts/t5-run.mjs (or t5:rerun) instead' && exit 1",
-    "test:workspace": "pnpm run --recursive test",
-    "test:l0": "node --test tests/*.test.mjs",
-    "test": "pnpm run test:workspace && pnpm run test:l0",
+    "test": "node scripts/test/run.mjs --kind product --kind infra --speed fast",
     "pilot:build-run": "node scripts/pilot-build-run.mjs",
     "a0": "node packages/tf-l0-spec/scripts/build-ids.mjs && node packages/tf-l0-spec/scripts/finalize-a0.mjs",
     "a1": "node packages/tf-l0-spec/scripts/build-catalog.mjs && node packages/tf-l0-spec/scripts/derive-effects.mjs && node packages/tf-l0-spec/scripts/build-laws.mjs && node packages/tf-l0-spec/scripts/finalize-a1.mjs",
@@ -56,7 +54,14 @@
     "policy:auth": "node packages/tf-compose/bin/tf-policy-auth.mjs",
     "policy:auth:samples": "node -e \"(async()=>{const {spawnSync}=require('node:child_process');const runs=[['ok','examples/flows/auth_ok.tf'],['wrong','examples/flows/auth_wrong_scope.tf'],['missing','examples/flows/auth_missing.tf']];for(const [label,file] of runs){const r=spawnSync('node',['packages/tf-compose/bin/tf-policy-auth.mjs','--','check',file],{stdio:'inherit'}); if(r.status!==0) console.error(`[auth smoke] ${label} -> nonzero (expected for wrong/missing)`);} process.exit(0)})();\"",
     "docs:gen": "node scripts/docgen/catalog.mjs && node scripts/docgen/dsl.mjs && node scripts/docgen/effects.mjs",
-    "docs:check": "node scripts/docgen/check.mjs"
+    "docs:check": "node scripts/docgen/check.mjs",
+    "test:product": "node scripts/test/run.mjs --kind product",
+    "test:infra": "node scripts/test/run.mjs --kind infra",
+    "test:proofs": "node scripts/test/run.mjs --kind proofs",
+    "test:parity": "node scripts/test/run.mjs --kind parity --allow-missing-deps",
+    "test:fast": "node scripts/test/run.mjs --speed fast",
+    "test:heavy": "node scripts/test/run.mjs --speed heavy --allow-missing-deps",
+    "tests:list": "node scripts/test/list.mjs && cat out/0.4/tests/available.json"
   },
   "devDependencies": {
     "typescript": "5.9.2",

--- a/packages/adapters/ts/execution/tests/execution.test.ts
+++ b/packages/adapters/ts/execution/tests/execution.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=adapters speed=fast deps=node
 import { readFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/coverage/generator/tests/coverage.test.ts
+++ b/packages/coverage/generator/tests/coverage.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=coverage speed=fast deps=node
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/explorer-test/claims-explorer.test.ts
+++ b/packages/explorer-test/claims-explorer.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=pages speed=fast deps=node
 import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';

--- a/packages/explorer-test/pages-workflow.test.ts
+++ b/packages/explorer-test/pages-workflow.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=pages speed=fast deps=node
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';

--- a/packages/explorer-test/test/source-label.test.ts
+++ b/packages/explorer-test/test/source-label.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=pages speed=fast deps=node
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 

--- a/packages/host-lite/test/c1.apply-persists.test.ts
+++ b/packages/host-lite/test/c1.apply-persists.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeHandler, createHost } from 'host-lite-ts';
 

--- a/packages/host-lite/test/c1.byte-determinism.test.ts
+++ b/packages/host-lite/test/c1.byte-determinism.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=determinism speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeRawHandler, makeHandler, createHost } from 'host-lite-ts';
 import { canonicalJsonBytes } from 'tf-lang-l0';

--- a/packages/host-lite/test/c1.http-400-404.test.ts
+++ b/packages/host-lite/test/c1.http-400-404.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeRawHandler, makeHandler, createHost } from 'host-lite-ts';
 import { canonicalJsonBytes } from 'tf-lang-l0';

--- a/packages/host-lite/test/c1.import-hygiene.test.ts
+++ b/packages/host-lite/test/c1.import-hygiene.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=deps speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/packages/host-lite/test/c1.lru-multiworld.test.ts
+++ b/packages/host-lite/test/c1.lru-multiworld.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=host speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeHandler, createHost } from 'host-lite-ts';
 

--- a/packages/host-lite/test/c1.proofs-gating-count.test.ts
+++ b/packages/host-lite/test/c1.proofs-gating-count.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=runtime speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { makeRawHandler, makeHandler, createHost } from 'host-lite-ts';
 import { canonicalJsonBytes, blake3hex } from 'tf-lang-l0';

--- a/packages/mapper/trace2tags/tests/mapper.test.ts
+++ b/packages/mapper/trace2tags/tests/mapper.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=trace speed=fast deps=node
 import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/oracles-core-ts/tests/oracles.test.ts
+++ b/packages/oracles-core-ts/tests/oracles.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { describe, it, expect } from "vitest";
 import { equals, subsetOf, inRange, matchesRegex, nonEmpty } from "../src/index.js";
 import { MESSAGES } from "../src/messages.js";

--- a/packages/oracles/conservation/tests/oracle.spec.ts
+++ b/packages/oracles/conservation/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/oracles/core/tests/core.spec.ts
+++ b/packages/oracles/core/tests/core.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/oracles/determinism/tests/oracle.spec.ts
+++ b/packages/oracles/determinism/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=determinism speed=fast deps=node
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/oracles/idempotence/tests/oracle.spec.ts
+++ b/packages/oracles/idempotence/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/oracles/transport/tests/oracle.spec.ts
+++ b/packages/oracles/transport/tests/oracle.spec.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=oracles speed=fast deps=node
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/pilot-core/tests/index.test.ts
+++ b/packages/pilot-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/pilot-replay/tests/index.test.ts
+++ b/packages/pilot-replay/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/pilot-risk/tests/index.test.ts
+++ b/packages/pilot-risk/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/pilot-strategy/tests/index.test.ts
+++ b/packages/pilot-strategy/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/tf-check/tests/trace.test.ts
+++ b/packages/tf-check/tests/trace.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { parseFilters } from '../src/filters.js';
 

--- a/packages/tf-check/tests/validator.test.ts
+++ b/packages/tf-check/tests/validator.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/tf-lang-l0-rs/tests/canon.meta
+++ b/packages/tf-lang-l0-rs/tests/canon.meta
@@ -1,0 +1,4 @@
+kind=product
+area=canon
+speed=fast
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/laws.meta
+++ b/packages/tf-lang-l0-rs/tests/laws.meta
@@ -1,0 +1,4 @@
+kind=product
+area=runtime
+speed=medium
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/proof.meta
+++ b/packages/tf-lang-l0-rs/tests/proof.meta
@@ -1,0 +1,4 @@
+kind=proofs
+area=proofs
+speed=fast
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/proof_dev.meta
+++ b/packages/tf-lang-l0-rs/tests/proof_dev.meta
@@ -1,0 +1,4 @@
+kind=proofs
+area=runtime
+speed=medium
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/proof_vector.meta
+++ b/packages/tf-lang-l0-rs/tests/proof_vector.meta
@@ -1,0 +1,4 @@
+kind=proofs
+area=proofs
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/spec_adapter.meta
+++ b/packages/tf-lang-l0-rs/tests/spec_adapter.meta
@@ -1,0 +1,4 @@
+kind=product
+area=spec
+speed=fast
+deps=rust

--- a/packages/tf-lang-l0-rs/tests/vectors.meta
+++ b/packages/tf-lang-l0-rs/tests/vectors.meta
@@ -1,0 +1,4 @@
+kind=product
+area=runtime
+speed=heavy
+deps=rust

--- a/packages/tf-lang-l0-ts/tests/canon.test.ts
+++ b/packages/tf-lang-l0-ts/tests/canon.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=canon speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import { canonicalJsonBytes, blake3hex } from '../src/canon/index.js';
 

--- a/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-dev.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=runtime speed=fast deps=node
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import type { Program } from '../src/model/bytecode.js';
 

--- a/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-tags.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=proofs speed=fast deps=node
 import { describe, it, expect } from 'vitest';
 import type { Witness, Normalization, Transport, Refutation, Conservativity, ProofTag } from '../src/proof/index.js';
 

--- a/packages/tf-lang-l0-ts/tests/proof-vector.test.ts
+++ b/packages/tf-lang-l0-ts/tests/proof-vector.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=proofs speed=fast deps=node
 import { it, expect, afterEach, beforeEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
+++ b/packages/tf-lang-l0-ts/tests/spec.adapter.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=spec speed=fast deps=node
 import { readFileSync, readdirSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";

--- a/packages/tf-lang-l0-ts/tests/vm.test.ts
+++ b/packages/tf-lang-l0-ts/tests/vm.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 
 import { describe, it, expect } from 'vitest';
 import { VM, Host } from '../src/vm/index.js';

--- a/packages/tf-plan-compare-core/tests/index.test.ts
+++ b/packages/tf-plan-compare-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { PlanNode } from '@tf-lang/tf-plan-core';
 import { ScaffoldPlan } from '@tf-lang/tf-plan-scaffold-core';

--- a/packages/tf-plan-compare-render/tests/index.test.ts
+++ b/packages/tf-plan-compare-render/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { CompareReport } from '@tf-lang/tf-plan-compare-core';
 import { renderHtml, renderMarkdown } from '../src/index.js';

--- a/packages/tf-plan-compare-render/tests/render.test.ts
+++ b/packages/tf-plan-compare-render/tests/render.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };
 import { enumeratePlan } from '@tf-lang/tf-plan-enum';

--- a/packages/tf-plan-compare-render/tests/xss.test.ts
+++ b/packages/tf-plan-compare-render/tests/xss.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=security speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import type { CompareReport } from '@tf-lang/tf-plan-compare-core';
 import { renderHtml, renderMarkdown } from '../src/index.js';

--- a/packages/tf-plan-compare/tests/index.test.ts
+++ b/packages/tf-plan-compare/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/tf-plan-core/tests/index.test.ts
+++ b/packages/tf-plan-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import {
   PLAN_GRAPH_VERSION,

--- a/packages/tf-plan-enum/tests/index.test.ts
+++ b/packages/tf-plan-enum/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { enumeratePlan } from '../src/index.js';
 import demoSpec from '../../../tests/specs/demo.json' with { type: 'json' };

--- a/packages/tf-plan-scaffold-core/tests/index.test.ts
+++ b/packages/tf-plan-scaffold-core/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { PlanNode } from '@tf-lang/tf-plan-core';
 import { createScaffoldPlan } from '../src/index.js';

--- a/packages/tf-plan-scaffold/tests/index.test.ts
+++ b/packages/tf-plan-scaffold/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/tf-plan-scoring/tests/index.test.ts
+++ b/packages/tf-plan-scoring/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { describe, expect, it } from 'vitest';
 import { scorePlanNode } from '../src/index.js';
 

--- a/packages/tf-plan/tests/index.test.ts
+++ b/packages/tf-plan/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=plan speed=fast deps=node
 import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/packages/utils/tests/index.test.ts
+++ b/packages/utils/tests/index.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=utils speed=fast deps=node
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/scripts/test/list.mjs
+++ b/scripts/test/list.mjs
@@ -1,0 +1,188 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+const IGNORED_DIRS = new Set(['.git', '.pnpm', '.turbo', 'node_modules', 'out', 'dist', 'target']);
+
+function parseValue(key, value) {
+  if (key === 'deps') {
+    if (!value || value === 'none') return [];
+    return value.split(',').map((part) => part.trim()).filter(Boolean);
+  }
+  return value;
+}
+
+function parseCommentMetadata(line, relPath) {
+  const prefix = '// @tf-test ';
+  if (!line.startsWith(prefix)) {
+    throw new Error(`Missing metadata header in ${relPath}`);
+  }
+  const tokens = line.slice(prefix.length).trim().split(/\s+/);
+  const meta = {};
+  for (const token of tokens) {
+    const [key, value] = token.split('=');
+    if (!key || value === undefined) {
+      throw new Error(`Invalid metadata token "${token}" in ${relPath}`);
+    }
+    meta[key] = parseValue(key, value);
+  }
+  if (!meta.deps) meta.deps = [];
+  return meta;
+}
+
+function parseMetaFile(content, relPath) {
+  const meta = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const [key, value] = line.split('=');
+    if (!key || value === undefined) {
+      throw new Error(`Invalid metadata entry "${line}" in ${relPath}`);
+    }
+    meta[key] = parseValue(key, value.trim());
+  }
+  if (!meta.deps) meta.deps = [];
+  return meta;
+}
+
+async function fileExists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findUp(startDir, target) {
+  let current = startDir;
+  while (true) {
+    const candidate = path.join(current, target);
+    if (await fileExists(candidate)) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+function isJsTest(name) {
+  return /(\.test|\.spec)\.(mjs|cjs|js)$/u.test(name);
+}
+
+function isTsTest(name) {
+  return /(\.test|\.spec)\.ts$/u.test(name);
+}
+
+export async function collectTests() {
+  const tests = [];
+
+  async function walk(dir) {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (IGNORED_DIRS.has(entry.name)) continue;
+      const fullPath = path.join(dir, entry.name);
+      const relPath = path.relative(ROOT, fullPath);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (isJsTest(entry.name) || isTsTest(entry.name)) {
+        const content = await fs.readFile(fullPath, 'utf8');
+        const firstLine = content.split(/\r?\n/, 1)[0] ?? '';
+        const meta = parseCommentMetadata(firstLine, relPath);
+        const runner = isTsTest(entry.name) ? 'vitest' : 'node';
+        const record = {
+          file: relPath,
+          runner,
+          meta,
+        };
+        if (runner === 'vitest') {
+          const pkgDir = await findUp(path.dirname(fullPath), 'package.json');
+          if (!pkgDir) {
+            throw new Error(`Unable to locate package.json for ${relPath}`);
+          }
+          record.packageDir = pkgDir;
+        }
+        tests.push(record);
+        continue;
+      }
+      if (entry.name.endsWith('.meta')) {
+        const content = await fs.readFile(fullPath, 'utf8');
+        const meta = parseMetaFile(content, relPath);
+        let testFile = null;
+        const base = fullPath.slice(0, -'.meta'.length);
+        const candidates = ['.rs', '.sh'];
+        for (const ext of candidates) {
+          const candidatePath = base + ext;
+          if (await fileExists(candidatePath)) {
+            testFile = path.relative(ROOT, candidatePath);
+            break;
+          }
+        }
+        if (!testFile) {
+          throw new Error(`Unable to find test file for metadata ${relPath}`);
+        }
+        const crateDir = await findUp(path.dirname(fullPath), 'Cargo.toml');
+        if (!crateDir) {
+          throw new Error(`Unable to locate Cargo.toml for ${relPath}`);
+        }
+        tests.push({
+          file: testFile,
+          runner: 'cargo',
+          meta,
+          crateDir,
+          testTarget: path.basename(testFile, path.extname(testFile)),
+        });
+      }
+    }
+  }
+
+  await walk(ROOT);
+  tests.sort((a, b) => a.file.localeCompare(b.file));
+  return tests;
+}
+
+async function writeAvailable(tests) {
+  const outputDir = path.join(ROOT, 'out', '0.4', 'tests');
+  await fs.mkdir(outputDir, { recursive: true });
+  const records = tests.map((test) => {
+    const entry = {
+      file: test.file,
+      runner: test.runner,
+      kind: test.meta.kind,
+      area: test.meta.area,
+      speed: test.meta.speed,
+      deps: test.meta.deps,
+    };
+    if (test.packageDir) {
+      entry.package = path.relative(ROOT, test.packageDir);
+    }
+    if (test.crateDir) {
+      entry.crate = path.relative(ROOT, test.crateDir);
+    }
+    return entry;
+  });
+  const payload = { tests: records };
+  const serialized = `${JSON.stringify(payload, null, 2)}\n`;
+  await fs.writeFile(path.join(outputDir, 'available.json'), serialized, 'utf8');
+  return serialized;
+}
+
+async function main() {
+  const tests = await collectTests();
+  await writeAvailable(tests);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/run.mjs
+++ b/scripts/test/run.mjs
@@ -1,0 +1,215 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+import { collectTests } from './list.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+
+function parseArgs(argv) {
+  const filters = new Map();
+  let allowMissingDeps = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--allow-missing-deps') {
+      allowMissingDeps = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument "${arg}"`);
+    }
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for argument "${arg}"`);
+    }
+    i += 1;
+    if (!filters.has(key)) {
+      filters.set(key, []);
+    }
+    filters.get(key).push(value);
+  }
+  return { filters, allowMissingDeps };
+}
+
+function matchesFilters(test, filters) {
+  for (const [key, values] of filters) {
+    if (key === 'deps') {
+      const deps = test.meta.deps ?? [];
+      if (!values.every((value) => deps.includes(value))) {
+        return false;
+      }
+      continue;
+    }
+    const metaValue = test.meta[key];
+    if (!values.includes(metaValue)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function runCommand(command, args, { cwd = ROOT, env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: env ? { ...process.env, ...env } : process.env,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      if (signal) {
+        resolve(1);
+      } else {
+        resolve(code ?? 0);
+      }
+    });
+  });
+}
+
+function commandExists(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+async function detectMissingDeps(tests) {
+  const required = new Set();
+  for (const test of tests) {
+    for (const dep of test.meta.deps ?? []) {
+      required.add(dep);
+    }
+  }
+  const missing = new Set();
+  for (const dep of required) {
+    if (dep === 'none' || dep === 'node') continue;
+    if (dep === 'rust') {
+      const available = await commandExists('cargo', ['--version']);
+      if (!available) missing.add(dep);
+      continue;
+    }
+    // Assume other deps are available for now.
+  }
+  return missing;
+}
+
+async function runNodeTests(tests) {
+  if (tests.length === 0) return 0;
+  const args = ['--test', ...tests.map((test) => test.file)];
+  const code = await runCommand(process.execPath, args);
+  return code === 0 ? 0 : 1;
+}
+
+async function runVitestTests(tests) {
+  if (tests.length === 0) return 0;
+  let failures = 0;
+  const byPackage = new Map();
+  for (const test of tests) {
+    const pkgDir = test.packageDir;
+    if (!pkgDir) {
+      throw new Error(`Missing package directory for ${test.file}`);
+    }
+    if (!byPackage.has(pkgDir)) {
+      byPackage.set(pkgDir, []);
+    }
+    byPackage.get(pkgDir).push(test);
+  }
+  for (const [pkgDir, groupedTests] of byPackage) {
+    const relPaths = groupedTests.map((test) => {
+      const absolute = path.join(ROOT, test.file);
+      return path.relative(pkgDir, absolute);
+    });
+    const code = await runCommand('pnpm', ['exec', 'vitest', 'run', ...relPaths], { cwd: pkgDir });
+    if (code !== 0) {
+      failures += 1;
+    }
+  }
+  return failures;
+}
+
+async function runCargoTests(tests) {
+  if (tests.length === 0) return 0;
+  let failures = 0;
+  for (const test of tests) {
+    const crateDir = test.crateDir;
+    const manifest = path.join(crateDir, 'Cargo.toml');
+    const args = ['test', '--manifest-path', manifest, '--test', test.testTarget];
+    const code = await runCommand('cargo', args, { cwd: crateDir });
+    if (code !== 0) {
+      failures += 1;
+    }
+  }
+  return failures;
+}
+
+async function main() {
+  const { filters, allowMissingDeps } = parseArgs(process.argv.slice(2));
+  const tests = await collectTests();
+  const selected = filters.size === 0 ? tests : tests.filter((test) => matchesFilters(test, filters));
+  const manifest = {
+    ok: true,
+    selected: selected.length,
+    run: { node: 0, vitest: 0, cargo: 0 },
+    skipped: [],
+  };
+
+  const missingDeps = await detectMissingDeps(selected);
+  const runnable = [];
+  for (const test of selected) {
+    const missingForTest = (test.meta.deps ?? []).filter((dep) => missingDeps.has(dep));
+    if (missingForTest.length > 0) {
+      const reason = `missing ${missingForTest.join(', ')}`;
+      manifest.skipped.push({ file: test.file, reason });
+      if (!allowMissingDeps) {
+        manifest.ok = false;
+      }
+      if (!allowMissingDeps) {
+        console.error(`Cannot run ${test.file}: ${reason}`);
+      } else {
+        console.warn(`Skipping ${test.file}: ${reason}`);
+      }
+      continue;
+    }
+    runnable.push(test);
+  }
+
+  const nodeTests = runnable.filter((test) => test.runner === 'node');
+  if (nodeTests.length > 0) {
+    const failures = await runNodeTests(nodeTests);
+    manifest.run.node = nodeTests.length;
+    if (failures > 0) manifest.ok = false;
+  }
+
+  const vitestTests = runnable.filter((test) => test.runner === 'vitest');
+  if (vitestTests.length > 0) {
+    const failures = await runVitestTests(vitestTests);
+    manifest.run.vitest = vitestTests.length;
+    if (failures > 0) manifest.ok = false;
+  }
+
+  const cargoTests = runnable.filter((test) => test.runner === 'cargo');
+  if (cargoTests.length > 0) {
+    const failures = await runCargoTests(cargoTests);
+    manifest.run.cargo = cargoTests.length;
+    if (failures > 0) manifest.ok = false;
+  }
+
+  const outputDir = path.join(ROOT, 'out', '0.4', 'tests');
+  await fs.mkdir(outputDir, { recursive: true });
+  const serialized = `${JSON.stringify(manifest, null, 2)}\n`;
+  await fs.writeFile(path.join(outputDir, 'manifest.json'), serialized, 'utf8');
+
+  if (!manifest.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/services/claims-api-ts/test/sqlite.test.ts
+++ b/services/claims-api-ts/test/sqlite.test.ts
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=services speed=fast deps=node
 import { execSync, spawnSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';

--- a/tests/adapters-inmem.test.mjs
+++ b/tests/adapters-inmem.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=adapters speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/adapters-misconfig.test.mjs
+++ b/tests/adapters-misconfig.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=adapters speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/alloy-auth.test.mjs
+++ b/tests/alloy-auth.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=alloy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/alloy-emit.test.mjs
+++ b/tests/alloy-emit.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=alloy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/app-order-publish.test.mjs
+++ b/tests/app-order-publish.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=apps speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=audit speed=fast deps=node
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile, unlink, access, writeFile, mkdir } from 'node:fs/promises';

--- a/tests/catalog-seed.test.mjs
+++ b/tests/catalog-seed.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=catalog speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/checker.test.mjs
+++ b/tests/checker.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=checker speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 const parse = await import('../packages/tf-compose/src/parser.mjs').catch(()=>import('../packages/tf-compose/src/parser.with-regions.mjs'));

--- a/tests/codegen-adapters-wireup.test.mjs
+++ b/tests/codegen-adapters-wireup.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=codegen speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/tests/codegen-rs.test.mjs
+++ b/tests/codegen-rs.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=parity area=codegen speed=heavy deps=rust
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/tests/docgen.test.mjs
+++ b/tests/docgen.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=infra area=docs speed=fast deps=node
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { readFile, stat } from 'node:fs/promises';

--- a/tests/dsl-fmt.test.mjs
+++ b/tests/dsl-fmt.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/dsl-literals.test.mjs
+++ b/tests/dsl-literals.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/dsl-show.test.mjs
+++ b/tests/dsl-show.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/effect-lattice.test.mjs
+++ b/tests/effect-lattice.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=effects speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/effects-deriver.test.mjs
+++ b/tests/effects-deriver.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=effects speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/manifest-schema.test.mjs
+++ b/tests/manifest-schema.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=manifest speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=manifest speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/normalize-commute.test.mjs
+++ b/tests/normalize-commute.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/normalize-laws.test.mjs
+++ b/tests/normalize-laws.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/parser-and-normalizer.test.mjs
+++ b/tests/parser-and-normalizer.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=dsl speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/pilot-full-parity.test.mjs
+++ b/tests/pilot-full-parity.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=parity area=runtime speed=heavy deps=node
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, rmSync, writeFileSync } from 'node:fs';

--- a/tests/pilot-min.test.mjs
+++ b/tests/pilot-min.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, mkdirSync, openSync, closeSync, unlinkSync } from 'node:fs';

--- a/tests/pilot-parity.test.mjs
+++ b/tests/pilot-parity.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=parity area=runtime speed=medium deps=node
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, rmSync, writeFileSync } from 'node:fs';

--- a/tests/policy-authorize.test.mjs
+++ b/tests/policy-authorize.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=policy speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';

--- a/tests/proofs-coverage.test.mjs
+++ b/tests/proofs-coverage.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=coverage speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/tests/provenance-status-trace.test.mjs
+++ b/tests/provenance-status-trace.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import test from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';

--- a/tests/regions.test.mjs
+++ b/tests/regions.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=regions speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/run-ir.test.mjs
+++ b/tests/run-ir.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/runner-caps.test.mjs
+++ b/tests/runner-caps.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/tests/runtime-verify.test.mjs
+++ b/tests/runtime-verify.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=runtime speed=heavy deps=node
 import test from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';

--- a/tests/smt-emit.test.mjs
+++ b/tests/smt-emit.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/smt-laws-extend.test.mjs
+++ b/tests/smt-laws-extend.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile } from 'node:fs/promises';

--- a/tests/smt-laws.test.mjs
+++ b/tests/smt-laws.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/smt-props.test.mjs
+++ b/tests/smt-props.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=proofs area=smt speed=fast deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/trace-filter.test.mjs
+++ b/tests/trace-filter.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=trace speed=fast deps=node
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawn } from 'node:child_process';

--- a/tests/trace-schema.test.mjs
+++ b/tests/trace-schema.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=trace speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/tests/trace-summary.test.mjs
+++ b/tests/trace-summary.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=trace speed=medium deps=node
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawn } from 'node:child_process';

--- a/tests/txn-policy.test.mjs
+++ b/tests/txn-policy.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=policy speed=medium deps=node
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/types-unify.test.mjs
+++ b/tests/types-unify.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=types speed=fast deps=node
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {

--- a/tests/verify-trace.test.mjs
+++ b/tests/verify-trace.test.mjs
@@ -1,3 +1,4 @@
+// @tf-test kind=product area=trace speed=medium deps=node
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawn } from 'node:child_process';


### PR DESCRIPTION
## Summary
- add @tf-test metadata headers across Node and TypeScript test suites plus .meta sidecars for Rust
- add scripts/test/list.mjs and scripts/test/run.mjs to collect metadata, filter by tags, and emit manifests
- update package.json test scripts and commit out/0.4/tests/{available,manifest}.json to surface available and executed tests

## Testing
- pnpm -w -r build
- pnpm run tests:list
- pnpm run test
- pnpm run test:parity

------
https://chatgpt.com/codex/tasks/task_e_68d14b755b94832089f9811fbce770ef