### PR TITLE
node:A3-SourceMaps cp:cp2_client_command

### DIFF
--- a/clients/vscode-tf/package.json
+++ b/clients/vscode-tf/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vscode-tf",
+  "displayName": "TF Language Tools",
+  "version": "0.0.1",
+  "publisher": "tf-lang",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "activationEvents": [
+    "onCommand:tf.showTraceSource"
+  ],
+  "main": "./dist/extension.js",
+  "type": "module",
+  "contributes": {
+    "commands": [
+      {
+        "command": "tf.showTraceSource",
+        "title": "TF: Show Trace Source"
+      }
+    ]
+  }
+}

--- a/clients/vscode-tf/package.json
+++ b/clients/vscode-tf/package.json
@@ -6,6 +6,9 @@
   "engines": {
     "vscode": "^1.80.0"
   },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "activationEvents": [
     "onCommand:tf.showTraceSource"
   ],

--- a/clients/vscode-tf/src/extension.ts
+++ b/clients/vscode-tf/src/extension.ts
@@ -1,0 +1,207 @@
+import path from 'node:path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import {
+  StreamMessageReader,
+  StreamMessageWriter,
+  createMessageConnection,
+  type MessageConnection,
+  RequestType
+} from 'vscode-jsonrpc/node.js';
+
+type VsModule = typeof import('vscode');
+
+interface DisposableLike { dispose(): unknown; }
+
+interface ExtensionLikeContext {
+  asAbsolutePath(relativePath: string): string;
+  subscriptions: DisposableLike[];
+}
+
+interface BasicPosition { line: number; character: number; }
+
+interface BasicRange { start: BasicPosition; end: BasicPosition; }
+
+interface EditorLike {
+  selection: BasicRange & { isEmpty: boolean; active: BasicPosition };
+  document: {
+    getText(range?: BasicRange): string;
+    getWordRangeAtPosition(position: BasicPosition, regex?: RegExp): BasicRange | undefined;
+    uri: { fsPath: string };
+  };
+  revealRange(range: unknown, revealType?: unknown): void;
+}
+
+export interface SourceMapParams {
+  symbol: string;
+  file: string;
+}
+
+export interface SourceMapRange {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+}
+
+export interface SourceMapWorkflowInput {
+  symbol: string | null;
+  file: string | null;
+}
+
+export type SourceMapRequester = (params: SourceMapParams) => Promise<SourceMapRange | null>;
+export type SourceMapRevealer = (range: SourceMapRange) => void;
+export type SourceMapNotifier = (message: string) => void;
+
+const SourceMapRequest = new RequestType<SourceMapParams, SourceMapRange | null, void>('tf/sourceMap');
+
+let vscodeModule: Promise<VsModule> | null = null;
+let lspConnection: MessageConnection | null = null;
+let lspProcess: ChildProcessWithoutNullStreams | null = null;
+let connectionPromise: Promise<MessageConnection> | null = null;
+let initializePromise: Promise<void> | null = null;
+
+async function loadVscode(): Promise<VsModule> {
+  if (!vscodeModule) {
+    vscodeModule = import('vscode');
+  }
+  return vscodeModule;
+}
+
+async function ensureConnection(context: ExtensionLikeContext): Promise<MessageConnection> {
+  if (!connectionPromise) {
+    connectionPromise = (async () => {
+      const serverModule = context.asAbsolutePath(path.join('..', '..', 'packages', 'tf-lsp-server', 'dist', 'server.js'));
+      lspProcess = spawn(process.execPath, [serverModule, '--stdio'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      const reader = new StreamMessageReader(lspProcess.stdout);
+      const writer = new StreamMessageWriter(lspProcess.stdin);
+      const connection = createMessageConnection(reader, writer);
+      connection.listen();
+      lspConnection = connection;
+      lspProcess.stderr.setEncoding('utf8');
+      lspProcess.stderr.on('data', data => {
+        const text = data.toString();
+        if (text.trim()) {
+          console.error(`[tf-lsp] ${text.trim()}`);
+        }
+      });
+      lspProcess.on('exit', () => {
+        connection.dispose();
+        lspConnection = null;
+        lspProcess = null;
+        connectionPromise = null;
+        initializePromise = null;
+      });
+      return connection;
+    })();
+  }
+  return connectionPromise;
+}
+
+async function ensureInitialized(context: ExtensionLikeContext): Promise<MessageConnection> {
+  const connection = await ensureConnection(context);
+  if (!initializePromise) {
+    initializePromise = (async () => {
+      await connection.sendRequest('initialize', {
+        processId: process.pid,
+        capabilities: {},
+        rootUri: null,
+        workspaceFolders: null
+      });
+      connection.sendNotification('initialized', {});
+    })();
+  }
+  await initializePromise;
+  return connection;
+}
+
+function pickSymbol(editor: EditorLike): string | null {
+  const selection = editor.selection;
+  const document = editor.document;
+  if (!selection.isEmpty) {
+    const selected = document.getText(selection).trim();
+    if (selected) {
+      return selected;
+    }
+  }
+  const wordRange = document.getWordRangeAtPosition(selection.active, /[A-Za-z0-9_:@\-]+/);
+  if (!wordRange) {
+    return null;
+  }
+  const word = document.getText(wordRange).trim();
+  return word || null;
+}
+
+export async function runSourceMapWorkflow(
+  input: SourceMapWorkflowInput,
+  request: SourceMapRequester,
+  reveal: SourceMapRevealer,
+  notify?: SourceMapNotifier
+): Promise<SourceMapRange | null> {
+  const symbol = (input.symbol || '').trim();
+  const file = input.file ? input.file.trim() : '';
+  if (!symbol || !file) {
+    notify?.('Select a symbol to map.');
+    return null;
+  }
+  const range = await request({ symbol, file });
+  if (!range) {
+    notify?.('No source range available for the selected symbol.');
+    return null;
+  }
+  reveal(range);
+  return range;
+}
+
+export async function activate(context: ExtensionLikeContext): Promise<void> {
+  const vscode = await loadVscode();
+  const command = vscode.commands.registerCommand('tf.showTraceSource', async () => {
+    const editor = vscode.window.activeTextEditor as EditorLike | undefined;
+    if (!editor) {
+      notifyUser(vscode, 'No active editor for TF source map.');
+      return;
+    }
+    const symbol = pickSymbol(editor);
+    const file = editor.document.uri.fsPath;
+    try {
+      await runSourceMapWorkflow(
+        { symbol, file },
+        async params => {
+          const connection = await ensureInitialized(context);
+          return connection.sendRequest(SourceMapRequest, params);
+        },
+        range => {
+          const start = new vscode.Position(range.start.line, range.start.character);
+          const end = new vscode.Position(range.end.line, range.end.character);
+          const target = new vscode.Range(start, end);
+          editor.revealRange(target, vscode.TextEditorRevealType.InCenter);
+        },
+        message => notifyUser(vscode, message)
+      );
+    } catch (err) {
+      notifyUser(vscode, `Failed to request source map: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  });
+  context.subscriptions.push(command as DisposableLike);
+}
+
+function notifyUser(vscode: VsModule, message: string): void {
+  void vscode.window.showInformationMessage(message);
+}
+
+export async function deactivate(): Promise<void> {
+  if (lspConnection) {
+    try {
+      await lspConnection.sendRequest('shutdown');
+    } catch {
+      // ignore shutdown errors
+    }
+    lspConnection.dispose();
+    lspConnection = null;
+  }
+  if (lspProcess) {
+    lspProcess.stdin.end();
+    lspProcess.kill();
+    lspProcess = null;
+  }
+  connectionPromise = null;
+  initializePromise = null;
+  vscodeModule = null;
+}

--- a/clients/vscode-tf/src/shims-vscode.d.ts
+++ b/clients/vscode-tf/src/shims-vscode.d.ts
@@ -1,0 +1,1 @@
+declare module 'vscode';

--- a/clients/vscode-tf/tsconfig.json
+++ b/clients/vscode-tf/tsconfig.json
@@ -6,11 +6,12 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
+    "noImplicitAny": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "declaration": false,
     "sourceMap": false
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/clients/vscode-tf/tsconfig.json
+++ b/clients/vscode-tf/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"]
+}

--- a/meta/checker.yml
+++ b/meta/checker.yml
@@ -11,6 +11,7 @@ forbid_paths:
   - "packages/tf-optimize/**"
   - "crates/**"
   - "**/*.generated.*"
+  - "clients/vscode-tf/dist/**"
 
 token_rules:
   - id: ts_any_type

--- a/packages/tf-lsp-server/src/server.ts
+++ b/packages/tf-lsp-server/src/server.ts
@@ -58,7 +58,15 @@ connection.onInitialized(() => {
   // No additional initialization behavior for the baseline server.
 });
 
-connection.onRequest('tf/sourceMap', async (params: { symbol?: string; file?: string }): Promise<Range | null> => {
+function escapeRegExp(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+}
+
+connection.onRequest('tf/sourceMap', async (params: { symbol?: string; file?: string; src_range?: Range | null }): Promise<Range | null> => {
+  const explicitRange = params?.src_range ?? null;
+  if (explicitRange) {
+    return explicitRange;
+  }
   const symbol = params?.symbol;
   const file = params?.file;
   if (!symbol || !file) {
@@ -72,7 +80,7 @@ connection.onRequest('tf/sourceMap', async (params: { symbol?: string; file?: st
   }
   let regex: RegExp;
   try {
-    regex = new RegExp(symbol, 'm');
+    regex = new RegExp(escapeRegExp(symbol), 'gm');
   } catch {
     return null;
   }

--- a/tools/vscode-smoke/command-check.mjs
+++ b/tools/vscode-smoke/command-check.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+const distModule = path.resolve(repoRoot, 'clients/vscode-tf/dist/extension.js');
+
+if (!existsSync(distModule)) {
+  const build = spawnSync('pnpm', ['exec', 'tsc', '-p', 'clients/vscode-tf/tsconfig.json'], { cwd: repoRoot, stdio: 'inherit' });
+  if ((build.status ?? 1) !== 0) {
+    throw new Error('Failed to compile VS Code extension for smoke test');
+  }
+}
+
+const { runSourceMapWorkflow } = await import(pathToFileURL(distModule).href);
+
+async function main() {
+  const calls = [];
+  const fakeRange = {
+    start: { line: 1, character: 2 },
+    end: { line: 1, character: 10 }
+  };
+  const result = await runSourceMapWorkflow(
+    { symbol: 'traceSymbol', file: '/tmp/example.tf' },
+    async params => {
+      calls.push({ kind: 'request', params });
+      return fakeRange;
+    },
+    range => {
+      calls.push({ kind: 'reveal', range });
+    },
+    message => {
+      calls.push({ kind: 'notify', message });
+    }
+  );
+
+  assert.deepEqual(result, fakeRange, 'Expected fake range to be returned');
+  assert.equal(calls.length, 2, 'Expected request and reveal calls');
+  assert.equal(calls[0].kind, 'request', 'First call should be request');
+  assert.equal(calls[1].kind, 'reveal', 'Second call should be reveal');
+  assert.deepEqual(calls[0].params, { symbol: 'traceSymbol', file: '/tmp/example.tf' });
+
+  console.log(JSON.stringify({ ok: true, calls, range: result }));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a tf/sourceMap custom request on the language server to locate symbols on disk
- implement a VS Code command that calls the new request and reveals the returned range in the editor
- provide a Node smoke helper that builds the extension if needed and exercises the source-map workflow helper

## Testing
- pnpm --filter @tf-lang/tf-lsp-server build
- pnpm exec tsc -p clients/vscode-tf/tsconfig.json
- node tools/vscode-smoke/command-check.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d417f379b88320aa0e90af743b7c44