### PR TITLE
feat(E1-E2-Proofs): solver gating

### DIFF
--- a/packages/tf-opt/bin/opt.mjs
+++ b/packages/tf-opt/bin/opt.mjs
@@ -2,6 +2,14 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
+const LAW_ALIAS = new Map([
+  ['law:emitmetric-commutes-with-pure', 'commute:emit-metric-with-pure'],
+  ['law:hash-idempotent', 'idempotent:hash'],
+  ['law:serialize-deserialize-eq-id', 'inverse:serialize-deserialize'],
+]);
+
+const LAW_NAME_PATTERN = /^(commute|idempotent|inverse):/;
+
 const arg = k => { const i = process.argv.indexOf(k); return i>=0 ? process.argv[i+1] : null; };
 if (process.argv.includes('--help')) { console.log('tf-opt --ir <file> [-o out.json] [--cost show] [--emit-used-laws <file>]'); process.exit(0); }
 
@@ -13,23 +21,122 @@ async function loadIR(p){
   try { return JSON.parse(await readFile(p, 'utf8')); } catch { return {}; }
 }
 
+function normalizeLawName(raw) {
+  if (typeof raw !== 'string') return null;
+  const value = raw.trim();
+  if (!value) return null;
+  if (LAW_ALIAS.has(value)) return LAW_ALIAS.get(value);
+  if (LAW_NAME_PATTERN.test(value)) return value;
+  return null;
+}
+
+function collectRewriteInfo(ir) {
+  const laws = new Set();
+  let rewrites = 0;
+
+  const visit = (node) => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const entry of node) visit(entry);
+      return;
+    }
+
+    const handledKeys = new Set();
+
+    if (Array.isArray(node.rewrites)) {
+      handledKeys.add('rewrites');
+      for (const rewrite of node.rewrites) {
+        if (!rewrite || typeof rewrite !== 'object') continue;
+        const law = normalizeLawName(rewrite.law ?? rewrite.law_id ?? rewrite.lawId ?? rewrite.id);
+        if (law) {
+          laws.add(law);
+          rewrites += 1;
+        }
+        // Some encoders may expose `laws` arrays per rewrite entry.
+        if (Array.isArray(rewrite.laws)) {
+          for (const entry of rewrite.laws) {
+            const normalized = normalizeLawName(entry);
+            if (normalized) {
+              laws.add(normalized);
+            }
+          }
+        }
+      }
+    }
+
+    if (Array.isArray(node.used_laws)) {
+      handledKeys.add('used_laws');
+      for (const entry of node.used_laws) {
+        const law = normalizeLawName(entry);
+        if (law) laws.add(law);
+      }
+    }
+
+    if (Array.isArray(node.laws)) {
+      handledKeys.add('laws');
+      for (const entry of node.laws) {
+        if (typeof entry === 'string') {
+          const law = normalizeLawName(entry);
+          if (law) laws.add(law);
+        } else if (entry && typeof entry === 'object') {
+          const law = normalizeLawName(entry.law ?? entry.id);
+          if (law) {
+            laws.add(law);
+            if (entry.applied === true) {
+              rewrites += 1;
+            }
+          }
+        }
+      }
+    }
+
+    const directLaw = normalizeLawName(node.law ?? node.law_id ?? node.lawId ?? node.id);
+    if (directLaw) {
+      laws.add(directLaw);
+      rewrites += 1;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (handledKeys.has(key)) continue;
+      if (key === 'law' || key === 'law_id' || key === 'lawId' || key === 'id') continue;
+      if (typeof value === 'string') {
+        const law = normalizeLawName(value);
+        if (law) laws.add(law);
+        continue;
+      }
+      visit(value);
+    }
+  };
+
+  visit(ir);
+
+  if (laws.size === 0) {
+    const prims = listPrims(ir);
+    if (prims.includes('hash') && prims.includes('emit-metric')) {
+      laws.add('commute:emit-metric-with-pure');
+      rewrites = Math.max(rewrites, 1);
+    }
+  }
+
+  return { laws, rewrites };
+}
+
 function listPrims(ir, acc = []) {
   if (!ir || typeof ir !== 'object') return acc;
   if (ir.node === 'Prim') acc.push((ir.prim || '').toLowerCase());
   for (const k of Object.keys(ir)) {
     const v = ir[k];
-    if (Array.isArray(v)) v.forEach(x => listPrims(x, acc));
+    if (Array.isArray(v)) v.forEach((x) => listPrims(x, acc));
     else if (v && typeof v === 'object') listPrims(v, acc);
   }
   return acc;
 }
 
 function rewritePlan(ir) {
-  // ultra-minimal: if sequence contains 'hash' then 'emit-metric', mark one rewrite
-  const prims = listPrims(ir);
-  const applied = prims.includes('hash') && prims.includes('emit-metric') ? 1 : 0;
-  const used_laws = applied ? ['commute:emit-metric-with-pure'] : [];
-  return { rewritesApplied: applied, used_laws };
+  const { laws, rewrites } = collectRewriteInfo(ir);
+  const used_laws = Array.from(laws).sort();
+  const rewritesApplied = rewrites > 0 ? rewrites : used_laws.length;
+  return { rewritesApplied, used_laws };
 }
 
 async function main(){

--- a/scripts/proofs/ci-gate.mjs
+++ b/scripts/proofs/ci-gate.mjs
@@ -1,21 +1,119 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { emitFlowEquivalence, listLawNames } from '../../packages/tf-l0-proofs/src/smt-laws.mjs';
 
-const arg = k => { const i = process.argv.indexOf(k); return i>=0 ? process.argv[i+1] : null; };
+const arg = (k) => {
+  const i = process.argv.indexOf(k);
+  return i >= 0 ? process.argv[i + 1] : null;
+};
+
+const KNOWN_LAWS = new Set(listLawNames());
 
 if (process.argv.includes('--check-used')) {
   const p = arg('--check-used');
-  const data = JSON.parse(await readFile(p, 'utf8'));
-  const missing = Array.isArray(data.used_laws) ? [] : ['unknown'];
+  if (!p) {
+    console.error('Missing path for --check-used');
+    process.exit(2);
+  }
+  const raw = await readFile(p, 'utf8');
+  const data = JSON.parse(raw);
+  const used = Array.isArray(data.used_laws) ? data.used_laws : [];
+  const missing = [];
+  for (const entry of used) {
+    if (!KNOWN_LAWS.has(entry)) {
+      missing.push(entry);
+    }
+  }
   console.log(JSON.stringify({ ok: missing.length === 0, missing }, null, 2));
   process.exit(missing.length === 0 ? 0 : 1);
 }
 
 if (process.argv.includes('--small')) {
-  // Tiny stub: pretend UNSAT (good) for bounded small graph
-  console.log(JSON.stringify({ ok: true, solver: 'stub', details: 'UNSAT (bounded)' }, null, 2));
-  process.exit(0);
+  const flowPath = arg('--small');
+  if (!flowPath) {
+    console.error('Missing flow path for --small');
+    process.exit(2);
+  }
+  const raw = await readFile(flowPath, 'utf8');
+  const flow = parseFlow(raw);
+  const witness = buildCommuteWitness(flow);
+  if (!witness) {
+    console.log(JSON.stringify({ ok: false, reason: 'unsupported-flow' }, null, 2));
+    process.exit(1);
+  }
+  const program = emitFlowEquivalence(witness.original, witness.reordered, [
+    'commute:emit-metric-with-pure',
+  ]);
+  const result = await runZ3(program);
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
 }
 
 console.log('Usage: ci-gate.mjs --check-used <file> | --small <flow.tf>');
 process.exit(2);
+
+function parseFlow(source) {
+  const cleaned = source
+    .replace(/seq\s*\{/gi, '')
+    .replace(/\}/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .join(' ');
+  return cleaned
+    .split('|>')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+function buildCommuteWitness(flow) {
+  if (flow.length !== 2) return null;
+  const [a, b] = flow;
+  if (a === 'hash' && b === 'emit-metric') {
+    return { original: flow, reordered: [b, a] };
+  }
+  if (a === 'emit-metric' && b === 'hash') {
+    return { original: flow, reordered: [b, a] };
+  }
+  return null;
+}
+
+async function runZ3(program) {
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    const child = spawn('z3', ['-in', '-smt2']);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', (error) => {
+      resolve({
+        ok: false,
+        solver: 'z3',
+        details: 'spawn-error',
+        error: error.message,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        code: null,
+      });
+    });
+    child.on('close', (code) => {
+      const trimmed = stdout.trim();
+      const ok = code === 0 && /^unsat$/im.test(trimmed);
+      resolve({
+        ok,
+        solver: 'z3',
+        details: ok ? 'UNSAT (flows equivalent)' : 'SAT/UNKNOWN',
+        stdout: trimmed,
+        stderr: stderr.trim(),
+        code,
+      });
+    });
+    child.stdin.end(program);
+  });
+}


### PR DESCRIPTION
## Summary
- teach tf-opt to collect law identifiers from IR metadata and normalise legacy aliases before emitting rewrite plans
- extend the proofs CI gate to validate used-law lists and to run a small Z3-based commute witness when available

## Testing
- node packages/tf-opt/bin/opt.mjs --ir out/0.4/ir/signing.ir.json --emit-used-laws out/0.5/proofs/used-laws.json
- node scripts/proofs/ci-gate.mjs --check-used out/0.5/proofs/used-laws.json
- bash -lc 'command -v z3 >/dev/null 2>&1 || { echo "{\"ok\": true, \"skipped\": \"z3 not found\"}"; exit 0; }; node scripts/proofs/ci-gate.mjs --small samples/e1/small_flow.tf'
- node tools/tf-lang-cli/index.mjs run E1-E2-Proofs cp1_linkage --diff out/tmp/latest.diff
- node tools/tf-lang-cli/index.mjs run E1-E2-Proofs cp2_solver_gate --diff out/tmp/latest.diff

------
https://chatgpt.com/codex/tasks/task_e_68d53a4756848320996b10bde851cf0c