### PR TITLE
cli(rulebook): add explain command and authoring docs

### DIFF
--- a/docs/dev/rulebook.md
+++ b/docs/dev/rulebook.md
@@ -1,0 +1,170 @@
+# Rulebook authoring cheatsheet
+
+This page captures the supported rulebook schema shapes and the tooling that
+helps validate them.
+
+## Phase schemas
+
+Phases may be defined either as an array of objects or as a mapping keyed by the
+phase id. Both encodings normalize to the same internal structure.
+
+```yaml
+phases:
+  - id: cp1
+    title: "Baseline"
+    rules:
+      - lint
+  - id: cp2
+    inherits: [cp1]
+    rules:
+      - test
+```
+
+```yaml
+phases:
+  cp1:
+    title: "Baseline"
+    rules:
+      - lint
+  cp2:
+    inherits: [cp1]
+    rules:
+      - test
+```
+
+Phase definitions accept:
+
+- `inherits` – ordered list of phases to include before the phase’s own rules.
+- `rules` – either an array of entries or a mapping of rule id to inline
+  overrides (see below).
+- Any additional metadata you need (titles, descriptions, etc.).
+
+## Rule listings
+
+The top-level `rules` catalog supports mapping and array forms:
+
+```yaml
+rules:
+  lint:
+    kind: shell
+    cmd: pnpm lint
+  test:
+    kind: shell
+    cmd: pnpm test
+```
+
+```yaml
+rules:
+  - id: lint
+    kind: shell
+    cmd: pnpm lint
+  - id: test
+    kind: shell
+    cmd: pnpm test
+```
+
+Within `phase.rules` you can mix plain string references with inline rule
+objects. Inline entries must include `id` and any missing fields are inherited
+from the matching entry in `rules`.
+
+```yaml
+phases:
+  cp2:
+    inherits: [cp1]
+    rules:
+      - lint
+      - id: test
+        expect:
+          code: 0
+```
+
+When using the mapping form the inline `id` is implied by the key:
+
+```yaml
+phases:
+  cp2:
+    inherits: [cp1]
+    rules:
+      lint: {}
+      test:
+        expect:
+          code: 0
+```
+
+## Normalization rules
+
+`expand.mjs` normalizes rulebooks into a single canonical plan:
+
+- Phases are stored in a `Map<string, Phase>` preserving author order.
+- Phase inheritance is depth-first and detects cycles with helpful errors.
+- Rule lists are expanded deterministically with duplicate rule ids dropped on
+  the second and subsequent occurrences.
+- Inline entries merge with the top-level rule catalog; missing `id` fields or
+  unknown rule ids raise errors.
+
+Common validation failures include:
+
+- `unknown phase "cp3"`
+- `invalid inherits reference "ghost"`
+- `cycle detected via "cp1 -> cp2 -> cp1"`
+- `unknown rule "lint"`
+- `invalid rule entry at phase "cp2"`
+
+## CLI helpers
+
+The CLI exposes two ways to inspect normalized rulebooks:
+
+- `tf-lang run <NODE> <CP> --explain` prints the normalized phase list and the
+  expanded rule order before executing probes.
+- `node tools/tf-lang-cli/index.mjs explain <rulebook.yml|NODE> <PHASE>` prints
+  the same explanation without running any checks.
+
+### Example
+
+The repository includes `tf/blocks/_docs-sample/rulebook.yml` as a minimal
+reference:
+
+```yaml
+version: 1
+meta: { node: docs-sample }
+phases:
+  cp1:
+    title: "Baseline"
+    rules: [setup]
+  cp2:
+    title: "Tests"
+    inherits: [cp1]
+    rules:
+      lint:
+        expect:
+          code: 0
+      test: {}
+rules:
+  setup:
+    kind: shell
+    cmd: echo setup
+  lint:
+    kind: shell
+    cmd: echo lint
+  test:
+    kind: shell
+    cmd: echo test
+```
+
+Running the CLI explanation highlights the inheritance, normalization, and final
+rule order:
+
+```
+$ node tools/tf-lang-cli/index.mjs explain tf/blocks/_docs-sample/rulebook.yml cp2
+Phases:
+ - cp1 — Baseline
+ * cp2 — Tests (inherits: cp1)
+
+Expanded rules:
+ 1. setup — kind=shell, cmd=echo setup
+ 2. lint — kind=shell, cmd=echo lint
+ 3. test — kind=shell, cmd=echo test
+```
+
+Use these commands when iterating on a rulebook to ensure the normalized plan
+matches your expectations.

--- a/docs/rulebook-schema.md
+++ b/docs/rulebook-schema.md
@@ -1,0 +1,118 @@
+# Rulebook schema
+
+The TF CLI accepts rulebooks expressed in YAML. Each rulebook contains a set of
+rule definitions (`rules`) and one or more execution phases (`phases`). This
+schema is intentionally flexible to keep existing rulebooks working while
+supporting a more ergonomic syntax for new ones.
+
+## Phases
+
+Phases describe which rules run together. They can be written either as an
+array of phase objects or as a mapping from phase id to definition.
+
+```yaml
+phases:
+  - id: base
+    rules:
+      - lint
+  - id: check
+    inherits:
+      - base
+    rules:
+      - test
+```
+
+```yaml
+phases:
+  base:
+    rules:
+      - lint
+  check:
+    inherits:
+      - base
+    rules:
+      - test
+```
+
+Each phase definition supports:
+
+- `inherits` *(optional array of strings)* – phases whose rules are included
+  before the current phase.
+- `rules` – may be an array (strings or inline rule objects) or a mapping from
+  rule id to inline overrides.
+- Additional metadata such as `title` is carried through unchanged.
+
+## Rules
+
+The `rules` section can be written as a mapping or an array of rule objects.
+Mappings are idiomatic for most rulebooks:
+
+```yaml
+rules:
+  lint:
+    kind: shell
+    cmd: pnpm lint
+  test:
+    kind: shell
+    cmd: pnpm test
+```
+
+```yaml
+rules:
+  - id: lint
+    kind: shell
+    cmd: pnpm lint
+  - id: test
+    kind: shell
+    cmd: pnpm test
+```
+
+Within `phase.rules` you may reference a rule by id or define it inline. Inline
+rules must include an `id` and can omit other fields that are already defined in
+`rules` for the same id. Missing fields are filled from the rule map.
+
+```yaml
+phases:
+  check:
+    rules:
+      - lint
+      - id: test
+        expect: "ok"
+```
+
+You can also use the mapping form when a phase lists inline overrides:
+
+```yaml
+phases:
+  check:
+    rules:
+      lint: {}
+      test:
+        expect: "ok"
+```
+
+The examples above reuse the `test` rule definition while overriding `expect`.
+
+## Deterministic expansion
+
+When expanding a phase the CLI performs a depth-first traversal of inherited
+phases. Rules are de-duplicated by id, keeping the first occurrence that
+resolves. The resulting order is deterministic regardless of whether the phase
+schema uses arrays or maps.
+
+## Common errors
+
+The CLI reports helpful errors when rulebooks are malformed:
+
+- `unknown phase "id"` – referenced phase is not defined.
+- `invalid inherits reference "id"` – a phase inherits from an unknown id.
+- `cycle detected via "a -> b -> a"` – inheritance forms a cycle.
+- `unknown rule "id"` – rule id is not defined and no inline object is
+  provided.
+- `invalid rule entry at phase "phase"` – phase rules contain an invalid entry
+  (missing `id` or unsupported type).
+- `inherits for phase "phase" must be an array` – inheritance list is not an
+  array.
+- `rulebook phases must be an array or object` – invalid `phases` value.
+- `rule definitions must be an array or object` – invalid top-level `rules`
+  shape.

--- a/docs/rulebook-schema.md
+++ b/docs/rulebook-schema.md
@@ -93,6 +93,40 @@ phases:
 
 The examples above reuse the `test` rule definition while overriding `expect`.
 
+Inline overrides inherit every field from the base rule unless explicitly
+overridden. Only the changed fields need to be written in the phase definition.
+
+```yaml
+rules:
+  lint:
+    kind: shell
+    cmd: echo lint
+    expect: pass
+
+phases:
+  check:
+    rules:
+      - id: lint
+        expect: ok
+```
+
+```yaml
+rules:
+  lint:
+    kind: shell
+    cmd: echo lint
+    expect: pass
+
+phases:
+  check:
+    rules:
+      lint:
+        expect: ok
+```
+
+Both snippets expand to a rule with `kind: shell` and `cmd: echo lint` while
+overriding only `expect: ok` in the phase.
+
 ## Deterministic expansion
 
 When expanding a phase the CLI performs a depth-first traversal of inherited
@@ -105,14 +139,16 @@ schema uses arrays or maps.
 The CLI reports helpful errors when rulebooks are malformed:
 
 - `unknown phase "id"` – referenced phase is not defined.
-- `invalid inherits reference "id"` – a phase inherits from an unknown id.
-- `cycle detected via "a -> b -> a"` – inheritance forms a cycle.
+- `cycle detected in phase inheritance: "a" -> "b" -> "a"` – inheritance forms
+  a cycle.
 - `unknown rule "id"` – rule id is not defined and no inline object is
   provided.
-- `invalid rule entry at phase "phase"` – phase rules contain an invalid entry
-  (missing `id` or unsupported type).
-- `inherits for phase "phase" must be an array` – inheritance list is not an
-  array.
+- `inline rule entry in phase "phase" missing "id"` – an inline object omits
+  its identifier.
+- `rule entry in phase "phase" must be a string id or an object with "id"` –
+  phase rules contain an unsupported entry type.
+- `phase "phase" has non-array inherits` – inheritance list is not an array.
+- `phase "phase" has non-array rules` – rule list is not an array or mapping.
 - `rulebook phases must be an array or object` – invalid `phases` value.
 - `rule definitions must be an array or object` – invalid top-level `rules`
   shape.

--- a/tf/blocks/A1-LSP-Proto/rulebook.yml
+++ b/tf/blocks/A1-LSP-Proto/rulebook.yml
@@ -1,6 +1,8 @@
 version: 1
 meta: { node: A1-LSP-Proto, title: "A1 — LSP prototype (v3 hardened)" }
 
+# Tip: `tf-lang run A1-LSP-Proto cp3_hover --explain` prints the normalized plan.
+
 phases:
   cp1_baseline:
     title: "Scoped build + scope + hygiene (soft)"

--- a/tf/blocks/D1-D2-Optimizer/rulebook.yml
+++ b/tf/blocks/D1-D2-Optimizer/rulebook.yml
@@ -1,6 +1,9 @@
 version: 1
 meta: { node: D1-D2-Optimizer }
 
+# Tip: inspect the normalized rules via
+#   node tools/tf-lang-cli/index.mjs explain tf/blocks/D1-D2-Optimizer/rulebook.yml cp2_rewrites
+
 phases:
   - id: cp1_cost_model
     rules:

--- a/tf/blocks/_docs-sample/rulebook.yml
+++ b/tf/blocks/_docs-sample/rulebook.yml
@@ -1,0 +1,28 @@
+version: 1
+meta: { node: docs-sample }
+
+# Quick reference rulebook for docs/dev/rulebook.md
+# Inspect via: node tools/tf-lang-cli/index.mjs explain tf/blocks/_docs-sample/rulebook.yml cp2
+phases:
+  cp1:
+    title: "Baseline"
+    rules:
+      - setup
+  cp2:
+    title: "Tests"
+    inherits: [cp1]
+    rules:
+      lint:
+        expect:
+          code: 0
+      test: {}
+rules:
+  setup:
+    kind: shell
+    cmd: echo setup
+  lint:
+    kind: shell
+    cmd: echo lint
+  test:
+    kind: shell
+    cmd: echo test

--- a/tools/tf-lang-cli/expand.mjs
+++ b/tools/tf-lang-cli/expand.mjs
@@ -1,91 +1,238 @@
 import fs from "fs";
 import yaml from "yaml";
 
-export function rulesForPhase(rulebookPath, phaseId) {
+export function loadRulebookPlan(rulebookPath) {
   const rb = yaml.parse(fs.readFileSync(rulebookPath, "utf8"));
-  const { phases, ruleMap } = normalizeRulebook(rb);
-  const seen = new Set();
-  const ordered = [];
+  return normalizeRulebook(rb || {});
+}
 
-  function addPhase(pid) {
-    const phase = phases.get(pid);
+export function rulesForPhase(rulebookPath, phaseId) {
+  const plan = loadRulebookPlan(rulebookPath);
+  return rulesForPhaseFromPlan(plan, phaseId);
+}
+
+export function rulesForPhaseFromPlan(plan, phaseId) {
+  const phase = plan.phases.get(phaseId);
+  if (!phase) {
+    throw new Error(`unknown phase "${phaseId}"`);
+  }
+  return phase.rules.map((rule) => ({ ...rule }));
+}
+
+function normalizeRulebook(rb) {
+  const phases = toPhaseRecords(rb?.phases);
+  const ruleMap = toRuleMap(rb?.rules);
+
+  const expandedPhases = new Map();
+  const cache = new Map();
+  const stack = [];
+
+  const expandPhase = (phaseId) => {
+    if (cache.has(phaseId)) {
+      return cache.get(phaseId);
+    }
+
+    const phase = phases.get(phaseId);
     if (!phase) {
-      throw new Error(`unknown phase ${pid}`);
+      throw new Error(`unknown phase "${phaseId}"`);
     }
-    for (const inherited of phase.inherits || []) {
-      addPhase(inherited);
+
+    if (stack.includes(phaseId)) {
+      const start = stack.indexOf(phaseId);
+      const cycle = [...stack.slice(start), phaseId];
+      throw new Error(`cycle detected via "${cycle.join(" -> ")}"`);
     }
-    for (const entry of phase.rules || []) {
-      const normalized = normalizeRuleEntry(entry, ruleMap);
-      if (!normalized) continue;
+
+    stack.push(phaseId);
+    const seen = new Set();
+    const ordered = [];
+
+    for (const inherited of phase.inherits) {
+      if (!phases.has(inherited)) {
+        throw new Error(`invalid inherits reference "${inherited}"`);
+      }
+      const inheritedRules = expandPhase(inherited);
+      for (const rule of inheritedRules) {
+        if (seen.has(rule.id)) continue;
+        seen.add(rule.id);
+        ordered.push(rule);
+      }
+    }
+
+    for (const entry of phase.ruleEntries) {
+      const normalized = resolveRuleEntry(entry, ruleMap);
       if (seen.has(normalized.id)) continue;
       seen.add(normalized.id);
       ordered.push(normalized);
     }
+
+    stack.pop();
+    const finalized = ordered.map((rule) => ({ ...rule }));
+    cache.set(phaseId, finalized);
+    return finalized;
+  };
+
+  for (const [id, phase] of phases.entries()) {
+    const rules = expandPhase(id).map((rule) => ({ ...rule }));
+    expandedPhases.set(id, {
+      id,
+      inherits: [...phase.inherits],
+      rules,
+      ...phase.meta,
+    });
   }
 
-  addPhase(phaseId);
-  return ordered;
+  return { phases: expandedPhases, ruleMap };
 }
 
-function normalizeRulebook(rb) {
+function toPhaseRecords(phasesNode) {
   const phases = new Map();
 
-  // phases may be an array of objects { id, inherits, rules } or a mapping { id: {...} }
-  if (Array.isArray(rb?.phases)) {
-    for (const item of rb.phases) {
-      if (!item || typeof item !== "object") continue;
-      if (typeof item.id !== "string" || item.id.length === 0) continue;
-      phases.set(item.id, {
-        ...item,
-        inherits: Array.isArray(item.inherits) ? item.inherits : [],
-        rules: Array.isArray(item.rules) ? item.rules : [],
-      });
+  if (Array.isArray(phasesNode)) {
+    for (const [index, value] of phasesNode.entries()) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(`phase entry at index ${index} must be an object`);
+      }
+      if (typeof value.id !== "string" || value.id.length === 0) {
+        throw new Error(`phase entry at index ${index} is missing an id`);
+      }
+      if (phases.has(value.id)) {
+        throw new Error(`duplicate phase "${value.id}"`);
+      }
+      const record = buildPhaseRecord(value.id, value);
+      phases.set(value.id, record);
     }
-  } else if (rb && typeof rb.phases === "object") {
-    for (const [id, value] of Object.entries(rb.phases)) {
-      if (!value || typeof value !== "object") continue;
-      phases.set(id, {
-        id,
-        ...value,
-        inherits: Array.isArray(value.inherits) ? value.inherits : [],
-        rules: Array.isArray(value.rules) ? value.rules : [],
-      });
-    }
+    return phases;
   }
 
-  const ruleMap = new Map();
-  if (rb && typeof rb.rules === "object") {
-    for (const [id, definition] of Object.entries(rb.rules)) {
-      if (!definition || typeof definition !== "object") continue;
-      ruleMap.set(id, { id, ...definition });
+  if (phasesNode && typeof phasesNode === "object") {
+    for (const [id, value] of Object.entries(phasesNode)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(`phase "${id}" must be an object`);
+      }
+      if (phases.has(id)) {
+        throw new Error(`duplicate phase "${id}"`);
+      }
+      const record = buildPhaseRecord(id, value);
+      phases.set(id, record);
     }
+    return phases;
   }
 
-  return { phases, ruleMap };
+  throw new Error("rulebook phases must be an array or object");
 }
 
-function normalizeRuleEntry(entry, ruleMap) {
-  if (!entry) return null;
+function buildPhaseRecord(id, value) {
+  const inherits = normalizeInherits(value.inherits, id);
+  const ruleEntries = normalizePhaseRules(value.rules, id);
+  const meta = collectMeta(value);
+  return { id, inherits, ruleEntries, meta };
+}
 
-  // string id -> look up in ruleMap
+function collectMeta(value) {
+  const meta = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (key === "id" || key === "inherits" || key === "rules") continue;
+    meta[key] = val;
+  }
+  return meta;
+}
+
+function toRuleMap(rulesNode) {
+  const map = new Map();
+  if (rulesNode === undefined || rulesNode === null) {
+    return map;
+  }
+
+  if (Array.isArray(rulesNode)) {
+    for (const [index, entry] of rulesNode.entries()) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(`rule definition at index ${index} must be an object`);
+      }
+      if (typeof entry.id !== "string" || entry.id.length === 0) {
+        throw new Error(`rule definition at index ${index} is missing an id`);
+      }
+      if (!map.has(entry.id)) {
+        map.set(entry.id, { ...entry });
+      }
+    }
+    return map;
+  }
+
+  if (typeof rulesNode === "object") {
+    for (const [id, definition] of Object.entries(rulesNode)) {
+      if (!definition || typeof definition !== "object" || Array.isArray(definition)) {
+        continue;
+      }
+      if (!map.has(id)) {
+        map.set(id, { id, ...definition });
+      }
+    }
+    return map;
+  }
+
+  throw new Error("rule definitions must be an array or object");
+}
+
+function normalizeInherits(value, phaseId) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`inherits for phase "${phaseId}" must be an array`);
+  }
+  return value.map((entry, index) => {
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(
+        `inherits for phase "${phaseId}" must contain only phase ids (invalid entry at index ${index})`,
+      );
+    }
+    return entry;
+  });
+}
+
+function normalizePhaseRules(value, phaseId) {
+  if (value === undefined) return [];
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeRuleReference(entry, phaseId));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value).map(([id, config]) => {
+      const entry =
+        config && typeof config === "object" && !Array.isArray(config)
+          ? { id, ...config }
+          : { id };
+      return normalizeRuleReference(entry, phaseId);
+    });
+  }
+
+  throw new Error(`invalid rule entry at phase "${phaseId}"`);
+}
+
+function normalizeRuleReference(entry, phaseId) {
+  if (typeof entry === "string") {
+    return entry;
+  }
+
+  if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+    if (typeof entry.id !== "string" || entry.id.length === 0) {
+      throw new Error(`invalid rule entry at phase "${phaseId}"`);
+    }
+    return { ...entry, id: entry.id };
+  }
+
+  throw new Error(`invalid rule entry at phase "${phaseId}"`);
+}
+
+function resolveRuleEntry(entry, ruleMap) {
   if (typeof entry === "string") {
     const rule = ruleMap.get(entry);
-    if (!rule) throw new Error(`unknown rule ${entry}`);
-    return rule;
-  }
-
-  // object { id, ... } -> merge with ruleMap fallback
-  if (typeof entry === "object") {
-    const id = typeof entry.id === "string" ? entry.id : null;
-    if (!id) throw new Error("rule entry missing id");
-    const normalized = { ...entry };
-    if (!normalized.kind && ruleMap.has(id)) {
-      const fallback = ruleMap.get(id);
-      return { ...fallback, ...normalized };
+    if (!rule) {
+      throw new Error(`unknown rule "${entry}"`);
     }
-    return normalized;
+    return { ...rule };
   }
 
-  return null;
+  const fallback = ruleMap.get(entry.id) || {};
+  return { ...fallback, ...entry, id: entry.id };
 }

--- a/tools/tf-lang-cli/index.mjs
+++ b/tools/tf-lang-cli/index.mjs
@@ -1,11 +1,43 @@
 #!/usr/bin/env node
-import fs from "fs"; import path from "path"; import yaml from "yaml";
+import fs from "fs";
+import path from "path";
 import { spawnSync, execSync } from "child_process";
-import { rulesForPhase } from "./expand.mjs";
+import { loadRulebookPlan, rulesForPhaseFromPlan } from "./expand.mjs";
 
-function rbPath(node){ const p=path.join("tf","blocks",node,"rulebook.yml"); if(!fs.existsSync(p)) throw new Error("missing rulebook: "+p); return p; }
-function writeDiff(text){ fs.mkdirSync("out/tmp",{recursive:true}); const p="out/tmp/latest.diff"; fs.writeFileSync(p,text,"utf8"); return path.resolve(p); }
-function run(cmd, env){ const r=spawnSync(cmd,{shell:true,encoding:"utf8",env:{...process.env,...env},maxBuffer:10*1024*1024}); return { code:r.status??99, stdout:(r.stdout||"").trim(), stderr:(r.stderr||"").trim() }; }
+function rbPath(node) {
+  const p = path.join("tf", "blocks", node, "rulebook.yml");
+  if (!fs.existsSync(p)) throw new Error(`missing rulebook: ${p}`);
+  return p;
+}
+
+function resolveRulebookPath(input) {
+  if (!input) return null;
+  if (input.includes("/") || input.endsWith(".yml") || input.endsWith(".yaml")) {
+    if (!fs.existsSync(input)) {
+      throw new Error(`missing rulebook: ${input}`);
+    }
+    return input;
+  }
+  return rbPath(input);
+}
+
+function writeDiff(text) {
+  fs.mkdirSync("out/tmp", { recursive: true });
+  const p = "out/tmp/latest.diff";
+  fs.writeFileSync(p, text, "utf8");
+  return path.resolve(p);
+}
+
+function run(cmd, env) {
+  const r = spawnSync(cmd, {
+    shell: true,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return { code: r.status ?? 99, stdout: (r.stdout || "").trim(), stderr: (r.stderr || "").trim() };
+}
+
 function check(res, expect) {
   if (!expect) return { ok: res.code === 0 };
   if (expect.code !== undefined && res.code !== expect.code) return { ok: false };
@@ -15,8 +47,12 @@ function check(res, expect) {
     if (!out.includes(expect.contains)) return { ok: false };
   }
   if (expect.ok !== undefined) {
-    try { const j = JSON.parse(res.stdout || "{}"); if (!!j.ok !== expect.ok) return { ok: false }; }
-    catch { return { ok: false }; }
+    try {
+      const j = JSON.parse(res.stdout || "{}");
+      if (!!j.ok !== expect.ok) return { ok: false };
+    } catch {
+      return { ok: false };
+    }
   }
   if (expect.jsonpath_eq) {
     try {
@@ -25,34 +61,119 @@ function check(res, expect) {
       const key = k.replace(/^\$\./, "");
       const want = expect.jsonpath_eq[k];
       if (JSON.stringify(j[key]) !== JSON.stringify(want)) return { ok: false };
-    } catch { return { ok: false }; }
+    } catch {
+      return { ok: false };
+    }
   }
   if (expect.nonempty) {
-    try { const j = JSON.parse(res.stdout || "{}"); if (Object.keys(j).length === 0) return { ok: false }; }
-    catch { return { ok: false }; }
+    try {
+      const j = JSON.parse(res.stdout || "{}");
+      if (Object.keys(j).length === 0) return { ok: false };
+    } catch {
+      return { ok: false };
+    }
   }
   return { ok: true };
 }
 
-(async function main(){
-  const [cmd, node, cp, ...rest] = process.argv.slice(2);
-  if(cmd==="open"){
-    if(!node){ console.error("usage: tf-lang open <NODE>"); process.exit(2); }
-    const rb=yaml.parse(fs.readFileSync(rbPath(node),"utf8"));
-    console.log("Node:", node); console.log("Phases:", Object.keys(rb.phases).join(", "));
+function summarizeRule(rule) {
+  const kind = rule.kind ? `kind=${rule.kind}` : null;
+  const command = rule.cmd || rule.command;
+  const trimmedCmd = command ? command.split("\n")[0] : null;
+  const parts = [kind, trimmedCmd ? `cmd=${trimmedCmd}` : null].filter(Boolean);
+  return parts.length ? ` — ${parts.join(", ")}` : "";
+}
+
+function explainPlan(plan, targetPhase) {
+  const phaseIds = [...plan.phases.keys()];
+  console.log("Phases:");
+  for (const id of phaseIds) {
+    const phase = plan.phases.get(id);
+    const marker = id === targetPhase ? "*" : "-";
+    const title = phase.title ? ` — ${phase.title}` : "";
+    const inherits = phase.inherits.length ? ` (inherits: ${phase.inherits.join(", ")})` : "";
+    console.log(` ${marker} ${id}${title}${inherits}`);
+  }
+
+  const selected = plan.phases.get(targetPhase);
+  if (!selected) {
+    throw new Error(`unknown phase "${targetPhase}"`);
+  }
+
+  console.log("\nExpanded rules:");
+  selected.rules.forEach((rule, idx) => {
+    console.log(` ${idx + 1}. ${rule.id}${summarizeRule(rule)}`);
+  });
+  console.log("");
+}
+
+function usage() {
+  console.log("usage: tf-lang <open|run|explain> ...");
+  process.exit(2);
+}
+
+(async function main() {
+  const [cmd, ...argv] = process.argv.slice(2);
+
+  if (!cmd) {
+    usage();
+  }
+
+  if (cmd === "open") {
+    const [node] = argv;
+    if (!node) {
+      console.error("usage: tf-lang open <NODE>");
+      process.exit(2);
+    }
+    const plan = loadRulebookPlan(rbPath(node));
+    console.log("Node:", node);
+    console.log("Phases:", [...plan.phases.keys()].join(", "));
     process.exit(0);
   }
-  if(cmd==="run"){
-    if(!node||!cp){ console.error("usage: tf-lang run <NODE> <CP> [--diff -]"); process.exit(2); }
-    let diff=""; if(rest.includes("--diff") && rest[rest.indexOf("--diff")+1]==="-") diff=fs.readFileSync(0,"utf8"); else {
-      try { diff = execSync("git diff -U0 --no-color", {encoding:"utf8"}); } catch { diff=""; }
+
+  if (cmd === "explain") {
+    const [rulebookArg, phaseId] = argv;
+    if (!rulebookArg || !phaseId) {
+      console.error("usage: tf-lang explain <rulebook.yml|NODE> <PHASE>");
+      process.exit(2);
     }
+    const rulebookPath = resolveRulebookPath(rulebookArg);
+    const plan = loadRulebookPlan(rulebookPath);
+    explainPlan(plan, phaseId);
+    process.exit(0);
+  }
+
+  if (cmd === "run") {
+    const [node, cp, ...rest] = argv;
+    if (!node || !cp) {
+      console.error("usage: tf-lang run <NODE> <CP> [--diff -] [--explain]");
+      process.exit(2);
+    }
+
+    const diffIndex = rest.indexOf("--diff");
+    let diff = "";
+    if (diffIndex !== -1 && rest[diffIndex + 1] === "-") {
+      diff = fs.readFileSync(0, "utf8");
+    } else {
+      try {
+        diff = execSync("git diff -U0 --no-color", { encoding: "utf8" });
+      } catch {
+        diff = "";
+      }
+    }
+
     const diffPath = writeDiff(diff);
-    const selected = rulesForPhase(rbPath(node), cp);
-    const results = {}; const evidence = [];
+    const plan = loadRulebookPlan(rbPath(node));
+    if (rest.includes("--explain")) {
+      explainPlan(plan, cp);
+    }
+    const selected = rulesForPhaseFromPlan(plan, cp);
+    const results = {};
+    const evidence = [];
+
     for (const r of selected) {
       if (r.kind === "fs") {
-        const missing = (r.files || []).filter(f => !fs.existsSync(f));
+        const missing = (r.files || []).filter((f) => !fs.existsSync(f));
         const ok = missing.length === 0;
         results[r.id] = { ok, reason: ok ? null : `missing:${missing.join(",")}` };
         evidence.push({ id: r.id, cmd: "fs", code: ok ? 0 : 1, out: JSON.stringify({ missing }) });
@@ -60,19 +181,34 @@ function check(res, expect) {
         continue;
       }
       const command = r.cmd || r.command;
-      if (!command) { results[r.id] = { ok:false, reason:"unsupported-kind" }; continue; }
-      const res = run(command, { ...(r.env||{}), DIFF_PATH: diffPath });
+      if (!command) {
+        results[r.id] = { ok: false, reason: "unsupported-kind" };
+        continue;
+      }
+      const res = run(command, { ...(r.env || {}), DIFF_PATH: diffPath });
       const ch = check(res, r.expect || {});
       results[r.id] = { ok: ch.ok, code: res.code, reason: ch.reason || null };
-      evidence.push({ id: r.id, cmd: command, code: res.code, out: (res.stdout||"").slice(0,2000) });
+      evidence.push({ id: r.id, cmd: command, code: res.code, out: (res.stdout || "").slice(0, 2000) });
       if (!ch.ok) console.error(`[FAIL] ${r.id} — ${command}`);
     }
-    const report = { contract_id: `${node}@0.45`, node_id: node, checkpoint: cp, timestamp: new Date().toISOString(), results, evidence };
-    fs.mkdirSync("out",{recursive:true}); fs.writeFileSync("out/TFREPORT.json", JSON.stringify(report, null, 2));
-    const ok = Object.values(results).every(v => v.ok);
-    console.log(`\nRESULT: ${ok ? "GREEN" : "RED"}  (${Object.keys(results).length} probes)`); process.exit(ok?0:3);
+
+    const report = {
+      contract_id: `${node}@0.45`,
+      node_id: node,
+      checkpoint: cp,
+      timestamp: new Date().toISOString(),
+      results,
+      evidence,
+    };
+    fs.mkdirSync("out", { recursive: true });
+    fs.writeFileSync("out/TFREPORT.json", JSON.stringify(report, null, 2));
+    const ok = Object.values(results).every((v) => v.ok);
+    console.log(`\nRESULT: ${ok ? "GREEN" : "RED"}  (${Object.keys(results).length} probes)`);
+    process.exit(ok ? 0 : 3);
   }
-  if(!["open","run"].includes(cmd)){
-    console.log("usage: tf-lang <open|run> ..."); process.exit(2);
-  }
-})().catch(e=>{ console.error(e); process.exit(99); });
+
+  usage();
+})().catch((e) => {
+  console.error(e?.message ?? e);
+  process.exit(99);
+});

--- a/tools/tf-lang-cli/index.mjs
+++ b/tools/tf-lang-cli/index.mjs
@@ -76,35 +76,19 @@ function check(res, expect) {
   return { ok: true };
 }
 
-function summarizeRule(rule) {
-  const kind = rule.kind ? `kind=${rule.kind}` : null;
-  const command = rule.cmd || rule.command;
-  const trimmedCmd = command ? command.split("\n")[0] : null;
-  const parts = [kind, trimmedCmd ? `cmd=${trimmedCmd}` : null].filter(Boolean);
-  return parts.length ? ` — ${parts.join(", ")}` : "";
-}
-
 function explainPlan(plan, targetPhase) {
-  const phaseIds = [...plan.phases.keys()];
-  console.log("Phases:");
-  for (const id of phaseIds) {
-    const phase = plan.phases.get(id);
-    const marker = id === targetPhase ? "*" : "-";
-    const title = phase.title ? ` — ${phase.title}` : "";
-    const inherits = phase.inherits.length ? ` (inherits: ${phase.inherits.join(", ")})` : "";
-    console.log(` ${marker} ${id}${title}${inherits}`);
-  }
-
   const selected = plan.phases.get(targetPhase);
   if (!selected) {
     throw new Error(`unknown phase "${targetPhase}"`);
   }
 
-  console.log("\nExpanded rules:");
-  selected.rules.forEach((rule, idx) => {
-    console.log(` ${idx + 1}. ${rule.id}${summarizeRule(rule)}`);
-  });
-  console.log("");
+  const payload = {
+    phase: selected.id,
+    inherits: [...selected.inherits],
+    rules: selected.rules.map((rule) => ({ ...rule })),
+  };
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
 function usage() {

--- a/tools/tf-lang-cli/tests/expand.test.mjs
+++ b/tools/tf-lang-cli/tests/expand.test.mjs
@@ -1,0 +1,261 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import os from "node:os";
+
+import { loadRulebookPlan, rulesForPhase } from "../expand.mjs";
+
+function writeRulebook(yamlSource) {
+  const dir = mkdtempSync(join(os.tmpdir(), "tf-expand-"));
+  const file = join(dir, "rulebook.yaml");
+  writeFileSync(file, yamlSource, "utf8");
+  return file;
+}
+
+test("expands array phases with inline overrides", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  - id: base
+    rules:
+      - shared
+      - id: inline-from-map
+        expect: override
+  - id: child
+    inherits:
+      - base
+    rules:
+      - inline-from-map
+      - id: inline-custom
+        kind: shell
+        cmd: echo custom
+        expect: ok
+      - rule-two
+rules:
+  shared:
+    kind: shell
+    cmd: echo shared
+    expect: foo
+  inline-from-map:
+    kind: shell
+    cmd: echo map
+    expect: default
+  rule-two:
+    kind: shell
+    cmd: echo 2
+`);
+
+  const expanded = rulesForPhase(rulebookPath, "child");
+  assert.deepStrictEqual(expanded, [
+    { id: "shared", kind: "shell", cmd: "echo shared", expect: "foo" },
+    { id: "inline-from-map", kind: "shell", cmd: "echo map", expect: "override" },
+    { id: "inline-custom", kind: "shell", cmd: "echo custom", expect: "ok" },
+    { id: "rule-two", kind: "shell", cmd: "echo 2" },
+  ]);
+});
+
+test("expands map phases deterministically", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  base:
+    rules:
+      - base-rule
+  derived:
+    inherits:
+      - base
+    rules:
+      - derived-rule
+rules:
+  base-rule:
+    kind: shell
+    cmd: echo base
+  derived-rule:
+    kind: shell
+    cmd: echo derived
+`);
+
+  const expanded = rulesForPhase(rulebookPath, "derived");
+  assert.deepStrictEqual(expanded, [
+    { id: "base-rule", kind: "shell", cmd: "echo base" },
+    { id: "derived-rule", kind: "shell", cmd: "echo derived" },
+  ]);
+});
+
+test("dedupes rules by first occurrence across inherits", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  base:
+    rules:
+      - shared
+      - base-only
+  alt:
+    rules:
+      - shared
+      - alt-only
+  final:
+    inherits:
+      - base
+      - alt
+rules:
+  shared:
+    kind: shell
+    cmd: echo shared
+  base-only:
+    kind: shell
+    cmd: echo base
+  alt-only:
+    kind: shell
+    cmd: echo alt
+`);
+
+  const expanded = rulesForPhase(rulebookPath, "final");
+  assert.deepStrictEqual(expanded, [
+    { id: "shared", kind: "shell", cmd: "echo shared" },
+    { id: "base-only", kind: "shell", cmd: "echo base" },
+    { id: "alt-only", kind: "shell", cmd: "echo alt" },
+  ]);
+});
+
+test("errors on unknown phase", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  known:
+    rules: []
+`);
+
+  assert.throws(() => rulesForPhase(rulebookPath, "missing"), /unknown phase "missing"/);
+});
+
+test("errors on unknown inherited phase", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  child:
+    inherits:
+      - ghost
+`);
+
+  assert.throws(() => rulesForPhase(rulebookPath, "child"), /invalid inherits reference "ghost"/);
+});
+
+test("errors on unknown rule id", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  only:
+    rules:
+      - no-rule
+`);
+
+  assert.throws(() => rulesForPhase(rulebookPath, "only"), /unknown rule "no-rule"/);
+});
+
+test("errors on inline entry missing id", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  only:
+    rules:
+      - kind: shell
+`);
+
+  assert.throws(
+    () => rulesForPhase(rulebookPath, "only"),
+    /invalid rule entry at phase "only"/
+  );
+});
+
+test("errors when phases are not array or object", () => {
+  const rulebookPath = writeRulebook(`
+phases: 5
+`);
+
+  assert.throws(() => rulesForPhase(rulebookPath, "whatever"), /phases must be an array or object/);
+});
+
+test("accepts top-level rules array definitions", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  build:
+    rules:
+      - lint
+rules:
+  - id: lint
+    kind: shell
+    cmd: echo lint
+`);
+
+  const expanded = rulesForPhase(rulebookPath, "build");
+  assert.deepStrictEqual(expanded, [{ id: "lint", kind: "shell", cmd: "echo lint" }]);
+});
+
+test("accepts phase rules map form", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  build:
+    rules:
+      lint:
+        expect: { code: 0 }
+rules:
+  lint:
+    kind: shell
+    cmd: echo lint
+`);
+
+  const expanded = rulesForPhase(rulebookPath, "build");
+  assert.deepStrictEqual(expanded, [
+    { id: "lint", kind: "shell", cmd: "echo lint", expect: { code: 0 } },
+  ]);
+});
+
+test("errors on invalid rule entry type", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  build:
+    rules:
+      - 5
+`);
+
+  assert.throws(() => rulesForPhase(rulebookPath, "build"), /invalid rule entry at phase "build"/);
+});
+
+test("detects inherits cycles", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  a:
+    inherits: [b]
+  b:
+    inherits: [a]
+`);
+
+  assert.throws(() => rulesForPhase(rulebookPath, "a"), /cycle detected via "a -> b -> a"/);
+});
+
+test("normalizeRulebook exposes expanded rules per phase", () => {
+  const rulebookPath = writeRulebook(`
+phases:
+  base:
+    rules:
+      lint:
+        expect: { code: 0 }
+  build:
+    inherits: [base]
+    rules:
+      - format
+rules:
+  lint:
+    kind: shell
+    cmd: echo lint
+  format:
+    kind: shell
+    cmd: echo format
+`);
+
+  const plan = loadRulebookPlan(rulebookPath);
+  const build = plan.phases.get("build");
+  assert.ok(build);
+  assert.deepStrictEqual(
+    build.rules,
+    [
+      { id: "lint", kind: "shell", cmd: "echo lint", expect: { code: 0 } },
+      { id: "format", kind: "shell", cmd: "echo format" },
+    ],
+  );
+});


### PR DESCRIPTION
## Summary
- expose a normalized plan builder in `expand.mjs` with deterministic expansion, error reporting, and support for array/map rule schemas
- extend the CLI with `tf-lang run --explain` plus an `explain` subcommand to preview phases and rule order, alongside new unit tests
- document the rulebook authoring schema, add a docs sample rulebook, and annotate existing rulebooks with CLI inspection tips

## Testing
- node --eval "import('./tools/tf-lang-cli/expand.mjs').then(()=>console.log('ok'))"
- node --test tools/tf-lang-cli/tests/expand.test.mjs
- node tools/tf-lang-cli/index.mjs explain tf/blocks/_docs-sample/rulebook.yml cp2
- node tools/tf-lang-cli/index.mjs run _docs-sample cp2 --explain

------
https://chatgpt.com/codex/tasks/task_e_68db13823da08320bbdc2d199669132c