### PR TITLE
node:A1-LSP-Proto cp:cp4_code_actions

### DIFF
--- a/packages/tf-lsp-server/bin/server.mjs
+++ b/packages/tf-lsp-server/bin/server.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/server.js');

--- a/packages/tf-lsp-server/package.json
+++ b/packages/tf-lsp-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@tf-lang/tf-lsp-server",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "node --enable-source-maps ./dist/server.js"
+  },
+  "dependencies": {
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/tf-lsp-server/src/server.ts
+++ b/packages/tf-lsp-server/src/server.ts
@@ -1,0 +1,530 @@
+/// <reference path="./shims.d.ts" />
+import {
+  CodeAction,
+  CodeActionKind,
+  CodeActionParams,
+  Diagnostic,
+  DiagnosticSeverity,
+  Hover,
+  InitializeParams,
+  InitializeResult,
+  Position,
+  ProposedFeatures,
+  Range,
+  TextDocumentChangeEvent,
+  TextDocumentPositionParams,
+  TextDocumentSyncKind,
+  TextDocuments,
+  createConnection,
+} from 'vscode-languageserver/node.js';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface CatalogPrimitive {
+  id?: string;
+  name?: string;
+  effects?: string[];
+  domain?: string;
+  major?: number;
+}
+
+interface Catalog {
+  primitives?: CatalogPrimitive[];
+}
+
+interface CheckVerdict {
+  ok: boolean;
+  reasons?: string[];
+}
+
+interface RegionVerdict {
+  ok: boolean;
+  reasons?: string[];
+}
+
+interface TextRange {
+  start: number;
+  end: number;
+}
+
+interface ProtectedMatch {
+  keyword: string;
+  index: number;
+  length: number;
+}
+
+type ParseFn = (source: string) => unknown;
+type CheckFn = (ir: unknown, catalog: Catalog) => CheckVerdict;
+type RegionFn = (ir: unknown, catalog: Catalog, protectedKeywords: string[]) => RegionVerdict;
+interface LawEntry {
+  id: string;
+  applies_to?: string[];
+}
+
+const connection = createConnection(ProposedFeatures.all);
+const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+const protectedMatchesByUri = new Map<string, ProtectedMatch[]>();
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(moduleDir, '../../..');
+const catalogPath = resolve(repoRoot, 'packages/tf-l0-spec/spec/catalog.json');
+const protectedPath = resolve(repoRoot, 'packages/tf-l0-spec/spec/protected.json');
+const lawsPath = resolve(repoRoot, 'packages/tf-l0-spec/spec/laws.json');
+const parserModuleUrl = new URL('../../tf-compose/src/parser.mjs', import.meta.url);
+const checkModuleUrl = new URL('../../tf-l0-check/src/check.mjs', import.meta.url);
+const regionModuleUrl = new URL('../../tf-l0-check/src/regions.mjs', import.meta.url);
+
+let catalogCache: Catalog | null = null;
+let protectedKeywordsCache: string[] | null = null;
+let lawsCache: LawEntry[] | null = null;
+let parseFnPromise: Promise<ParseFn> | null = null;
+let checkFnPromise: Promise<CheckFn> | null = null;
+let regionFnPromise: Promise<RegionFn> | null = null;
+
+connection.onInitialize((params: InitializeParams): InitializeResult => {
+  const capabilities = params.capabilities;
+  void capabilities;
+
+  return {
+    capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
+      hoverProvider: true,
+      codeActionProvider: true,
+    },
+  };
+});
+
+documents.onDidOpen((event: TextDocumentChangeEvent<TextDocument>) => {
+  void validateDocument(event.document);
+});
+
+documents.onDidChangeContent((change: TextDocumentChangeEvent<TextDocument>) => {
+  void validateDocument(change.document);
+});
+
+documents.onDidClose((event) => {
+  protectedMatchesByUri.delete(event.document.uri);
+  connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+});
+
+connection.onHover(async (params: TextDocumentPositionParams): Promise<Hover | null> => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return null;
+  }
+  const symbol = extractSymbol(document, params.position);
+  if (!symbol) {
+    return null;
+  }
+  const catalog = await loadCatalog();
+  const primitive = lookupPrimitive(catalog, symbol);
+  if (!primitive) {
+    return null;
+  }
+  const signature = buildSignature(primitive);
+  const effects = primitive.effects ?? [];
+  const laws = await loadLawIds(primitive.id ?? '');
+  const payload = JSON.stringify({ signature, effects, laws });
+  return { contents: { kind: 'plaintext', value: payload } };
+});
+
+connection.onCodeAction((params: CodeActionParams): CodeAction[] => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return [];
+  }
+  const matches = protectedMatchesByUri.get(document.uri);
+  if (!matches || matches.length === 0) {
+    return [];
+  }
+  const text = document.getText();
+  const actions: CodeAction[] = [];
+  for (const match of matches) {
+    const callRange = expandToCall(text, match);
+    const range = rangeFromOffsets(document, callRange.start, callRange.end);
+    const editText = buildAuthorizeWrap(document, text, callRange);
+    const action: CodeAction = {
+      title: `Wrap ${match.keyword} with Authorize`,
+      kind: CodeActionKind.QuickFix,
+      edit: {
+        changes: {
+          [document.uri]: [
+            {
+              range,
+              newText: editText,
+            },
+          ],
+        },
+      },
+    };
+    actions.push(action);
+  }
+  return actions;
+});
+
+documents.listen(connection);
+connection.listen();
+
+async function validateDocument(document: TextDocument): Promise<void> {
+  const text = document.getText();
+
+  try {
+    const ir = await parseText(text);
+    const [catalog, protectedKeywords] = await Promise.all([
+      loadCatalog(),
+      loadProtectedKeywords(),
+    ]);
+
+    const diagnostics: Diagnostic[] = [];
+
+    const checkVerdict = await runCheckIR(ir, catalog);
+    if (Array.isArray(checkVerdict.reasons)) {
+      for (const reason of checkVerdict.reasons) {
+        diagnostics.push({
+          severity: DiagnosticSeverity.Warning,
+          message: reason,
+          range: fullDocumentRange(document),
+        });
+      }
+    }
+
+    const regionVerdict = await runCheckRegions(ir, catalog, protectedKeywords);
+    if (!regionVerdict.ok) {
+      const matches = findProtectedViolations(text, protectedKeywords);
+      protectedMatchesByUri.set(document.uri, matches);
+      for (const match of matches) {
+        diagnostics.push({
+          severity: DiagnosticSeverity.Error,
+          message: `Protected op '${match.keyword}' must be inside Authorize{}`,
+          range: rangeForMatch(document, match.index, match.length),
+        });
+      }
+    } else {
+      protectedMatchesByUri.delete(document.uri);
+    }
+
+    connection.sendDiagnostics({ uri: document.uri, diagnostics });
+  } catch (error: unknown) {
+    const parseDiagnostic = buildParseDiagnostic(error, document);
+    if (parseDiagnostic) {
+      protectedMatchesByUri.delete(document.uri);
+      connection.sendDiagnostics({ uri: document.uri, diagnostics: [parseDiagnostic] });
+      return;
+    }
+    const message = error instanceof Error && typeof error.message === 'string'
+      ? error.message
+      : 'Unknown error during validation';
+    connection.console.error(message);
+    protectedMatchesByUri.delete(document.uri);
+    connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
+  }
+}
+
+async function loadCatalog(): Promise<Catalog> {
+  if (catalogCache) {
+    return catalogCache;
+  }
+  try {
+    const raw = await readFile(catalogPath, 'utf8');
+    catalogCache = JSON.parse(raw) as Catalog;
+  } catch (error) {
+    connection.console.error(`Failed to load catalog: ${String(error)}`);
+    catalogCache = { primitives: [] };
+  }
+  return catalogCache;
+}
+
+async function loadProtectedKeywords(): Promise<string[]> {
+  if (protectedKeywordsCache) {
+    return protectedKeywordsCache;
+  }
+  try {
+    const raw = await readFile(protectedPath, 'utf8');
+    const parsed = JSON.parse(raw) as { protected_keywords?: string[] };
+    protectedKeywordsCache = parsed.protected_keywords ?? [];
+  } catch (error) {
+    connection.console.error(`Failed to load protected keywords: ${String(error)}`);
+    protectedKeywordsCache = [];
+  }
+  return protectedKeywordsCache;
+}
+
+async function loadLawIds(primitiveId: string): Promise<string[]> {
+  if (!primitiveId) {
+    return [];
+  }
+  if (!lawsCache) {
+    try {
+      const raw = await readFile(lawsPath, 'utf8');
+      const parsed = JSON.parse(raw) as { laws?: LawEntry[] };
+      lawsCache = parsed.laws ?? [];
+    } catch (error) {
+      connection.console.error(`Failed to load laws: ${String(error)}`);
+      lawsCache = [];
+    }
+  }
+  return lawsCache
+    .filter((law) => Array.isArray(law.applies_to) && law.applies_to.some((entry) => entry?.toLowerCase() === primitiveId.toLowerCase()))
+    .map((law) => law.id)
+    .filter((id) => typeof id === 'string' && id.length > 0);
+}
+
+async function parseText(source: string): Promise<unknown> {
+  if (!parseFnPromise) {
+    parseFnPromise = import(parserModuleUrl.href).then((mod) => {
+      const fn = (mod as { parseDSL?: ParseFn }).parseDSL;
+      if (typeof fn !== 'function') {
+        throw new Error('parseDSL export missing');
+      }
+      return fn;
+    });
+  }
+  const fn = await parseFnPromise;
+  return fn(source);
+}
+
+async function runCheckIR(ir: unknown, catalog: Catalog): Promise<CheckVerdict> {
+  if (!checkFnPromise) {
+    checkFnPromise = import(checkModuleUrl.href).then((mod) => {
+      const fn = (mod as { checkIR?: CheckFn }).checkIR;
+      if (typeof fn !== 'function') {
+        throw new Error('checkIR export missing');
+      }
+      return fn;
+    });
+  }
+  const fn = await checkFnPromise;
+  return fn(ir, catalog);
+}
+
+async function runCheckRegions(
+  ir: unknown,
+  catalog: Catalog,
+  protectedKeywords: string[],
+): Promise<RegionVerdict> {
+  if (!regionFnPromise) {
+    regionFnPromise = import(regionModuleUrl.href).then((mod) => {
+      const fn = (mod as { checkRegions?: RegionFn }).checkRegions;
+      if (typeof fn !== 'function') {
+        throw new Error('checkRegions export missing');
+      }
+      return fn;
+    });
+  }
+  const fn = await regionFnPromise;
+  return fn(ir, catalog, protectedKeywords);
+}
+
+function lookupPrimitive(catalog: Catalog, symbol: string): CatalogPrimitive | null {
+  const primitives = catalog.primitives ?? [];
+  const lowerSymbol = symbol.toLowerCase();
+  if (lowerSymbol.startsWith('tf:')) {
+    return primitives.find((entry) => (entry.id ?? '').toLowerCase() === lowerSymbol) ?? null;
+  }
+  return (
+    primitives.find((entry) => (entry.name ?? '').toLowerCase() === lowerSymbol) ??
+    primitives.find((entry) => (entry.id ?? '').toLowerCase().endsWith(`/${lowerSymbol}@${entry.major ?? ''}`)) ??
+    null
+  );
+}
+
+function buildSignature(primitive: CatalogPrimitive): string {
+  const name = primitive.name ?? primitive.id ?? 'unknown';
+  const hints: Record<string, string> = {
+    publish: 'topic, key, payload',
+    'write-object': 'resource_uri, payload',
+    'read-object': 'resource_uri',
+    'sign-data': 'key_ref, payload',
+  };
+  const lowerName = typeof name === 'string' ? name.toLowerCase() : 'op';
+  const hint = hints[lowerName] ?? '';
+  return hint.length > 0 ? `${name}(${hint})` : `${name}()`;
+}
+
+function extractSymbol(document: TextDocument, position: Position): string | null {
+  const text = document.getText();
+  const offset = document.offsetAt(position);
+  if (offset < 0 || offset >= text.length) {
+    return null;
+  }
+  const isSymbolChar = (ch: string) => /[A-Za-z0-9_:@\/-]/.test(ch);
+  let start = offset;
+  while (start > 0 && isSymbolChar(text[start - 1] ?? '')) {
+    start -= 1;
+  }
+  let end = offset;
+  while (end < text.length && isSymbolChar(text[end] ?? '')) {
+    end += 1;
+  }
+  const symbol = text.slice(start, end).trim();
+  return symbol.length > 0 ? symbol : null;
+}
+
+function buildParseDiagnostic(error: unknown, document: TextDocument): Diagnostic | null {
+  if (!(error instanceof Error) || typeof error.message !== 'string') {
+    return null;
+  }
+  const match = /Parse error at (\d+):(\d+):([^\n]+)/.exec(error.message);
+  if (!match) {
+    return null;
+  }
+  const line = Math.max(parseInt(match[1], 10) - 1, 0);
+  const character = Math.max(parseInt(match[2], 10) - 1, 0);
+  const start: Position = { line, character };
+  const end: Position = { line, character: character + 1 };
+  return {
+    severity: DiagnosticSeverity.Error,
+    message: error.message.trim(),
+    range: { start, end },
+  };
+}
+
+function fullDocumentRange(document: TextDocument): Range {
+  const endPosition = document.positionAt(document.getText().length);
+  return { start: { line: 0, character: 0 }, end: endPosition };
+}
+
+function rangeForMatch(document: TextDocument, index: number, length: number): Range {
+  const start = document.positionAt(index);
+  const end = document.positionAt(index + length);
+  return { start, end };
+}
+
+function rangeFromOffsets(document: TextDocument, start: number, end: number): Range {
+  const startPos = document.positionAt(start);
+  const endPos = document.positionAt(end);
+  return { start: startPos, end: endPos };
+}
+
+function findProtectedViolations(text: string, keywords: string[]): ProtectedMatch[] {
+  if (keywords.length === 0) {
+    return [];
+  }
+  const authorizeRanges = collectAuthorizeRanges(text);
+  const matches: ProtectedMatch[] = [];
+  for (const keyword of keywords) {
+    const regex = new RegExp(`\\b${escapeRegExp(keyword)}\\b`, 'gi');
+    let match: RegExpExecArray | null = null;
+    while ((match = regex.exec(text)) !== null) {
+      const index = match.index;
+      const length = match[0].length;
+      if (!insideAuthorize(index, authorizeRanges)) {
+        matches.push({ keyword, index, length });
+      }
+    }
+  }
+  return matches;
+}
+
+function expandToCall(text: string, match: ProtectedMatch): TextRange {
+  let start = match.index;
+  let end = match.index + match.length;
+  let cursor = end;
+  while (cursor < text.length && /\s/.test(text[cursor] ?? '')) {
+    cursor += 1;
+  }
+  if (cursor < text.length && text[cursor] === '(') {
+    const close = findMatchingSymbol(text, cursor, '(', ')');
+    if (close !== -1) {
+      end = close + 1;
+    }
+  }
+  return { start, end };
+}
+
+function buildAuthorizeWrap(document: TextDocument, text: string, range: TextRange): string {
+  const original = text.slice(range.start, range.end);
+  const startPos = document.positionAt(range.start);
+  const lineStartOffset = document.offsetAt({ line: startPos.line, character: 0 });
+  const leadingSegment = text.slice(lineStartOffset, range.start);
+  const indentMatch = leadingSegment.match(/^\s*/);
+  const indent = indentMatch ? indentMatch[0] ?? '' : '';
+  const inner = original.trim();
+  const innerLines = inner.split(/\r?\n/).map((line) => line.trim());
+  const indented = innerLines.map((line) => `${indent}  ${line}`).join('\n');
+  return `Authorize{ scope: "" } {\n${indented}\n${indent}}`;
+}
+
+function collectAuthorizeRanges(text: string): TextRange[] {
+  const ranges: TextRange[] = [];
+  const lower = text.toLowerCase();
+  let index = 0;
+  while (index < lower.length) {
+    const hit = lower.indexOf('authorize', index);
+    if (hit === -1) {
+      break;
+    }
+    let cursor = hit + 'authorize'.length;
+    cursor = skipWhitespace(lower, cursor);
+    if (cursor < lower.length && lower[cursor] === '(') {
+      const endParen = findMatchingSymbol(text, cursor, '(', ')');
+      if (endParen === -1) {
+        index = hit + 1;
+        continue;
+      }
+      cursor = endParen + 1;
+    }
+    cursor = skipWhitespace(lower, cursor);
+    if (cursor >= lower.length || lower[cursor] !== '{') {
+      index = hit + 1;
+      continue;
+    }
+    const endBrace = findMatchingSymbol(text, cursor, '{', '}');
+    if (endBrace === -1) {
+      index = hit + 1;
+      continue;
+    }
+    ranges.push({ start: cursor, end: endBrace + 1 });
+    index = hit + 1;
+  }
+  return ranges;
+}
+
+function skipWhitespace(text: string, start: number): number {
+  let cursor = start;
+  while (cursor < text.length && /\s/.test(text[cursor] ?? '')) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function findMatchingSymbol(text: string, start: number, openChar: string, closeChar: string): number {
+  let depth = 0;
+  let inString: string | null = null;
+  for (let i = start; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      if (ch === '\\' && i + 1 < text.length) {
+        i += 1;
+        continue;
+      }
+      if (ch === inString) {
+        inString = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === '\'') {
+      inString = ch;
+      continue;
+    }
+    if (ch === openChar) {
+      depth += 1;
+    } else if (ch === closeChar) {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+function insideAuthorize(index: number, ranges: TextRange[]): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/tf-lsp-server/src/shims.d.ts
+++ b/packages/tf-lsp-server/src/shims.d.ts
@@ -1,0 +1,19 @@
+declare module '../../tf-compose/src/parser.mjs' {
+  export function parseDSL(source: string): unknown;
+}
+
+declare module '../../tf-l0-check/src/check.mjs' {
+  export interface CheckVerdict {
+    ok: boolean;
+    reasons?: string[];
+  }
+  export function checkIR(ir: unknown, catalog: unknown): CheckVerdict;
+}
+
+declare module '../../tf-l0-check/src/regions.mjs' {
+  export interface RegionVerdict {
+    ok: boolean;
+    reasons?: string[];
+  }
+  export function checkRegions(ir: unknown, catalog: unknown, protectedKeywords: string[]): RegionVerdict;
+}

--- a/packages/tf-lsp-server/tsconfig.json
+++ b/packages/tf-lsp-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/samples/a1/illegal_write.tf
+++ b/samples/a1/illegal_write.tf
@@ -1,1 +1,1 @@
-# a legal syntax, illegal policy (write outside Authorize)
+authorize{ par{ write-object(resource_uri="s3://bucket/item"); write-object(resource_uri="s3://bucket/item") } }

--- a/samples/a1/protected_write.tf
+++ b/samples/a1/protected_write.tf
@@ -1,1 +1,1 @@
-# legal except protected write outside Authorize (for code action)
+write-object(resource_uri="s3://bucket/item")

--- a/samples/a1/syntax_error.tf
+++ b/samples/a1/syntax_error.tf
@@ -1,1 +1,1 @@
-# malformed on purpose (for parser error surfacing)
+write-object(resource_uri="s3://bucket/item"

--- a/tools/tf-lsp-sample/catalog-loader.mjs
+++ b/tools/tf-lsp-sample/catalog-loader.mjs
@@ -1,11 +1,11 @@
 import { readFile } from 'node:fs/promises';
-export async function loadCatalog() {
-  const candidates = [
-    'packages/tf-l0-spec/spec/catalog.json',
-    'catalogs/catalog.json',
-  ];
-  for (const p of candidates) {
-    try { return JSON.parse(await readFile(p, 'utf8')); } catch { }
-  }
-  return { primitives: [] };
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export async function loadSampleCatalog() {
+  const catalogPath = join(here, '../../packages/tf-l0-spec/spec/catalog.json');
+  const raw = await readFile(catalogPath, 'utf8');
+  return JSON.parse(raw);
 }

--- a/tools/tf-lsp-sample/code-action-check.mjs
+++ b/tools/tf-lsp-sample/code-action-check.mjs
@@ -1,11 +1,79 @@
-#!/usr/bin/env node
-// Stub that calls your server's "wrap with Authorize" code action directly (module import)
-// Replace the import below to match your server implementation once it exists.
-import { wrapWithAuthorize } from '../../packages/tf-lsp-server/src/actions/wrap-authorize.mjs';
 import { readFile } from 'node:fs/promises';
-const file = process.argv[process.argv.indexOf('--file') + 1];
-const src = await readFile(file, 'utf8');
-const edit = wrapWithAuthorize(src, { rangeHint: null });
-if (!edit) process.exit(1);
-console.log('inserted:Authorize'); // rulebook checks for this token
-process.exit(0);
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { LspClient } from './lsp-client.mjs';
+
+function usage() {
+  console.error('usage: node code-action-check.mjs --file <path>');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const args = { file: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--file') {
+      args.file = argv[i + 1] ?? null;
+      i += 1;
+      continue;
+    }
+  }
+  if (!args.file) {
+    usage();
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const filePath = resolve(args.file);
+  const text = await readFile(filePath, 'utf8');
+  const uri = pathToFileURL(filePath).toString();
+
+  const client = new LspClient();
+  try {
+    await client.initialize(null);
+    await client.sendNotification('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId: 'tf',
+        version: 1,
+        text,
+      },
+    });
+
+    await new Promise((resolve) => {
+      client.once('diagnostics', resolve);
+    });
+
+    const endPosition = { line: text.split(/\r?\n/).length - 1, character: (text.split(/\r?\n/).pop() ?? '').length };
+    const actions = await client.sendRequest('textDocument/codeAction', {
+      textDocument: { uri },
+      range: { start: { line: 0, character: 0 }, end: endPosition },
+      context: { diagnostics: [] },
+    });
+
+    const arrayActions = Array.isArray(actions) ? actions : [];
+    console.log(`actions:${arrayActions.length}`);
+    const inserted = arrayActions.some((action) => {
+      const edits = action?.edit?.changes?.[uri] ?? [];
+      return Array.isArray(edits) && edits.some((edit) => typeof edit?.newText === 'string' && edit.newText.includes('Authorize{ scope: "" }'));
+    });
+    if (inserted) {
+      console.log('inserted:Authorize');
+    }
+
+    await client.sendNotification('textDocument/didClose', {
+      textDocument: { uri },
+    });
+    await client.shutdown();
+    process.exit(inserted ? 0 : 1);
+  } catch (error) {
+    console.error(error);
+    try { await client.shutdown(); } catch {}
+    process.exit(1);
+  }
+}
+
+main();

--- a/tools/tf-lsp-sample/hover-check.mjs
+++ b/tools/tf-lsp-sample/hover-check.mjs
@@ -1,9 +1,75 @@
-#!/usr/bin/env node
-// Usage: node tools/tf-lsp-sample/hover-check.mjs --symbol "tf:network/publish@1"
-import { readFile } from 'node:fs/promises';
-const sym = process.argv[process.argv.indexOf('--symbol') + 1];
-const cat = JSON.parse(await readFile('packages/tf-l0-spec/spec/catalog.json', 'utf8'));
-const entry = (cat.primitives || []).find(p => p.id === sym);
-if (!entry) process.exit(1);
-console.log(`effects:${JSON.stringify(entry.effects || [])}`);
-process.exit(0);
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { LspClient } from './lsp-client.mjs';
+
+function usage() {
+  console.error('usage: node hover-check.mjs --symbol <symbol>');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const args = { symbol: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--symbol') {
+      args.symbol = argv[i + 1] ?? null;
+      i += 1;
+      continue;
+    }
+  }
+  if (!args.symbol) {
+    usage();
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const client = new LspClient();
+  const tempUri = pathToFileURL(resolve('out/tmp/hover.tf')).toString();
+  try {
+    await client.initialize(null);
+    await client.sendNotification('textDocument/didOpen', {
+      textDocument: {
+        uri: tempUri,
+        languageId: 'tf',
+        version: 1,
+        text: args.symbol,
+      },
+    });
+
+    const hover = await client.sendRequest('textDocument/hover', {
+      textDocument: { uri: tempUri },
+      position: { line: 0, character: Math.max(args.symbol.length - 1, 0) },
+    });
+
+    await client.sendNotification('textDocument/didClose', {
+      textDocument: { uri: tempUri },
+    });
+
+    const contents = hover?.contents;
+    let value = '';
+    if (!hover) {
+      console.log('hover:null');
+      await client.shutdown();
+      process.exit(1);
+    }
+    if (typeof contents === 'string') {
+      value = contents;
+    } else if (Array.isArray(contents)) {
+      value = contents.map((item) => (typeof item === 'string' ? item : item?.value ?? '')).join('\n');
+    } else if (contents && typeof contents === 'object') {
+      value = contents.value ?? '';
+    }
+    console.log(value);
+    await client.shutdown();
+    process.exit(value ? 0 : 1);
+  } catch (error) {
+    console.error(error);
+    try { await client.shutdown(); } catch {}
+    process.exit(1);
+  }
+}
+
+main();

--- a/tools/tf-lsp-sample/lsp-client.mjs
+++ b/tools/tf-lsp-sample/lsp-client.mjs
@@ -1,0 +1,127 @@
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+function toContent(message) {
+  const payload = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(payload, 'utf8')}\r\n\r\n${payload}`;
+}
+
+export class LspClient extends EventEmitter {
+  constructor() {
+    super();
+    const moduleDir = dirname(fileURLToPath(import.meta.url));
+    const serverPath = resolve(moduleDir, '../../packages/tf-lsp-server/bin/server.mjs');
+    this.proc = spawn('node', [serverPath, '--stdio'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.buffer = '';
+    this.nextId = 1;
+    this.pending = new Map();
+
+    this.proc.stdout.setEncoding('utf8');
+    this.proc.stdout.on('data', (chunk) => {
+      this.buffer += chunk;
+      this.#processBuffer();
+    });
+
+    this.proc.stderr.setEncoding('utf8');
+    this.proc.stderr.on('data', (chunk) => {
+      if (chunk.trim().length > 0) {
+        this.emit('stderr', chunk);
+      }
+    });
+
+    this.proc.on('exit', (code) => {
+      for (const [, resolver] of this.pending) {
+        resolver.reject(new Error(`LSP server exited with code ${code ?? 0}`));
+      }
+      this.pending.clear();
+    });
+  }
+
+  async initialize(rootUri = null) {
+    const params = {
+      processId: process.pid,
+      rootUri,
+      capabilities: {},
+    };
+    const result = await this.sendRequest('initialize', params);
+    await this.sendNotification('initialized', {});
+    return result;
+  }
+
+  sendRequest(method, params) {
+    const id = this.nextId;
+    this.nextId += 1;
+    const message = { jsonrpc: '2.0', id, method, params };
+    const payload = toContent(message);
+    this.proc.stdin.write(payload, 'utf8');
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+  }
+
+  async sendNotification(method, params) {
+    const message = { jsonrpc: '2.0', method, params };
+    const payload = toContent(message);
+    await new Promise((resolve) => this.proc.stdin.write(payload, 'utf8', resolve));
+  }
+
+  async shutdown() {
+    try {
+      await this.sendRequest('shutdown', null);
+      await this.sendNotification('exit', null);
+    } catch {
+      this.proc.kill();
+    }
+  }
+
+  #processBuffer() {
+    while (true) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (headerEnd === -1) {
+        return;
+      }
+      const header = this.buffer.slice(0, headerEnd);
+      const lengthMatch = /Content-Length: (\d+)/i.exec(header);
+      if (!lengthMatch) {
+        this.buffer = this.buffer.slice(headerEnd + 4);
+        continue;
+      }
+      const length = Number.parseInt(lengthMatch[1], 10);
+      const totalLength = headerEnd + 4 + length;
+      if (this.buffer.length < totalLength) {
+        return;
+      }
+      const body = this.buffer.slice(headerEnd + 4, totalLength);
+      this.buffer = this.buffer.slice(totalLength);
+      try {
+        const message = JSON.parse(body);
+        this.#handleMessage(message);
+      } catch (error) {
+        this.emit('error', error);
+      }
+    }
+  }
+
+  #handleMessage(message) {
+    if (typeof message.id === 'number' && this.pending.has(message.id)) {
+      const { resolve, reject } = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      if ('error' in message) {
+        reject(new Error(String(message.error?.message ?? 'Unknown error')));
+        return;
+      }
+      resolve(message.result);
+      return;
+    }
+    if (message.method) {
+      this.emit('notification', message);
+      if (message.method === 'textDocument/publishDiagnostics') {
+        this.emit('diagnostics', message.params);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a standalone tf LSP package with build scripts and runtime entry point
- implement server features for parsing, diagnostics, hover metadata, and authorize-wrapping code actions
- add sample Terraform flows plus CLI probes for diagnostics, hover, and code-action validation using a lightweight LSP client

## Testing
- pnpm -C packages/tf-lsp-server build
- node tools/tf-lsp-sample/diag-check.mjs --file samples/a1/illegal_write.tf
- node tools/tf-lsp-sample/diag-check.mjs --file samples/a1/protected_write.tf
- node tools/tf-lsp-sample/hover-check.mjs --symbol tf:network/publish@1
- node tools/tf-lsp-sample/code-action-check.mjs --file samples/a1/protected_write.tf


------
https://chatgpt.com/codex/tasks/task_e_68d31f7d0ac8832091a95f4c7a00c938