### PR TITLE
chore(optimizer): stable plan emission + sorted used_laws/rewrites

### DIFF
--- a/packages/tf-opt/lib/tests/utils.test.mjs
+++ b/packages/tf-opt/lib/tests/utils.test.mjs
@@ -1,0 +1,88 @@
+// @tf-test kind: product speed: fast deps: node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  stableStringify,
+  normalizeRewriteEntries,
+  buildUsedLawManifest,
+} from '../utils.mjs';
+
+const COMMUTE_LAW = 'commute:emit-metric-with-pure';
+const INVERSE_LAW = 'inverse:serialize-deserialize';
+const IDEMPOTENT_LAW = 'idempotent:hash';
+
+test('stableStringify sorts object keys recursively', () => {
+  const input = {
+    beta: 1,
+    alpha: {
+      zeta: 3,
+      gamma: 2,
+    },
+  };
+  const expected = [
+    '{',
+    '  "alpha": {',
+    '    "gamma": 2,',
+    '    "zeta": 3',
+    '  },',
+    '  "beta": 1',
+    '}',
+  ].join('\n');
+  assert.equal(stableStringify(input), expected);
+});
+
+test('normalizeRewriteEntries dedupes and sorts by rewrite then law', () => {
+  const entries = [
+    { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+    { law: INVERSE_LAW, rewrite: 'normalize-io' },
+    { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+    { law: IDEMPOTENT_LAW, rewrite: 'dedupe-hash' },
+    { law: INVERSE_LAW, rewrite: 'normalize-io' },
+    { law: COMMUTE_LAW, rewrite: 'adjust-primitives' },
+  ];
+  assert.deepEqual(normalizeRewriteEntries(entries), [
+    { law: COMMUTE_LAW, rewrite: 'adjust-primitives' },
+    { law: IDEMPOTENT_LAW, rewrite: 'dedupe-hash' },
+    { law: INVERSE_LAW, rewrite: 'normalize-io' },
+    { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+  ]);
+});
+
+test('buildUsedLawManifest merges plan data and extras deterministically', () => {
+  const initialPlan = {
+    used_laws: [INVERSE_LAW, COMMUTE_LAW],
+    rewrites: [
+      { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+      { law: INVERSE_LAW, rewrite: 'normalize-io' },
+    ],
+  };
+  const planOnly = buildUsedLawManifest({ plans: [initialPlan] });
+  assert.deepEqual(planOnly, {
+    used_laws: [COMMUTE_LAW, INVERSE_LAW],
+    rewrites: [
+      { law: INVERSE_LAW, rewrite: 'normalize-io' },
+      { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+    ],
+  });
+
+  const postPlan = {
+    used_laws: [IDEMPOTENT_LAW],
+    rewrites: [
+      { law: IDEMPOTENT_LAW, rewrite: 'dedupe-hash' },
+      { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+    ],
+  };
+  const manifest = buildUsedLawManifest({
+    plans: [initialPlan, postPlan],
+    extras: [[IDEMPOTENT_LAW], new Set([COMMUTE_LAW])],
+  });
+  assert.deepEqual(manifest, {
+    used_laws: [COMMUTE_LAW, IDEMPOTENT_LAW, INVERSE_LAW],
+    rewrites: [
+      { law: IDEMPOTENT_LAW, rewrite: 'dedupe-hash' },
+      { law: INVERSE_LAW, rewrite: 'normalize-io' },
+      { law: COMMUTE_LAW, rewrite: 'swap-hash-emit' },
+    ],
+  });
+});

--- a/packages/tf-opt/lib/utils.mjs
+++ b/packages/tf-opt/lib/utils.mjs
@@ -1,0 +1,94 @@
+import { isKnownLaw } from './data.mjs';
+
+function normalizeForStableStringify(value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeForStableStringify);
+  }
+  if (value && typeof value === 'object') {
+    const next = {};
+    for (const key of Object.keys(value).sort()) {
+      next[key] = normalizeForStableStringify(value[key]);
+    }
+    return next;
+  }
+  return value;
+}
+
+export function stableStringify(value) {
+  return JSON.stringify(normalizeForStableStringify(value), null, 2);
+}
+
+export function normalizeRewriteEntries(entries = []) {
+  const dedupe = new Map();
+  const unknownLaws = new Set();
+  for (const entry of entries || []) {
+    if (!entry || typeof entry !== 'object') continue;
+    const law = typeof entry.law === 'string' ? entry.law.trim() : '';
+    const rewrite = typeof entry.rewrite === 'string' ? entry.rewrite.trim() : '';
+    if (!law || !rewrite) continue;
+    if (!isKnownLaw(law)) {
+      unknownLaws.add(law);
+      continue;
+    }
+    const key = `${rewrite}\u0000${law}`;
+    if (!dedupe.has(key)) {
+      dedupe.set(key, { law, rewrite });
+    }
+  }
+
+  if (unknownLaws.size > 0) {
+    throw new Error(`unknown law(s): ${Array.from(unknownLaws).sort().join(', ')}`);
+  }
+
+  const sorted = Array.from(dedupe.values());
+  sorted.sort((a, b) => {
+    const rewriteCmp = a.rewrite.localeCompare(b.rewrite);
+    if (rewriteCmp !== 0) return rewriteCmp;
+    return a.law.localeCompare(b.law);
+  });
+
+  return sorted;
+}
+
+export function buildUsedLawManifest({ plans = [], extras = [] } = {}) {
+  const usedLawSet = new Set();
+  const rewriteEntries = [];
+
+  for (const plan of plans || []) {
+    if (!plan || typeof plan !== 'object') continue;
+    if (Array.isArray(plan.used_laws)) {
+      for (const law of plan.used_laws) {
+        if (typeof law !== 'string') continue;
+        const trimmed = law.trim();
+        if (trimmed) usedLawSet.add(trimmed);
+      }
+    }
+    if (Array.isArray(plan.rewrites)) {
+      rewriteEntries.push(...plan.rewrites);
+    }
+  }
+
+  for (const group of extras || []) {
+    if (!group) continue;
+    const iterable = Array.isArray(group) || group instanceof Set ? group : [];
+    for (const law of iterable) {
+      if (typeof law !== 'string') continue;
+      const trimmed = law.trim();
+      if (trimmed) usedLawSet.add(trimmed);
+    }
+  }
+
+  const used_laws = Array.from(usedLawSet).sort();
+  const rewrites = normalizeRewriteEntries(rewriteEntries);
+
+  if (used_laws.some((law) => !isKnownLaw(law))) {
+    const unknown = used_laws.filter((law) => !isKnownLaw(law));
+    throw new Error(`unknown law(s): ${unknown.sort().join(', ')}`);
+  }
+
+  const manifest = { used_laws };
+  if (rewrites.length > 0) {
+    manifest.rewrites = rewrites;
+  }
+  return manifest;
+}


### PR DESCRIPTION
## Summary
- ensure the optimizer builds plans with deterministically sorted used laws and rewrites via shared utilities
- emit used-law manifests from a single helper covering plan-only and apply flows with optional extras
- add targeted utils tests for stable stringify, rewrite normalization, and manifest unions

## Testing
- node packages/tf-opt/bin/opt.mjs --ir out/0.4/ir/signing.ir.json --plan-only > /tmp/plan1.json
- node packages/tf-opt/bin/opt.mjs --ir out/0.4/ir/signing.ir.json --plan-only > /tmp/plan2.json
- diff -u /tmp/plan1.json /tmp/plan2.json
- node packages/tf-opt/bin/opt.mjs --ir out/0.4/ir/signing.ir.json --emit-used-laws /tmp/used.json
- jq '.used_laws|. == ( .|sort )' /tmp/used.json
- node --test packages/tf-opt/lib/tests/utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68daff8a66bc8320b80dc9a66bb93c04