### PR TITLE
node:A3-SourceMaps cp:cp2_client_command

### DIFF
--- a/clients/vscode-tf/dist/extension.d.ts
+++ b/clients/vscode-tf/dist/extension.d.ts
@@ -1,0 +1,16 @@
+import type * as vscode from 'vscode';
+type SourceMapParams = {
+    symbol: string;
+    file: string;
+};
+interface SourceMapClient {
+    onReady?: () => Promise<void>;
+    sendRequest<R>(method: string, params: SourceMapParams): Promise<R>;
+    stop?: () => Promise<void>;
+}
+export declare function __setLanguageClient(client: SourceMapClient | null): void;
+export declare function __setVscodeModule(module: typeof import('vscode') | null): void;
+export declare function runShowTraceSource(client: SourceMapClient, editorOverride?: vscode.TextEditor | null): Promise<void>;
+export declare function activate(context: vscode.ExtensionContext): Promise<void>;
+export declare function deactivate(): Promise<void>;
+export {};

--- a/clients/vscode-tf/dist/extension.js
+++ b/clients/vscode-tf/dist/extension.js
@@ -1,0 +1,150 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.__setLanguageClient = __setLanguageClient;
+exports.__setVscodeModule = __setVscodeModule;
+exports.runShowTraceSource = runShowTraceSource;
+exports.activate = activate;
+exports.deactivate = deactivate;
+let languageClient = null;
+let vscodeModule = null;
+function __setLanguageClient(client) {
+    languageClient = client;
+}
+function __setVscodeModule(module) {
+    vscodeModule = module;
+}
+function getVscode() {
+    if (!vscodeModule) {
+        const loaded = require('vscode');
+        vscodeModule = loaded;
+    }
+    return vscodeModule;
+}
+async function ensureLanguageClient(context) {
+    if (languageClient) {
+        return languageClient;
+    }
+    try {
+        const { LanguageClient, TransportKind } = await Promise.resolve().then(() => __importStar(require('vscode-languageclient/node')));
+        const serverModule = context.asAbsolutePath('../../packages/tf-lsp-server/dist/server.js');
+        const serverOptions = {
+            run: { module: serverModule, transport: 2 /* TransportKind.ipc */ },
+            debug: { module: serverModule, transport: 2 /* TransportKind.ipc */, options: { execArgv: ['--nolazy', '--inspect=6009'] } }
+        };
+        const clientOptions = { documentSelector: [{ scheme: 'file' }] };
+        const client = new LanguageClient('tfLanguageServer', 'TF Language Server', serverOptions, clientOptions);
+        context.subscriptions.push(client.start());
+        languageClient = client;
+        return client;
+    }
+    catch (error) {
+        console.error('tf.showTraceSource: language client unavailable', error);
+        return null;
+    }
+}
+function activeEditor(editor) {
+    if (editor) {
+        return editor;
+    }
+    return getVscode().window.activeTextEditor ?? null;
+}
+function extractSymbol(editor) {
+    const document = editor.document;
+    const selection = editor.selection;
+    if (selection && !selection.isEmpty) {
+        const text = document.getText(selection).trim();
+        if (text) {
+            return text;
+        }
+    }
+    const range = document.getWordRangeAtPosition(selection.active, /[A-Za-z0-9_:@\-]+/);
+    if (!range) {
+        return null;
+    }
+    const text = document.getText(range).trim();
+    return text || null;
+}
+function toVscodeRange(vscodeApi, range) {
+    const start = new vscodeApi.Position(range.start.line, range.start.character);
+    const end = new vscodeApi.Position(range.end.line, range.end.character);
+    return new vscodeApi.Range(start, end);
+}
+async function runShowTraceSource(client, editorOverride) {
+    const vscodeApi = getVscode();
+    const editor = activeEditor(editorOverride);
+    if (!editor) {
+        await vscodeApi.window.showWarningMessage('No active editor for TF trace source.');
+        return;
+    }
+    const symbol = extractSymbol(editor);
+    if (!symbol) {
+        await vscodeApi.window.showWarningMessage('Select a symbol to locate its source.');
+        return;
+    }
+    if (client.onReady) {
+        await client.onReady();
+    }
+    const params = { symbol, file: editor.document.uri.fsPath };
+    const result = await client.sendRequest('tf/sourceMap', params);
+    if (!result) {
+        await vscodeApi.window.showWarningMessage(`No source mapping found for ${symbol}.`);
+        return;
+    }
+    const mappedRange = toVscodeRange(vscodeApi, result);
+    editor.revealRange(mappedRange, 1 /* vscodeApi.TextEditorRevealType.InCenter */);
+    editor.selection = new vscodeApi.Selection(mappedRange.start, mappedRange.end);
+}
+async function activate(context) {
+    const vscodeApi = getVscode();
+    await ensureLanguageClient(context);
+    const disposable = vscodeApi.commands.registerCommand('tf.showTraceSource', async () => {
+        if (!languageClient) {
+            const ensured = await ensureLanguageClient(context);
+            if (!ensured) {
+                await vscodeApi.window.showWarningMessage('TF language client is not available.');
+                return;
+            }
+        }
+        await runShowTraceSource(languageClient);
+    });
+    context.subscriptions.push(disposable);
+}
+async function deactivate() {
+    if (languageClient && languageClient.stop) {
+        await languageClient.stop();
+    }
+    languageClient = null;
+}

--- a/clients/vscode-tf/package.json
+++ b/clients/vscode-tf/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tf-lang/vscode-tf",
+  "private": true,
+  "version": "0.0.0",
+  "description": "TF VS Code extension",
+  "main": "./dist/extension.js",
+  "types": "./dist/extension.d.ts",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "activationEvents": [
+    "onCommand:tf.showTraceSource"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "tf.showTraceSource",
+        "title": "TF: Show Trace Source"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json"
+  }
+}

--- a/clients/vscode-tf/src/extension.ts
+++ b/clients/vscode-tf/src/extension.ts
@@ -1,0 +1,140 @@
+import type * as vscode from 'vscode';
+
+type SourceMapRange = {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+};
+
+type SourceMapParams = {
+  symbol: string;
+  file: string;
+};
+
+interface SourceMapClient {
+  onReady?: () => Promise<void>;
+  sendRequest<R>(method: string, params: SourceMapParams): Promise<R>;
+  stop?: () => Promise<void>;
+}
+
+let languageClient: SourceMapClient | null = null;
+let vscodeModule: typeof import('vscode') | null = null;
+
+export function __setLanguageClient(client: SourceMapClient | null): void {
+  languageClient = client;
+}
+
+export function __setVscodeModule(module: typeof import('vscode') | null): void {
+  vscodeModule = module;
+}
+
+function getVscode(): typeof import('vscode') {
+  if (!vscodeModule) {
+    const loaded = require('vscode');
+    vscodeModule = loaded as typeof import('vscode');
+  }
+  return vscodeModule;
+}
+
+async function ensureLanguageClient(context: vscode.ExtensionContext): Promise<SourceMapClient | null> {
+  if (languageClient) {
+    return languageClient;
+  }
+  try {
+    const { LanguageClient, TransportKind } = await import('vscode-languageclient/node');
+    const serverModule = context.asAbsolutePath('../../packages/tf-lsp-server/dist/server.js');
+    const serverOptions = {
+      run: { module: serverModule, transport: TransportKind.ipc },
+      debug: { module: serverModule, transport: TransportKind.ipc, options: { execArgv: ['--nolazy', '--inspect=6009'] } }
+    };
+    const clientOptions = { documentSelector: [{ scheme: 'file' }] };
+    const client = new LanguageClient('tfLanguageServer', 'TF Language Server', serverOptions, clientOptions);
+    context.subscriptions.push(client.start());
+    languageClient = client;
+    return client;
+  } catch (error) {
+    console.error('tf.showTraceSource: language client unavailable', error);
+    return null;
+  }
+}
+
+function activeEditor(editor?: vscode.TextEditor | null): vscode.TextEditor | null {
+  if (editor) {
+    return editor;
+  }
+  return getVscode().window.activeTextEditor ?? null;
+}
+
+function extractSymbol(editor: vscode.TextEditor): string | null {
+  const document = editor.document;
+  const selection = editor.selection;
+  if (selection && !selection.isEmpty) {
+    const text = document.getText(selection).trim();
+    if (text) {
+      return text;
+    }
+  }
+  const range = document.getWordRangeAtPosition(selection.active, /[A-Za-z0-9_:@\-]+/);
+  if (!range) {
+    return null;
+  }
+  const text = document.getText(range).trim();
+  return text || null;
+}
+
+function toVscodeRange(vscodeApi: typeof import('vscode'), range: SourceMapRange): vscode.Range {
+  const start = new vscodeApi.Position(range.start.line, range.start.character);
+  const end = new vscodeApi.Position(range.end.line, range.end.character);
+  return new vscodeApi.Range(start, end);
+}
+
+export async function runShowTraceSource(
+  client: SourceMapClient,
+  editorOverride?: vscode.TextEditor | null
+): Promise<void> {
+  const vscodeApi = getVscode();
+  const editor = activeEditor(editorOverride);
+  if (!editor) {
+    await vscodeApi.window.showWarningMessage('No active editor for TF trace source.');
+    return;
+  }
+  const symbol = extractSymbol(editor);
+  if (!symbol) {
+    await vscodeApi.window.showWarningMessage('Select a symbol to locate its source.');
+    return;
+  }
+  if (client.onReady) {
+    await client.onReady();
+  }
+  const params: SourceMapParams = { symbol, file: editor.document.uri.fsPath };
+  const result = await client.sendRequest<SourceMapRange | null>('tf/sourceMap', params);
+  if (!result) {
+    await vscodeApi.window.showWarningMessage(`No source mapping found for ${symbol}.`);
+    return;
+  }
+  const mappedRange = toVscodeRange(vscodeApi, result);
+  editor.revealRange(mappedRange, vscodeApi.TextEditorRevealType.InCenter);
+  editor.selection = new vscodeApi.Selection(mappedRange.start, mappedRange.end);
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const vscodeApi = getVscode();
+  await ensureLanguageClient(context);
+  const disposable = vscodeApi.commands.registerCommand('tf.showTraceSource', async () => {
+    if (!languageClient) {
+      const ensured = await ensureLanguageClient(context);
+      if (!ensured) {
+        await vscodeApi.window.showWarningMessage('TF language client is not available.');
+        return;
+      }
+    }
+    await runShowTraceSource(languageClient as SourceMapClient);
+  });
+  context.subscriptions.push(disposable);
+}
+
+export async function deactivate(): Promise<void> {
+  if (languageClient && languageClient.stop) {
+    await languageClient.stop();
+  }
+  languageClient = null;
+}

--- a/clients/vscode-tf/src/shims-languageclient.d.ts
+++ b/clients/vscode-tf/src/shims-languageclient.d.ts
@@ -1,0 +1,24 @@
+declare module 'vscode-languageclient/node' {
+  import type { Disposable } from 'vscode';
+
+  export const enum TransportKind {
+    ipc = 2
+  }
+
+  export interface ServerOptions {
+    run: { module: string; transport: TransportKind };
+    debug: { module: string; transport: TransportKind; options?: Record<string, unknown> };
+  }
+
+  export interface LanguageClientOptions {
+    documentSelector?: Array<{ scheme?: string; language?: string }>;
+  }
+
+  export class LanguageClient {
+    constructor(id: string, name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions);
+    start(): Disposable;
+    onReady(): Promise<void>;
+    sendRequest<R>(method: string, params: unknown): Promise<R>;
+    stop(): Promise<void>;
+  }
+}

--- a/clients/vscode-tf/src/shims-node.d.ts
+++ b/clients/vscode-tf/src/shims-node.d.ts
@@ -1,0 +1,1 @@
+declare function require(id: string): unknown;

--- a/clients/vscode-tf/src/shims-vscode.d.ts
+++ b/clients/vscode-tf/src/shims-vscode.d.ts
@@ -1,0 +1,62 @@
+declare module 'vscode' {
+  export type Thenable<T> = PromiseLike<T>;
+
+  export interface Disposable {
+    dispose(): void;
+  }
+
+  export interface ExtensionContext {
+    readonly subscriptions: Disposable[];
+    asAbsolutePath(relativePath: string): string;
+  }
+
+  export namespace commands {
+    function registerCommand(command: string, callback: (...args: unknown[]) => unknown): Disposable;
+    function executeCommand<T = unknown>(command: string, ...args: unknown[]): Thenable<T | undefined>;
+  }
+
+  export namespace window {
+    const activeTextEditor: TextEditor | undefined;
+    function showWarningMessage(message: string): Thenable<void>;
+  }
+
+  export const enum TextEditorRevealType {
+    InCenter = 1
+  }
+
+  export class Position {
+    constructor(line: number, character: number);
+    readonly line: number;
+    readonly character: number;
+  }
+
+  export class Range {
+    constructor(start: Position, end: Position);
+    readonly start: Position;
+    readonly end: Position;
+  }
+
+  export class Selection extends Range {
+    constructor(anchor: Position, active: Position);
+    readonly anchor: Position;
+    readonly active: Position;
+    readonly isEmpty: boolean;
+  }
+
+  export interface Uri {
+    readonly fsPath: string;
+  }
+
+  export interface TextDocument {
+    readonly uri: Uri;
+    getText(range?: Range): string;
+    getWordRangeAtPosition(position: Position, regexp?: RegExp): Range | undefined;
+  }
+
+  export interface TextEditor {
+    document: TextDocument;
+    selection: Selection;
+    selections: Selection[];
+    revealRange(range: Range, revealType?: TextEditorRevealType): void;
+  }
+}

--- a/clients/vscode-tf/tsconfig.json
+++ b/clients/vscode-tf/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Node"
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}

--- a/tools/vscode-smoke/command-check.mjs
+++ b/tools/vscode-smoke/command-check.mjs
@@ -1,0 +1,114 @@
+import { strict as assert } from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const extensionUrl = pathToFileURL(path.join(__dirname, '../../clients/vscode-tf/dist/extension.js')).href;
+const extension = await import(extensionUrl);
+
+class Position {
+  constructor(line, character) {
+    this.line = line;
+    this.character = character;
+  }
+}
+
+class Range {
+  constructor(start, end) {
+    this.start = start;
+    this.end = end;
+  }
+}
+
+class Selection extends Range {
+  constructor(anchor, active) {
+    super(anchor, active);
+    this.anchor = anchor;
+    this.active = active;
+    this.isEmpty = anchor.line === active.line && anchor.character === active.character;
+  }
+}
+
+const mockVscode = {
+  Position,
+  Range,
+  Selection,
+  TextEditorRevealType: { InCenter: 1 },
+  window: {
+    activeTextEditor: null,
+    async showWarningMessage() {
+      mockVscode.__warnings.push(Array.from(arguments));
+    }
+  },
+  commands: {
+    registerCommand() {
+      return { dispose() {} };
+    }
+  },
+  __warnings: []
+};
+
+extension.__setVscodeModule(mockVscode);
+
+class FakeDocument {
+  constructor(text) {
+    this.uri = { fsPath: '/tmp/fake.tf' };
+    this._text = text;
+  }
+
+  getText() {
+    return this._text;
+  }
+
+  getWordRangeAtPosition() {
+    return undefined;
+  }
+}
+
+class FakeEditor {
+  constructor(text) {
+    this.document = new FakeDocument(text);
+    this._selection = new Selection(new Position(0, 0), new Position(0, text.length));
+    this.selections = [this._selection];
+    this.revealed = null;
+  }
+
+  get selection() {
+    return this._selection;
+  }
+
+  set selection(value) {
+    this._selection = value;
+    this.selections[0] = value;
+  }
+
+  revealRange(range, revealType) {
+    this.revealed = { range, revealType };
+  }
+}
+
+const calls = [];
+const stubClient = {
+  async onReady() {
+    calls.push(['onReady']);
+  },
+  async sendRequest(method, params) {
+    calls.push([method, params]);
+    return { start: { line: 1, character: 2 }, end: { line: 1, character: 8 } };
+  }
+};
+
+const editor = new FakeEditor('tf:network/publish@1');
+await extension.runShowTraceSource(stubClient, editor);
+
+assert.deepEqual(calls[0], ['onReady']);
+assert.equal(calls[1][0], 'tf/sourceMap');
+assert.equal(calls[1][1].symbol, 'tf:network/publish@1');
+assert.equal(calls[1][1].file, '/tmp/fake.tf');
+assert.ok(editor.revealed, 'editor did not reveal range');
+assert.equal(editor.revealed.range.start.line, 1);
+assert.equal(editor.selection.start.character, 2);
+
+console.log(JSON.stringify({ ok: true, calls: calls.length }));


### PR DESCRIPTION
## Summary
- add a `tf/sourceMap` LSP request that resolves the first regex match of a symbol inside a file
- add a VS Code `tf.showTraceSource` command that asks the server for a source map and reveals the range in the editor
- add a node smoke helper to exercise the command handler with a stub client

## Testing
- pnpm exec tsc -p packages/tf-lsp-server/tsconfig.json
- pnpm exec tsc -p clients/vscode-tf/tsconfig.json
- node tools/vscode-smoke/command-check.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d417f379b88320aa0e90af743b7c44