### PR TITLE
fix(LSP+Parser): robust authorize wrapper + tolerate 'authorize {'

### DIFF
--- a/packages/tf-compose/src/parser.mjs
+++ b/packages/tf-compose/src/parser.mjs
@@ -91,7 +91,11 @@ function tokenize(src) {
     }
 
     if (src.startsWith('authorize', i)) {
-      const next = src[i + 9] ?? '';
+      let lookahead = i + 9;
+      while (lookahead < src.length && /\s/.test(src[lookahead])) {
+        lookahead += 1;
+      }
+      const next = src[lookahead] ?? '';
       if (next === '{' || next === '(') {
         consumeWord('authorize');
         tokens.push(makeToken('REGION_AUTH', null, start));

--- a/packages/tf-lsp-server/src/actions/wrap-authorize.mjs
+++ b/packages/tf-lsp-server/src/actions/wrap-authorize.mjs
@@ -1,3 +1,15 @@
+function getBaseIndent(lines) {
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const match = line.match(/^(\s*)/);
+    if (match) {
+      return match[1] ?? '';
+    }
+    return '';
+  }
+  return '';
+}
+
 export function wrapWithAuthorize(src, range = {}) {
   const start = typeof range?.start === 'number' ? range.start : 0;
   const end = typeof range?.end === 'number' ? range.end : src.length;
@@ -9,25 +21,36 @@ export function wrapWithAuthorize(src, range = {}) {
   const inside = src.slice(safeStart, safeEnd);
   const after = src.slice(safeEnd);
 
-  const lines = inside.split(/\r?\n/);
+  const trailingNewline = /\r?\n$/.test(inside);
+  const normalizedInside = inside.replace(/\r\n/g, '\n');
+  const lines = normalizedInside.split('\n');
+
+  if (trailingNewline && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
   while (lines.length && !lines[lines.length - 1].trim()) {
     lines.pop();
   }
 
-  const firstNonEmpty = lines.find(line => line.trim().length > 0);
-  const baseIndent = firstNonEmpty ? (firstNonEmpty.match(/^(\s*)/)?.[1] ?? '') : '';
+  const baseIndent = getBaseIndent(lines);
 
-  const indentedBody = lines
-    .map(line => {
-      if (!line.trim()) return baseIndent;
-      const normalized = line.startsWith(baseIndent) ? line.slice(baseIndent.length) : line.trimStart();
-      return `${baseIndent}  ${normalized}`;
-    })
-    .join('\n');
+  const indentedLines = lines.map(line => {
+    if (!line.trim()) {
+      return '';
+    }
+    let normalized;
+    if (baseIndent && line.startsWith(baseIndent)) {
+      normalized = line.slice(baseIndent.length);
+    } else {
+      normalized = line.trimStart();
+    }
+    return `${baseIndent}  ${normalized}`;
+  });
 
-  const trailingNewline = /\r?\n$/.test(inside);
+  const indentedBody = indentedLines.join('\n');
   const bodySection = indentedBody ? `${indentedBody}\n` : '';
-  let newText = `${baseIndent}Authorize{ scope: "" } {\n${bodySection}${baseIndent}}`;
+  let newText = `${baseIndent}authorize{ scope: "" } {\n${bodySection}${baseIndent}}`;
   if (trailingNewline) {
     newText += '\n';
   }

--- a/packages/tf-lsp-server/src/actions/wrap-authorize.test.mjs
+++ b/packages/tf-lsp-server/src/actions/wrap-authorize.test.mjs
@@ -1,0 +1,56 @@
+// @tf-test kind=unit area=tf-lsp speed=fast deps=none
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { wrapWithAuthorize } from './wrap-authorize.mjs';
+
+const CASES = [
+  {
+    name: 'handles leading blank lines with trailing newline',
+    before: 'task "example" {\n',
+    selection: '\n    alpha();\n      beta();\n',
+    after: '}\n',
+    expectedReplacement:
+      '    authorize{ scope: "" } {\n\n      alpha();\n        beta();\n    }\n',
+  },
+  {
+    name: 'preserves mixed tab and space indentation without final newline',
+    before: 'module "mix" {\n',
+    selection: '\t  first();\n\t\tsecond();',
+    after: '\n}\n',
+    expectedReplacement:
+      '\t  authorize{ scope: "" } {\n\t    first();\n\t    second();\n\t  }',
+  },
+  {
+    name: 'trims trailing blank lines but keeps final newline intent',
+    before: 'config {\n',
+    selection: '      gamma();\n\n\n',
+    after: '}\n',
+    expectedReplacement:
+      '      authorize{ scope: "" } {\n        gamma();\n      }\n',
+  },
+  {
+    name: 'drops trailing blank lines without adding a newline',
+    before: 'locals {\n',
+    selection: '    delta();\n\n   ',
+    after: '\n}\n',
+    expectedReplacement:
+      '    authorize{ scope: "" } {\n      delta();\n    }',
+  },
+];
+
+for (const { name, before, selection, after, expectedReplacement } of CASES) {
+  test(name, () => {
+    const source = `${before}${selection}${after}`;
+    const range = { start: before.length, end: before.length + selection.length };
+    const result = wrapWithAuthorize(source, range);
+
+    assert.equal(result.start, range.start);
+    assert.equal(result.end, range.end);
+    assert.equal(result.newText, expectedReplacement);
+
+    const applied = `${before}${result.newText}${after}`;
+    const expectedDocument = `${before}${expectedReplacement}${after}`;
+    assert.equal(applied, expectedDocument);
+  });
+}

--- a/packages/tf-lsp-server/src/server.ts
+++ b/packages/tf-lsp-server/src/server.ts
@@ -208,7 +208,7 @@ async function computeWrapAuthorizeActions(params: CodeActionParams, doc: TextDo
   };
 
   const action: CodeAction = {
-    title: 'Wrap with Authorize{ scope: "" }',
+    title: 'Wrap with authorize{ scope: "" }',
     kind: CodeActionKind.QuickFix,
     edit: {
       changes: {

--- a/scripts/lsp-smoke/stdio.mjs
+++ b/scripts/lsp-smoke/stdio.mjs
@@ -118,7 +118,7 @@ async function main() {
     console.log(JSON.stringify({ titles }, null, 2));
     const ok = grep
       ? titles.some(t => t.includes(grep))
-      : titles.some(t => /Authorize/.test(t));
+      : titles.some(t => t.includes('authorize{ scope:'));
     process.exit(ok ? 0 : 2);
   }
 }


### PR DESCRIPTION
## Summary
- preserve selection indentation and whitespace when building the authorize quick fix by factoring a base-indent helper that skips leading blanks, normalizes blank lines, and respects trailing newline intent
- accept optional whitespace before `{` when tokenizing authorize blocks so both `authorize{` and `authorize {` parse
- update the server code action title and smoke probe to the lowercase `authorize{ scope: "" }` token so the quick fix is discoverable
- add unit tests covering leading blanks, mixed indentation, and trailing blank line selections for the authorize wrapper

## Testing
- node --test packages/tf-lsp-server/src/actions/wrap-authorize.test.mjs
- node scripts/lsp-smoke/stdio.mjs --mode codeAction --file samples/a4/let_decl.tf
- pnpm -C packages/tf-lsp-server build

------
https://chatgpt.com/codex/tasks/task_e_68daff4d5df88320b49609c711a6593a