### PR TITLE
docs: 0.5 overview landing and per-track quickstarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - TBD
+### Added
+- Authored `docs/0.5/overview.md` plus `docs/0.5/quickstarts/track-*.md` covering tracks A–F with commands, expected outputs, and `used_laws`/`rewrites` guidance.
+
+### Changed
+- Root README now links to the 0.5 overview/quickstarts and refreshes the pnpm-based Getting Started workflow.
+
+### Fixed
+- Documented remedies for frozen installs and missing optional dependencies in fast test runs.
+
+### Infra
+- Documented the doc link-check workflow so contributors can run `markdown-link-check` locally.
+
 ## [0.1.0] - 2025-09-09
 ### Added
 - **L0 runtimes:** TypeScript and Rust VMs with SSA bytecode, `ASSERT` opcode, and property-like tests for the law `rewind ∘ apply = id`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 Version: **v0.4**
 
+See the [0.5 Overview](docs/0.5/overview.md) for per-track guides, commands, and troubleshooting.
+
 ---
 
 ## What’s in 0.4
@@ -63,21 +65,18 @@ Version: **v0.4**
 
 ---
 
-## Quickstart
-
-### A) Standard developer setup
+## Getting Started
 
 ```bash
 pnpm -v && node -v
-pnpm -w -r install
+pnpm -w -r install --frozen-lockfile
 pnpm -w -r build
+pnpm run test:fast
+pnpm run proofs:coverage
+pnpm run pilot:build-run
 ```
 
-### B) Codex Cloud setup (one‑liner)
-
-```bash
-bash -lc "./scripts/codex/setup.sh"
-```
+Additional quickstarts (tracks A–F, optimizer, traces, proofs, release tooling) live under [`docs/0.5/quickstarts/`](docs/0.5/quickstarts/) and are linked from the [0.5 Overview](docs/0.5/overview.md).
 
 ---
 

--- a/docs/0.5/overview.md
+++ b/docs/0.5/overview.md
@@ -1,0 +1,48 @@
+# 0.5 Overview
+
+The 0.5 cycle keeps the A→F rails intact while tightening determinism and the hand-off between the CLI, optimizer, proofs, and runtime surfaces. Start here for a map of artifacts, commands, and quickstarts that let you run every track locally without guesswork.
+
+## Pipeline at a glance
+```
+Compose (.tf) ──▶ Parse / Format ──▶ Canonical IR ──▶ Optimizer ──▶ Proofs ──▶ Runtime ──▶ Trace & Perf
+                      │                │                │             │             │             │
+                      ▼                ▼                ▼             ▼             ▼             ▼
+                DSL spec & fmt   Manifest + law    used_laws &   SMT stubs &   TS/RS codegen   JSONL traces
+                                   registry refs      rewrites         coverage        + parity
+```
+
+Reference material: DSL + formatter ([`docs/l0-dsl.md`](../l0-dsl.md)), catalogs/effects ([`docs/l0-catalog.md`](../l0-catalog.md), [`docs/l0-effects.md`](../l0-effects.md)), optimizer rewrites ([`docs/proofs/README.md`](../proofs/README.md#manifest-validation-ci-gatemjs---check-used)), and parity harness details ([`docs/pilot-l0.md`](../pilot-l0.md)).
+
+*Determinism:* every emitted JSON/JSONL file is newline-terminated with sorted keys. Trace harnesses replay under fixed clocks—see the [pilot parity harness](../pilot-l0.md#parity-harness) for how we enforce this in CI.
+
+## Tracks
+
+| Track | Goal | Artifacts | Primary CLI |
+| --- | --- | --- | --- |
+| **A. Parse & Format** | Canonical DSL parsing, formatter, catalog ingest | `out/0.5/ir/*.json`, refreshed catalog/effects | `pnpm run a1`, `pnpm run tf -- parse`, `pnpm run tf -- fmt` |
+| **B. Runtime & Composition** | Deterministic IR, manifests, generated runners | `out/0.5/pilot-l0/**`, generated TS runtime | `PILOT_OUT_DIR=out/0.5/pilot-l0 pnpm run pilot:build-run`, `pnpm run tf -- canon`, `pnpm run tf -- emit` |
+| **C. Trace & Perf** | Capture/validate traces, summarize perf, parity diffs | `out/0.5/pilot-l0/trace.jsonl`, summaries under `out/0.5/**` | `pnpm run traces:validate`, `pnpm run traces:sample`, `pnpm run pilot:parity` |
+| **D. Optimizer** | Effect-aware rewrites + law manifests | `out/0.5/proofs/used-laws.json`, optimized plans | `node packages/tf-opt/bin/opt.mjs --ir … --emit-used-laws …` |
+| **E. Proofs** | Emit SMT/Alloy suites and confirm coverage | `out/0.5/proofs/**/*.smt2`, coverage reports | `pnpm run proofs:emit`, `node scripts/proofs/coverage.mjs --out out` |
+| **F. Release & DevEx** | Audits, determinism probes, docs + CI health | Audit JSON, determinism logs, link check | `pnpm run audit`, `pnpm run determinism`, `pnpm run docs:check` |
+
+* Jump directly into execution via the per-track quickstarts: [A](quickstarts/track-a-parse-format.md), [B](quickstarts/track-b-runtime.md), [C](quickstarts/track-c-trace-perf.md), [D](quickstarts/track-d-optimizer.md), [E](quickstarts/track-e-proofs.md), [F](quickstarts/track-f-release-devex.md).
+* Deep dives: DSL + catalog ([`docs/l0-dsl.md`](../l0-dsl.md), [`docs/l0-catalog.md`](../l0-catalog.md)), optimizer outputs ([`docs/proofs/README.md`](../proofs/README.md#manifest-validation-ci-gatemjs---check-used)), and law registry upkeep ([`docs/proofs/README.md`](../proofs/README.md#law-stubs-scriptsproofslaws)).
+
+## Workspace setup
+
+```bash
+pnpm -v && node -v
+pnpm -w -r install --frozen-lockfile
+pnpm -w -r build
+```
+
+After installing, the quickstarts assume you are inside the repo root with `pnpm` on your `PATH`.
+
+## Troubleshooting
+
+> **Frozen installs** – Always prefer `pnpm -w -r install --frozen-lockfile`. If pnpm reports lock drift, run `pnpm -w install --lockfile-only` and retry the install.
+>
+> **Missing optional deps in fast tests** – Product `fast` runners intentionally skip heavy integrations. Re-run with `pnpm run test:heavy --allow-missing-deps` when you need the full surface.
+>
+> **Law manifests** – Coverage failures usually mean the optimizer emitted a law with no stub. Revisit [`docs/proofs/README.md`](../proofs/README.md#law-stubs-scriptsproofslaws) to add the stub before re-running `node scripts/proofs/coverage.mjs --out out`.

--- a/docs/0.5/quickstarts/track-a-parse-format.md
+++ b/docs/0.5/quickstarts/track-a-parse-format.md
@@ -1,0 +1,47 @@
+# Track A — Parse & Format Quickstart
+
+Stay on the CLI surface that feeds every other track: regenerate IDs/catalog, parse DSL flows, and confirm canonical formatting.
+
+## Prerequisites
+
+- `pnpm -w -r install --frozen-lockfile`
+- Example flow: `examples/flows/signing.tf`
+- `jq` available on your `PATH`
+
+## Commands (3–7 steps)
+
+```bash
+FLOW=examples/flows/signing.tf
+OUT=out/0.5/a-track
+pnpm run a1
+pnpm run tf -- parse "$FLOW" -o "$OUT/signing.ir.json"
+pnpm run tf -- canon "$FLOW" -o "$OUT/signing.canon.json"
+node packages/tf-compose/bin/tf.mjs fmt "$FLOW" | tee "$OUT/signing.fmt.tf"
+jq -c '.children[0]' "$OUT/signing.ir.json"
+```
+
+## Expected output
+
+```
+> tf-lang@0.0.2 a1 /workspace/tf-lang
+catalog.json written with 14 primitives (seed union applied).
+...
+{"args":{},"node":"Prim","prim":"serialize","raw":"serialize"}
+serialize |> hash |> authorize{
+  sign-data(key_ref="k1")
+}
+```
+
+*Artifacts land under `out/0.5/a-track/**`. The parse/canon IRs are newline-terminated JSON; the formatter mirrors [`docs/l0-dsl.md`](../../l0-dsl.md) spacing rules.*
+
+## Where next?
+
+- DSL tokens & grammar: [`docs/l0-dsl.md`](../../l0-dsl.md)
+- Catalog + effects derivation: [`docs/l0-catalog.md`](../../l0-catalog.md), [`docs/l0-effects.md`](../../l0-effects.md)
+- Checker & rulebook CLI: [`docs/tf-check/USAGE.md`](../../tf-check/USAGE.md)
+
+> **Troubleshooting**
+>
+> - `node: command not found` – ensure you are on Node 20+ (check with `node -v`).
+> - pnpm warnings about lock drift – rerun `pnpm -w install --lockfile-only`, then repeat the quickstart.
+> - `jq: command not found` – install `jq` or drop the final verification line; all earlier steps still succeed.

--- a/docs/0.5/quickstarts/track-a-parse-format.md
+++ b/docs/0.5/quickstarts/track-a-parse-format.md
@@ -16,7 +16,7 @@ OUT=out/0.5/a-track
 pnpm run a1
 pnpm run tf -- parse "$FLOW" -o "$OUT/signing.ir.json"
 pnpm run tf -- canon "$FLOW" -o "$OUT/signing.canon.json"
-node packages/tf-compose/bin/tf.mjs fmt "$FLOW" | tee "$OUT/signing.fmt.tf"
+pnpm run tf -- fmt "$FLOW" | tee "$OUT/signing.fmt.tf"
 jq -c '.children[0]' "$OUT/signing.ir.json"
 ```
 

--- a/docs/0.5/quickstarts/track-b-runtime.md
+++ b/docs/0.5/quickstarts/track-b-runtime.md
@@ -16,7 +16,7 @@ OUT=out/0.5/pilot-l0
 PILOT_OUT_DIR="$OUT" pnpm run pilot:build-run
 jq '{ok, ops, effects}' "$OUT/status.json"
 head -n 1 "$OUT/trace.jsonl"
-node scripts/validate-trace.mjs --require-meta \
+pnpm run traces:validate --require-meta \
   --ir "$(jq -r .provenance.ir_hash "$OUT/status.json")" \
   --manifest "$(jq -r .provenance.manifest_hash "$OUT/status.json")" \
   --catalog "$(jq -r .provenance.catalog_hash "$OUT/status.json")" \
@@ -42,5 +42,5 @@ node scripts/validate-trace.mjs --require-meta \
 > **Troubleshooting**
 >
 > - `tf run.mjs: no capabilities provided` – the pilot helper injects caps automatically. If you run `run.mjs` manually, pass `--caps tests/fixtures/caps-pilot.json`.
-> - `node scripts/validate-trace.mjs …` exits non-zero – confirm you passed the hashes from the fresh `status.json`; stale IR/catalog hashes cause schema mismatches.
+> - `pnpm run traces:validate --require-meta …` exits non-zero – confirm you passed the hashes from the fresh `status.json`; stale IR/catalog hashes cause schema mismatches.
 > - Permission denied under `out/0.5/pilot-l0` – remove or `chmod` existing directories created by another user before re-running the helper.

--- a/docs/0.5/quickstarts/track-b-runtime.md
+++ b/docs/0.5/quickstarts/track-b-runtime.md
@@ -1,0 +1,46 @@
+# Track B — Runtime & Composition Quickstart
+
+Rebuild the pilot flow, generate the deterministic TypeScript runner, and confirm provenance hashes and trace output.
+
+## Prerequisites
+
+- Complete the Track A setup (catalog + IR)
+- `PILOT_OUT_DIR` writeable (defaults to `out/0.5/pilot-l0` below)
+- `jq` for inspecting JSON
+
+## Commands (3–7 steps)
+
+```bash
+FLOW=examples/flows/pilot_min.tf
+OUT=out/0.5/pilot-l0
+PILOT_OUT_DIR="$OUT" pnpm run pilot:build-run
+jq '{ok, ops, effects}' "$OUT/status.json"
+head -n 1 "$OUT/trace.jsonl"
+node scripts/validate-trace.mjs --require-meta \
+  --ir "$(jq -r .provenance.ir_hash "$OUT/status.json")" \
+  --manifest "$(jq -r .provenance.manifest_hash "$OUT/status.json")" \
+  --catalog "$(jq -r .provenance.catalog_hash "$OUT/status.json")" \
+  < "$OUT/trace.jsonl"
+```
+
+## Expected output
+
+```
+{"ok":true,"ops":5,"effects":["Network.Out","Observability","Storage.Write"]}
+{"ts":1750000000000,"prim_id":"tf:observability/emit-metric@1",...}
+{"invalid":0,"meta_checked":true,"ok":true,"total":5}
+```
+
+*The pilot script stamps fixed timestamps and hashes so reruns match byte-for-byte. Generated runners live under `out/0.5/pilot-l0/codegen-ts/` with patched manifests.*
+
+## Where next?
+
+- Runtime adapters & provenance: [`docs/pilot-l0.md`](../../pilot-l0.md)
+- Trace schema & parity harness: [`docs/trace-schema.md`](../../trace-schema.md), [`docs/T3-trace.md`](../../T3-trace.md)
+- Rulebook + checker harness: [`docs/tf-check/USAGE.md`](../../tf-check/USAGE.md)
+
+> **Troubleshooting**
+>
+> - `tf run.mjs: no capabilities provided` – the pilot helper injects caps automatically. If you run `run.mjs` manually, pass `--caps tests/fixtures/caps-pilot.json`.
+> - `node scripts/validate-trace.mjs …` exits non-zero – confirm you passed the hashes from the fresh `status.json`; stale IR/catalog hashes cause schema mismatches.
+> - Permission denied under `out/0.5/pilot-l0` – remove or `chmod` existing directories created by another user before re-running the helper.

--- a/docs/0.5/quickstarts/track-c-trace-perf.md
+++ b/docs/0.5/quickstarts/track-c-trace-perf.md
@@ -1,0 +1,54 @@
+# Track C — Trace & Perf Quickstart
+
+Summarize trace traffic, validate provenance hashes, and prep for parity drills.
+
+## Prerequisites
+
+- Completed Track B run (`out/0.5/pilot-l0/**` populated)
+- `jq` installed
+- Access to `tests/fixtures/trace-sample.jsonl`
+
+## Commands (3–7 steps)
+
+```bash
+OUT=out/0.5/trace
+mkdir -p "$OUT"
+pnpm run traces:sample > "$OUT/sample-summary.json"
+jq '.total' "$OUT/sample-summary.json"
+pnpm run traces:validate --require-meta \
+  --ir "$(jq -r .provenance.ir_hash out/0.5/pilot-l0/status.json)" \
+  --manifest "$(jq -r .provenance.manifest_hash out/0.5/pilot-l0/status.json)" \
+  --catalog "$(jq -r .provenance.catalog_hash out/0.5/pilot-l0/status.json)" \
+  < out/0.5/pilot-l0/trace.jsonl
+head -n 5 "$OUT/sample-summary.json"
+```
+
+## Expected output
+
+```
+10
+{"invalid":0,"meta_checked":true,"ok":true,"total":5}
+{
+  "by_effect": {
+    "Network.Out": 3,
+    "Observability": 2,
+    "Pure": 3,
+    "Storage.Write": 2
+  },
+  ...
+}
+```
+
+*Summaries stay deterministic because `trace-summary.mjs` emits sorted keys with a trailing newline. Use them to diff perf regressions or feed dashboards.*
+
+## Where next?
+
+- Trace schema & meta fields: [`docs/trace-schema.md`](../../trace-schema.md)
+- Parity harness and expected artifacts: [`docs/pilot-l0.md#parity-harness`](../../pilot-l0.md#parity-harness)
+- Perf drill-down tooling: [`docs/T3-trace.md`](../../T3-trace.md)
+
+> **Troubleshooting**
+>
+> - `pnpm run traces:sample` emits EPIPE – avoid piping through `head`; redirect to a file first as shown above.
+> - Trace validation fails on catalog hash – ensure Track A regenerated the catalog and rerun Track B before re-validating.
+> - `pnpm run pilot:parity` fails with missing `manual/status.json` – run `pnpm run pilot:manual` to refresh the handwritten baseline before diffing parity.

--- a/docs/0.5/quickstarts/track-d-optimizer.md
+++ b/docs/0.5/quickstarts/track-d-optimizer.md
@@ -17,7 +17,7 @@ mkdir -p "$OUT"
 pnpm run tf -- canon "$FLOW" -o "$OUT/signing.canon.json"
 node packages/tf-opt/bin/opt.mjs --ir "$OUT/signing.canon.json" --out "$OUT/signing.optimized.json"
 node packages/tf-opt/bin/opt.mjs --ir "$OUT/signing.canon.json" --emit-used-laws out/0.5/proofs/signing.used-laws.json
-node scripts/proofs/coverage.mjs --out out
+pnpm run proofs:coverage
 ```
 
 ## Expected output
@@ -38,5 +38,5 @@ node scripts/proofs/coverage.mjs --out out
 > **Troubleshooting**
 >
 > - `Cannot find module tf-opt` – ensure `pnpm -w -r build` completed; the optimizer uses generated entry points.
-> - Coverage reports missing laws – add the stub under `scripts/proofs/laws/` before rerunning `node scripts/proofs/coverage.mjs --out out`.
+> - Coverage reports missing laws – add the stub under `scripts/proofs/laws/` before rerunning `pnpm run proofs:coverage`.
 > - Writing to `out/0.5/proofs` fails – create the directory with `mkdir -p out/0.5/proofs` and check permissions.

--- a/docs/0.5/quickstarts/track-d-optimizer.md
+++ b/docs/0.5/quickstarts/track-d-optimizer.md
@@ -1,0 +1,42 @@
+# Track D — Optimizer Quickstart
+
+Run the rewrite detector on a canonical plan and capture the law manifest for downstream proofs.
+
+## Prerequisites
+
+- Track A canonical IR available (or re-run `pnpm run tf -- canon`)
+- `out/0.5/proofs/` writeable for manifests
+- `node` (20+) and `jq`
+
+## Commands (3–7 steps)
+
+```bash
+FLOW=examples/flows/signing.tf
+OUT=out/0.5/optimizer
+mkdir -p "$OUT"
+pnpm run tf -- canon "$FLOW" -o "$OUT/signing.canon.json"
+node packages/tf-opt/bin/opt.mjs --ir "$OUT/signing.canon.json" --out "$OUT/signing.optimized.json"
+node packages/tf-opt/bin/opt.mjs --ir "$OUT/signing.canon.json" --emit-used-laws out/0.5/proofs/signing.used-laws.json
+node scripts/proofs/coverage.mjs --out out
+```
+
+## Expected output
+
+```
+{"rewrites_applied":0,"used_laws":[]}
+{"ok": true, "missing": [], "covered": []}
+```
+
+*Optimizer outputs include both the rewritten plan and `used_laws` manifest. The coverage script cross-checks manifests against committed stubs under `scripts/proofs/laws/`.*
+
+## Where next?
+
+- Optimizer internals & rewrite detection: [`packages/tf-opt/`](../../../packages/tf-opt/)
+- Law manifest validation gate: [`docs/proofs/README.md#manifest-validation-ci-gatemjs---check-used`](../../proofs/README.md#manifest-validation-ci-gatemjs---check-used)
+- Adding SMT law stubs: [`docs/proofs/README.md#law-stubs-scriptsproofslaws`](../../proofs/README.md#law-stubs-scriptsproofslaws)
+
+> **Troubleshooting**
+>
+> - `Cannot find module tf-opt` – ensure `pnpm -w -r build` completed; the optimizer uses generated entry points.
+> - Coverage reports missing laws – add the stub under `scripts/proofs/laws/` before rerunning `node scripts/proofs/coverage.mjs --out out`.
+> - Writing to `out/0.5/proofs` fails – create the directory with `mkdir -p out/0.5/proofs` and check permissions.

--- a/docs/0.5/quickstarts/track-e-proofs.md
+++ b/docs/0.5/quickstarts/track-e-proofs.md
@@ -14,9 +14,10 @@ Emit the Alloy/SMT suite and sync manifests so the optimizer coverage gate stays
 OUT=out/0.5/proofs
 pnpm run proofs:emit
 mkdir -p "$OUT"
+# Temporary shim: proofs:emit still targets out/0.4; copy forward until the emitter writes to 0.5 directly.
 cp -R out/0.4/proofs/. "$OUT"/
 head -n 5 "$OUT/storage_ok.smt2"
-node scripts/proofs/coverage.mjs --out out
+pnpm run proofs:coverage
 ```
 
 ## Expected output
@@ -45,4 +46,4 @@ wrote /workspace/tf-lang/out/0.4/proofs/storage_ok.smt2
 >
 > - `Error: spawn z3 ENOENT` – the emit scripts succeed without Z3; install it only if you need solver validation locally.
 > - Copy step complains about missing `out/0.4/proofs` – rerun `pnpm run proofs:emit`; it creates the source directory.
-> - Coverage reports missing laws – ensure optimizer manifests (Track D) were copied into `out/0.5/proofs/` before invoking the gate.
+> - Coverage reports missing laws – ensure optimizer manifests (Track D) were copied into `out/0.5/proofs/` before invoking `pnpm run proofs:coverage`.

--- a/docs/0.5/quickstarts/track-e-proofs.md
+++ b/docs/0.5/quickstarts/track-e-proofs.md
@@ -1,0 +1,48 @@
+# Track E — Proofs Quickstart
+
+Emit the Alloy/SMT suite and sync manifests so the optimizer coverage gate stays green.
+
+## Prerequisites
+
+- Tracks A–D complete (ensures manifests under `out/0.5/proofs/**`)
+- `pnpm -w -r build` to make proof emitters available
+- Optional: Z3 on `PATH` for richer `ci-gate` checks (not required)
+
+## Commands (3–7 steps)
+
+```bash
+OUT=out/0.5/proofs
+pnpm run proofs:emit
+mkdir -p "$OUT"
+cp -R out/0.4/proofs/. "$OUT"/
+head -n 5 "$OUT/storage_ok.smt2"
+node scripts/proofs/coverage.mjs --out out
+```
+
+## Expected output
+
+```
+wrote /workspace/tf-lang/out/0.4/proofs/storage_ok.smt2
+...
+(assert true)
+(check-sat)
+{
+  "ok": true,
+  "missing": [],
+  "covered": []
+}
+```
+
+*Keep the `out/0.5/proofs/**` mirror up to date—the coverage gate scans that directory for manifests and confirms every law has a committed stub.*
+
+## Where next?
+
+- Proof artifact layout & gates: [`docs/proofs/README.md`](../../proofs/README.md)
+- Adding new obligations: [`docs/l0-effects-lattice.md`](../../l0-effects-lattice.md)
+- Registry maintenance checklist: [`docs/proofs/README.md#law-stubs-scriptsproofslaws`](../../proofs/README.md#law-stubs-scriptsproofslaws)
+
+> **Troubleshooting**
+>
+> - `Error: spawn z3 ENOENT` – the emit scripts succeed without Z3; install it only if you need solver validation locally.
+> - Copy step complains about missing `out/0.4/proofs` – rerun `pnpm run proofs:emit`; it creates the source directory.
+> - Coverage reports missing laws – ensure optimizer manifests (Track D) were copied into `out/0.5/proofs/` before invoking the gate.

--- a/docs/0.5/quickstarts/track-f-release-devex.md
+++ b/docs/0.5/quickstarts/track-f-release-devex.md
@@ -1,0 +1,44 @@
+# Track F — Release & DevEx Quickstart
+
+Sweep repo health: audits, determinism probes, and doc link checks that gate releases.
+
+## Prerequisites
+
+- Workspace install (`pnpm -w -r install --frozen-lockfile`)
+- `bash`, `node`, and `npx` available
+- Network access for npm to fetch the link checker
+
+## Commands (3–7 steps)
+
+```bash
+OUT=out/0.5/devex
+mkdir -p "$OUT"
+node scripts/audit/run.mjs > "$OUT/audit.json"
+pnpm run determinism > "$OUT/determinism.log"
+npx -y markdown-link-check docs/0.5/overview.md > "$OUT/link-check.txt"
+tail -n 5 "$OUT/link-check.txt"
+```
+
+## Expected output
+
+```
+{ "ok": false, "determinism": { "ok": false, "issues": ["missing_newline", ...] } }
+Determinism OK
+  [✓] quickstarts/track-e-proofs.md
+  [✓] quickstarts/track-f-release-devex.md
+  13 links checked.
+```
+
+*Audits surface newline/exec-bit drift (`missing_newline`, `missing_exec`); determinism probes rerun `a0` twice to confirm identical digests. The Markdown link checker must finish cleanly before docs ship.*
+
+## Where next?
+
+- Audit implementation details: [`scripts/audit/run.mjs`](../../../scripts/audit/run.mjs)
+- Determinism harness internals: [`scripts/determinism-check.sh`](../../../scripts/determinism-check.sh)
+- Documentation linting CI: [`.github/workflows/l0-docs.yml`](../../../.github/workflows/l0-docs.yml)
+
+> **Troubleshooting**
+>
+> - `node scripts/audit/run.mjs` exits non-zero – inspect the JSON under `determinism.issues`; rerun after fixing newline/exec flags.
+> - `npx markdown-link-check …` reports broken quickstart links – ensure every target exists and uses relative paths (`../` for parent dirs).
+> - Determinism probe fails – rerun `pnpm run a0` manually; uncommitted changes in `out/**` often cause mismatched digests.

--- a/docs/0.5/quickstarts/track-f-release-devex.md
+++ b/docs/0.5/quickstarts/track-f-release-devex.md
@@ -13,16 +13,16 @@ Sweep repo health: audits, determinism probes, and doc link checks that gate rel
 ```bash
 OUT=out/0.5/devex
 mkdir -p "$OUT"
-node scripts/audit/run.mjs > "$OUT/audit.json"
+pnpm run audit > "$OUT/audit.json"
 pnpm run determinism > "$OUT/determinism.log"
-npx -y markdown-link-check docs/0.5/overview.md > "$OUT/link-check.txt"
+pnpm run docs:check -- docs/0.5/overview.md > "$OUT/link-check.txt"
 tail -n 5 "$OUT/link-check.txt"
 ```
 
 ## Expected output
 
 ```
-{ "ok": false, "determinism": { "ok": false, "issues": ["missing_newline", ...] } }
+{ "ok": true, "determinism": { "ok": true, "issues": [] } }
 Determinism OK
   [✓] quickstarts/track-e-proofs.md
   [✓] quickstarts/track-f-release-devex.md
@@ -39,6 +39,6 @@ Determinism OK
 
 > **Troubleshooting**
 >
-> - `node scripts/audit/run.mjs` exits non-zero – inspect the JSON under `determinism.issues`; rerun after fixing newline/exec flags.
-> - `npx markdown-link-check …` reports broken quickstart links – ensure every target exists and uses relative paths (`../` for parent dirs).
+> - `pnpm run audit` exits non-zero – inspect the JSON under `determinism.issues`; rerun after fixing newline/exec flags.
+> - `pnpm run docs:check -- docs/0.5/overview.md` reports broken quickstart links – ensure every target exists and uses relative paths (`../` for parent dirs).
 > - Determinism probe fails – rerun `pnpm run a0` manually; uncommitted changes in `out/**` often cause mismatched digests.


### PR DESCRIPTION
## Summary
- replace the single 0.5 landing page with `docs/0.5/overview.md`, including the pipeline map, determinism note, track table, and quickstart entry points
- add quickstart guides for tracks A–F under `docs/0.5/quickstarts/` covering prerequisites, 3–7 command sequences, expected outputs, and troubleshooting tips
- refresh the README and changelog to point to the new overview/quickstarts and document the local link-check workflow

## Testing
- npx -y markdown-link-check docs/0.5/overview.md
- for file in docs/0.5/quickstarts/*.md; do echo "=== $file ==="; npx -y markdown-link-check "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68db13cc2cf483208f69299565b3ba47