### PR TITLE
feat(proofs): finalize schema validation

### DIFF
--- a/packages/tf-l0-proofs/src/smt-laws.microtest.mjs
+++ b/packages/tf-l0-proofs/src/smt-laws.microtest.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { validateLawEntries } from './smt-laws.mjs';
+
+assert.throws(
+  () =>
+    validateLawEntries({
+      'malformed:test-law': {
+        name: 'Malformed test law',
+        axioms: ['(assert true)'],
+      },
+    }),
+  (error) => {
+    assert.ok(error instanceof Error, 'Expected an Error instance');
+    assert.match(error.message, /malformed:test-law/);
+    assert.match(error.message, /missing an id/i);
+    return true;
+  },
+  'validateLawEntries should flag entries missing identifiers',
+);
+
+console.log('smt-laws validation micro-test passed');

--- a/scripts/proofs/ci-gate.mjs
+++ b/scripts/proofs/ci-gate.mjs
@@ -30,7 +30,8 @@ function parseSmallFlow(source) {
     .replace(/#.*$/gm, '');
   const withoutSeq = cleaned.replace(/\bseq\s*\{/gi, '').replace(/\}/g, '');
   return withoutSeq
-    .split('|>')
+    .replace(/\|\s*>/g, '\n')
+    .split(/\n+/)
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0)
     .map((segment) => canonicalPrimitiveName(segment.split(/\s+/)[0]))
@@ -279,6 +280,7 @@ if (process.argv.includes('--small')) {
       status: 'missing-laws',
       data: {
         ...baseData,
+        status: 'missing-laws',
         missing_laws: unknown.sort((a, b) => a.localeCompare(b)),
       },
     };
@@ -315,6 +317,7 @@ if (process.argv.includes('--small')) {
   }
   const data = {
     ...baseDataWithSmt,
+    status,
     stdout: stdout || undefined,
     stderr: stderr || undefined,
   };

--- a/tf/blocks/E1-E2-Proofs/rulebook.yml
+++ b/tf/blocks/E1-E2-Proofs/rulebook.yml
@@ -5,6 +5,7 @@ phases:
     rules:
       - used_laws_present
       - no_missing_laws
+      - smt_law_schema_microtest
 
   cp2_solver_gate:
     rules:
@@ -20,6 +21,11 @@ rules:
     kind: process
     cmd: node scripts/proofs/ci-gate.mjs --check-used out/0.5/proofs/used-laws.json
     expect: { code: 0, contains: '"missing": []' }
+
+  smt_law_schema_microtest:
+    kind: process
+    cmd: node --eval "import('./packages/tf-l0-proofs/src/smt-laws.microtest.mjs')"
+    expect: { code: 0, contains: 'smt-laws validation micro-test passed' }
 
   z3_optional_small:
     kind: process


### PR DESCRIPTION
## Summary
- freeze and expose the normalized SMT law registry with stable iteration helpers
- add a node micro-test to ensure malformed laws are rejected and wire it into the proofs rulebook
- keep the small-solver gate data-focused while reporting solver status and skip details cleanly

## Testing
- node --eval "import('./packages/tf-l0-proofs/src/smt-laws.microtest.mjs')"
- node scripts/proofs/ci-gate.mjs --check-used out/0.5/proofs/used-laws.json
- node scripts/proofs/ci-gate.mjs --small samples/e1/small_flow.tf

------
https://chatgpt.com/codex/tasks/task_e_68daff61ba648320a1852b55f2e3ac69