### PR TITLE
Tighten L0 enums and infer effects fallbacks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,29 +52,58 @@ jobs:
         id: changes
         run: |
           set -euo pipefail
-          BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
-          git fetch origin "$BASE_REF" --depth=1
-          BASE_SHA="origin/${BASE_REF}"
-          MERGE_BASE=$(git merge-base HEAD "$BASE_SHA")
 
-          L0_CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD -- '*.l0.json' '*.l0.yaml' '*.l0.yml')
-          L2_CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD -- '*.l2.json' '*.l2.yaml' '*.l2.yml')
-          TOUCH_SCHEMA=$(git diff --name-only "$MERGE_BASE"...HEAD -- 'schemas/**' 'tools/tf-lang-cli/**' 'spec/v0.6/**')
-
-          if [ -n "$TOUCH_SCHEMA" ]; then
-            L0_TARGETS=$(git ls-files '*.l0.json' '*.l0.yaml' '*.l0.yml')
-            L2_TARGETS=$(git ls-files '*.l2.json' '*.l2.yaml' '*.l2.yml')
+          # Determine diff range
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            git fetch --no-tags --prune --depth=1 origin "${BASE_REF}"
+            BASE_SHA="origin/${BASE_REF}"
+            MERGE_BASE="$(git merge-base "${GITHUB_SHA}" "${BASE_SHA}")"
+            DIFF_FROM="${MERGE_BASE}"
+            DIFF_TO="${GITHUB_SHA}"
           else
-            L0_TARGETS="$L0_CHANGED"
-            L2_TARGETS="$L2_CHANGED"
+            # push event
+            DIFF_FROM="${{ github.event.before }}"
+            DIFF_TO="${GITHUB_SHA}"
           fi
 
-          {
-            printf 'l0_changed<<EOF\n%s\nEOF\n' "$L0_CHANGED"
-            printf 'l2_changed<<EOF\n%s\nEOF\n' "$L2_CHANGED"
-            printf 'l0_targets<<EOF\n%s\nEOF\n' "$L0_TARGETS"
-            printf 'l2_targets<<EOF\n%s\nEOF\n' "$L2_TARGETS"
-          } >> "$GITHUB_OUTPUT"
+          # Collect changed files
+          CHANGED="$(git diff --name-only "${DIFF_FROM}" "${DIFF_TO}")"
+
+          # Derive targets
+          L0_CHANGED="$(echo "${CHANGED}" | grep -E '\.l0\.(json|ya?ml)$' || true)"
+          L2_CHANGED="$(echo "${CHANGED}" | grep -E '\.l2\.(json|ya?ml)$' || true)"
+          SCHEMA_CHANGED="$(echo "${CHANGED}" | grep -E '^schemas/|^tools/tf-lang-cli/|^spec/v0\.6/' || true)"
+
+          L0_TARGETS="${L0_CHANGED}"
+          L2_TARGETS="${L2_CHANGED}"
+
+          if [[ -n "${SCHEMA_CHANGED}" ]]; then
+            L0_TARGETS="$(git ls-files '**/*.l0.json' '**/*.l0.yaml' '**/*.l0.yml' || true)"
+            L2_TARGETS="$(git ls-files '**/*.l2.json' '**/*.l2.yaml' '**/*.l2.yml' || true)"
+          fi
+
+          # If push with empty diff (edge), fallback to validating all tracked L0/L2
+          if [[ -z "${L0_TARGETS}${L2_TARGETS}${SCHEMA_CHANGED}" && "${{ github.event_name }}" == "push" ]]; then
+            L0_TARGETS="$(git ls-files '**/*.l0.json' '**/*.l0.yaml' '**/*.l0.yml' || true)"
+            L2_TARGETS="$(git ls-files '**/*.l2.json' '**/*.l2.yaml' '**/*.l2.yml' || true)"
+          fi
+
+          echo "l0_changed<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${L0_CHANGED}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "l2_changed<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${L2_CHANGED}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "l0_targets<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${L0_TARGETS}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "l2_targets<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${L2_TARGETS}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Validate L0 schemas
         if: steps.changes.outputs.l0_targets != ''

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,106 @@
+name: check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.l0.json'
+      - '**/*.l0.yaml'
+      - '**/*.l0.yml'
+      - '**/*.l2.json'
+      - '**/*.l2.yaml'
+      - '**/*.l2.yml'
+      - 'schemas/**'
+      - 'tools/tf-lang-cli/**'
+      - 'spec/v0.6/**'
+  pull_request:
+    paths:
+      - '**/*.l0.json'
+      - '**/*.l0.yaml'
+      - '**/*.l0.yml'
+      - '**/*.l2.json'
+      - '**/*.l2.yaml'
+      - '**/*.l2.yml'
+      - 'schemas/**'
+      - 'tools/tf-lang-cli/**'
+      - 'spec/v0.6/**'
+  workflow_dispatch:
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Detect impacted artifacts
+        id: changes
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
+          git fetch origin "$BASE_REF" --depth=1
+          BASE_SHA="origin/${BASE_REF}"
+          MERGE_BASE=$(git merge-base HEAD "$BASE_SHA")
+
+          L0_CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD -- '*.l0.json' '*.l0.yaml' '*.l0.yml')
+          L2_CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD -- '*.l2.json' '*.l2.yaml' '*.l2.yml')
+          TOUCH_SCHEMA=$(git diff --name-only "$MERGE_BASE"...HEAD -- 'schemas/**' 'tools/tf-lang-cli/**' 'spec/v0.6/**')
+
+          if [ -n "$TOUCH_SCHEMA" ]; then
+            L0_TARGETS=$(git ls-files '*.l0.json' '*.l0.yaml' '*.l0.yml')
+            L2_TARGETS=$(git ls-files '*.l2.json' '*.l2.yaml' '*.l2.yml')
+          else
+            L0_TARGETS="$L0_CHANGED"
+            L2_TARGETS="$L2_CHANGED"
+          fi
+
+          {
+            printf 'l0_changed<<EOF\n%s\nEOF\n' "$L0_CHANGED"
+            printf 'l2_changed<<EOF\n%s\nEOF\n' "$L2_CHANGED"
+            printf 'l0_targets<<EOF\n%s\nEOF\n' "$L0_TARGETS"
+            printf 'l2_targets<<EOF\n%s\nEOF\n' "$L2_TARGETS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate L0 schemas
+        if: steps.changes.outputs.l0_targets != ''
+        env:
+          L0_FILES: ${{ steps.changes.outputs.l0_targets }}
+        run: |
+          set -euo pipefail
+          pnpm -w run validate:l0 $(printf '%s\n' "$L0_FILES")
+
+      - name: Validate L2 schemas
+        if: steps.changes.outputs.l2_targets != ''
+        env:
+          L2_FILES: ${{ steps.changes.outputs.l2_targets }}
+        run: |
+          set -euo pipefail
+          pnpm -w run validate:l2 $(printf '%s\n' "$L2_FILES")
+
+      - name: Replay effects summary
+        if: steps.changes.outputs.l0_changed != ''
+        env:
+          L0_CHANGED: ${{ steps.changes.outputs.l0_changed }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$L0_CHANGED" | while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            echo "::group::effects $file"
+            node tools/tf-lang-cli/index.mjs effects "$file"
+            echo "::endgroup::"
+          done

--- a/docs/0.6/index.md
+++ b/docs/0.6/index.md
@@ -1,0 +1,10 @@
+# TF-Lang v0.6 Specification
+
+> Generated from `spec/v0.6`
+
+> No specification pages were found for this version.
+> Tip: add Markdown files under `spec/v0.6` to populate this site.
+
+---
+
+[Back to top](#tf-lang-v06-specification)

--- a/docs/0.6/index.md
+++ b/docs/0.6/index.md
@@ -4,6 +4,7 @@
 
 > No specification pages were found for this version.
 > Tip: add Markdown files under `spec/v0.6` to populate this site.
+> For complex macro lines in YAML, prefer block scalars or quotes. The CLI has a best-effort sanitizer, but `--strict-yaml` disables it and enforces standard YAML.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "proofs:coverage:docs": "node scripts/proofs/coverage.mjs --docs docs/l0-proof-coverage.md",
     "proofs:emit-missing": "node scripts/proofs/emit-missing-laws.mjs",
     "tf": "node packages/tf-compose/bin/tf.mjs",
+    "validate:l0": "node tools/tf-lang-cli/scripts/validate.mjs l0",
+    "validate:l2": "node tools/tf-lang-cli/scripts/validate.mjs l2",
     "codegen:rs:signing": "node scripts/generate-rs-run.mjs out/0.4/ir/signing.ir.json -o out/0.4/codegen-rs/signing",
     "parity:ts-rs:signing": "node scripts/cross-parity-ts-rs.mjs --ir out/0.4/ir/signing.ir.json",
     "trace:filter": "node packages/tf-l0-tools/trace-filter.mjs",

--- a/schemas/l0-dag.schema.json
+++ b/schemas/l0-dag.schema.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tf-lang.dev/schemas/l0-dag.schema.json",
+  "title": "TF-Lang L0 DAG",
+  "type": "object",
+  "required": ["pipeline_id", "created_at", "effects", "nodes"],
+  "additionalProperties": false,
+  "properties": {
+    "pipeline_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "effects": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      ]
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/node"
+      }
+    }
+  },
+  "$defs": {
+    "data": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/data"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        }
+      ]
+    },
+    "binding": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "condition": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "op": {
+              "type": "string",
+              "minLength": 1
+            },
+            "var": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        }
+      ]
+    },
+    "node": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["Transform", "Publish", "Subscribe", "Keypair"]
+        },
+        "description": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string",
+          "minLength": 1
+        },
+        "qos": {
+          "type": "string",
+          "enum": ["at_most_once", "at_least_once", "exactly_once"]
+        },
+        "algorithm": {
+          "type": "string",
+          "enum": ["RSA", "EC_P256", "EC_P384", "EC_P521", "Ed25519", "X25519"]
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        },
+        "in": {
+          "$ref": "#/$defs/binding"
+        },
+        "out": {
+          "$ref": "#/$defs/binding"
+        },
+        "payload": {
+          "$ref": "#/$defs/data"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/data"
+              }
+            }
+          ]
+        },
+        "when": {
+          "$ref": "#/$defs/condition"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/$defs/data"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "Subscribe"
+              }
+            }
+          },
+          "then": {
+            "required": ["channel", "qos", "out"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "Publish"
+              }
+            }
+          },
+          "then": {
+            "required": ["channel", "qos", "payload"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "Transform"
+              }
+            }
+          },
+          "then": {
+            "required": ["spec", "in", "out"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "Keypair"
+              }
+            }
+          },
+          "then": {
+            "required": ["algorithm", "out"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/l2-pipeline.schema.json
+++ b/schemas/l2-pipeline.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tf-lang.dev/schemas/l2-pipeline.schema.json",
+  "title": "TF-Lang L2 Pipeline",
+  "type": "object",
+  "required": ["pipeline", "steps"],
+  "additionalProperties": false,
+  "properties": {
+    "pipeline": {
+      "$ref": "#/$defs/identifier"
+    },
+    "description": {
+      "type": "string"
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ioEntry"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/step"
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ioEntry"
+      }
+    },
+    "slas": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "ensures": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/data"
+      }
+    }
+  },
+  "$defs": {
+    "data": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/data"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        }
+      ]
+    },
+    "identifier": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ioEntry": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "patternProperties": {
+        "^[A-Za-z_][A-Za-z0-9_.-]*$": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "$ref": "#/$defs/data"
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "stepDetail": {
+      "type": "object",
+      "properties": {
+        "when": {
+          "type": "string",
+          "minLength": 1
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/data"
+          }
+        },
+        "input": {
+          "$ref": "#/$defs/data"
+        },
+        "output": {
+          "$ref": "#/$defs/data"
+        },
+        "using": {
+          "$ref": "#/$defs/data"
+        }
+      },
+      "additionalProperties": true
+    },
+    "branchStep": {
+      "type": "object",
+      "required": ["when", "then"],
+      "properties": {
+        "when": {
+          "type": "string",
+          "minLength": 1
+        },
+        "then": {
+          "$ref": "#/$defs/stepList"
+        },
+        "else": {
+          "$ref": "#/$defs/stepList"
+        }
+      },
+      "additionalProperties": false
+    },
+    "step": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "patternProperties": {
+        "^[A-Za-z_][A-Za-z0-9_.-]*$": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/stepDetail"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "required": ["branch"]
+          },
+          "then": {
+            "properties": {
+              "branch": {
+                "$ref": "#/$defs/branchStep"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "stepList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/step"
+      }
+    }
+  }
+}

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const VERSION = "0.6";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const specDir = path.join(repoRoot, "spec", `v${VERSION}`);
+const outDir = path.join(repoRoot, "docs", VERSION);
+
+async function ensureDirectory(dir) {
+  await mkdir(dir, { recursive: true });
+}
+
+async function walk(dir, prefix = "") {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const rel = path.join(prefix, entry.name);
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(abs, rel)));
+    } else {
+      files.push({ relative: rel, absolute: abs });
+    }
+  }
+  return files;
+}
+
+function deriveTitle(content, relativePath) {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) {
+      const title = trimmed.replace(/^#+\s*/, "").trim();
+      if (title.length > 0) {
+        return title;
+      }
+    }
+  }
+  const base = path.basename(relativePath, path.extname(relativePath));
+  return base
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ") || relativePath;
+}
+
+function normalisePath(relativePath) {
+  return relativePath.split(path.sep).join("/");
+}
+
+function buildIndex(pages) {
+  const lines = [
+    `# TF-Lang v${VERSION} Specification`,
+    "",
+    `> Generated from \`spec/v${VERSION}\``,
+    "",
+  ];
+  if (pages.length === 0) {
+    lines.push("> No specification pages were found for this version.");
+    lines.push("> Tip: add Markdown files under `spec/v0.6` to populate this site.");
+  } else {
+    for (const page of pages) {
+      const depth = page.relative.split("/").length - 1;
+      const indent = "  ".repeat(depth);
+      lines.push(`${indent}- [${page.title}](./${page.relative})`);
+    }
+  }
+  lines.push("", "---", "", "[Back to top](#tf-lang-v06-specification)", "");
+  return lines.join("\n");
+}
+
+function applyPageChrome(content, relativePath) {
+  const normalized = normalisePath(relativePath);
+  let body = content.replace(/^\uFEFF/, "");
+  if (!body.startsWith("\n")) {
+    body = `\n${body}`;
+  }
+  body = body.replace(/\s+$/, "");
+  const header = [
+    `> Generated from \`spec/v${VERSION}/${normalized}\``,
+    "",
+    "[Back to index](./index.md)",
+    "",
+  ].join("\n");
+  const footer = ["", "---", "", "[Back to index](./index.md)", ""].join("\n");
+  return `${header}${body}\n${footer}`;
+}
+
+async function main() {
+  let entries = [];
+  try {
+    const stats = await stat(specDir);
+    if (stats.isDirectory()) {
+      entries = await walk(specDir);
+      entries.sort((a, b) => a.relative.localeCompare(b.relative));
+    }
+  } catch {
+    entries = [];
+  }
+
+  await rm(outDir, { recursive: true, force: true });
+  await ensureDirectory(outDir);
+
+  const pages = [];
+
+  for (const entry of entries) {
+    const targetPath = path.join(outDir, entry.relative);
+    await ensureDirectory(path.dirname(targetPath));
+
+    if (entry.relative.endsWith(".md")) {
+      const content = await readFile(entry.absolute, "utf8");
+      const pageContent = applyPageChrome(content, entry.relative);
+      await writeFile(targetPath, pageContent, "utf8");
+      const title = deriveTitle(content, entry.relative);
+      if (entry.relative !== "index.md") {
+        pages.push({
+          relative: normalisePath(entry.relative),
+          title,
+        });
+      }
+    } else {
+      await copyFile(entry.absolute, targetPath);
+    }
+  }
+
+  const indexContent = buildIndex(pages);
+  await writeFile(path.join(outDir, "index.md"), indexContent, "utf8");
+
+  console.log(`built ${entries.length} artifact(s) into docs/${VERSION}`);
+}
+
+main().catch((err) => {
+  console.error(err?.message ?? err);
+  process.exit(1);
+});

--- a/tools/tf-lang-cli/lib/dot.mjs
+++ b/tools/tf-lang-cli/lib/dot.mjs
@@ -1,0 +1,126 @@
+function quote(value) {
+  const text = String(value ?? "");
+  return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function extractVar(ref) {
+  if (typeof ref !== "string") return null;
+  if (!ref.startsWith("@")) return null;
+  const body = ref.slice(1);
+  const match = body.match(/^[A-Za-z0-9_]+/);
+  return match ? match[0] : null;
+}
+
+function collectOutputs(node) {
+  const outputs = new Set();
+  const out = node?.out;
+  if (typeof out === "string") {
+    outputs.add(out);
+  } else if (out && typeof out === "object") {
+    if (typeof out.var === "string") {
+      outputs.add(out.var);
+    }
+    if (Array.isArray(out.vars)) {
+      for (const v of out.vars) {
+        if (typeof v === "string") {
+          outputs.add(v);
+        }
+      }
+    }
+  }
+  return outputs;
+}
+
+function collectDependencies(node) {
+  const refs = new Set();
+
+  function visit(value, key = "") {
+    if (key === "out" || value === null || value === undefined) {
+      return;
+    }
+    if (typeof value === "string") {
+      const found = extractVar(value);
+      if (found) {
+        refs.add(found);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+    if (typeof value === "object") {
+      if (typeof value.var === "string") {
+        refs.add(value.var);
+      }
+      for (const [childKey, childValue] of Object.entries(value)) {
+        visit(childValue, childKey);
+      }
+    }
+  }
+
+  for (const [key, val] of Object.entries(node ?? {})) {
+    visit(val, key);
+  }
+
+  return refs;
+}
+
+export function buildDotGraph(doc = {}) {
+  const nodes = Array.isArray(doc?.nodes) ? doc.nodes : [];
+  const pipelineId = doc?.pipeline_id || doc?.pipeline || "pipeline";
+  const lines = [];
+  lines.push(`digraph ${quote(pipelineId)} {`);
+  lines.push("  rankdir=LR;");
+  lines.push("  node [shape=box, style=rounded];");
+
+  const varToNode = new Map();
+
+  for (const node of nodes) {
+    if (!node || typeof node !== "object") continue;
+    const nodeId = node.id ? String(node.id) : null;
+    if (!nodeId) continue;
+    const kind = node.kind ? String(node.kind) : "";
+    const label = kind ? `${nodeId} (${kind})` : nodeId;
+    lines.push(`  ${quote(nodeId)} [label=${quote(label)}];`);
+    for (const output of collectOutputs(node)) {
+      if (!varToNode.has(output)) {
+        varToNode.set(output, nodeId);
+      }
+    }
+  }
+
+  const edges = new Set();
+  const externals = new Set();
+
+  for (const node of nodes) {
+    if (!node || typeof node !== "object" || !node.id) continue;
+    const nodeId = String(node.id);
+    for (const dep of collectDependencies(node)) {
+      const src = varToNode.get(dep);
+      if (src) {
+        edges.add(`  ${quote(src)} -> ${quote(nodeId)};`);
+      } else {
+        externals.add(dep);
+        edges.add(`  ${quote(`@${dep}`)} -> ${quote(nodeId)};`);
+      }
+    }
+  }
+
+  if (externals.size > 0) {
+    lines.push("  node [shape=ellipse, style=dashed];");
+    for (const ext of externals) {
+      lines.push(`  ${quote(`@${ext}`)};`);
+    }
+    lines.push("  node [shape=box, style=rounded];");
+  }
+
+  for (const edge of edges) {
+    lines.push(edge);
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}

--- a/tools/tf-lang-cli/lib/effects.mjs
+++ b/tools/tf-lang-cli/lib/effects.mjs
@@ -1,0 +1,39 @@
+export function summarizeEffects(doc = {}) {
+  const effects = doc?.effects;
+  if (typeof effects === "string") {
+    if (effects.trim().length > 0) {
+      return effects;
+    }
+  }
+  if (Array.isArray(effects)) {
+    if (effects.length > 0) {
+      return effects.join("+");
+    }
+  }
+  if (effects && typeof effects === "object") {
+    const keys = Object.keys(effects);
+    if (keys.length > 0) {
+      return keys.join("+");
+    }
+  }
+  const nodes = Array.isArray(doc?.nodes) ? doc.nodes : [];
+  const kindToEffect = new Map([
+    ["Publish", "Outbound"],
+    ["Subscribe", "Inbound"],
+    ["Keypair", "Entropy"],
+    ["Transform", "Pure"],
+  ]);
+  const preferredOrder = ["Outbound", "Inbound", "Entropy", "Pure"];
+  const seen = new Set();
+  for (const node of nodes) {
+    const effect = kindToEffect.get(node?.kind);
+    if (effect) {
+      seen.add(effect);
+    }
+  }
+  const inferred = preferredOrder.filter((effect) => seen.has(effect));
+  if (inferred.length > 0) {
+    return inferred.join("+");
+  }
+  return "";
+}

--- a/tools/tf-lang-cli/scripts/validate.mjs
+++ b/tools/tf-lang-cli/scripts/validate.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv";
+import { parse as parseYaml } from "yaml";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+
+const SCHEMAS = {
+  l0: path.join(repoRoot, "schemas", "l0-dag.schema.json"),
+  l2: path.join(repoRoot, "schemas", "l2-pipeline.schema.json"),
+};
+
+function usage() {
+  console.error("usage: validate <l0|l2> <file...>");
+  process.exit(2);
+}
+
+function sanitiseMacroScalars(text) {
+  const lines = text.split(/\r?\n/);
+  const result = [];
+
+  const countParens = (segment) => {
+    const opens = segment.match(/\(/g)?.length ?? 0;
+    const closes = segment.match(/\)/g)?.length ?? 0;
+    return opens - closes;
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(/^(\s*-\s*[^:\n]+:\s*)(.*)$/);
+    if (!match) {
+      result.push(line);
+      continue;
+    }
+
+    const [, prefix, remainder] = match;
+    const trimmed = remainder.trim();
+    if (
+      trimmed.length === 0 ||
+      trimmed.startsWith("'") ||
+      trimmed.startsWith('"') ||
+      trimmed.startsWith("|") ||
+      trimmed.startsWith(">")
+    ) {
+      result.push(line);
+      continue;
+    }
+
+    if (!trimmed.includes("(")) {
+      result.push(line);
+      continue;
+    }
+
+    let content = trimmed;
+    let depth = countParens(content);
+    let j = i;
+    while (depth > 0 && j + 1 < lines.length) {
+      j += 1;
+      const nextLine = lines[j];
+      const nextTrimmed = nextLine.trim();
+      content += ` ${nextTrimmed}`;
+      depth += countParens(nextTrimmed);
+    }
+
+    const escaped = content.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    result.push(`${prefix}"${escaped.trim()}"`);
+    i = j;
+  }
+
+  return result.join("\n");
+}
+
+function parseYamlDocument(raw) {
+  try {
+    return parseYaml(raw);
+  } catch (error) {
+    if (error?.name !== "YAMLParseError") {
+      throw error;
+    }
+    const sanitised = sanitiseMacroScalars(raw);
+    if (sanitised === raw) {
+      throw error;
+    }
+    return parseYaml(sanitised);
+  }
+}
+
+function parseDocument(targetPath, raw) {
+  const ext = path.extname(targetPath).toLowerCase();
+  if (ext === ".yaml" || ext === ".yml") {
+    return parseYamlDocument(raw);
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const hint =
+      "Document was not valid JSON. Supply either JSON or YAML with .yml/.yaml extension.";
+    throw new Error(`${error?.message ?? error}\n${hint}`);
+  }
+}
+
+async function loadSchema(schemaKey) {
+  const schemaPath = SCHEMAS[schemaKey];
+  if (!schemaPath) {
+    usage();
+  }
+  const schemaText = await readFile(schemaPath, "utf8");
+  return JSON.parse(schemaText);
+}
+
+async function main() {
+  let args = process.argv.slice(2);
+  if (args[0] === "validate") {
+    args = args.slice(1);
+  }
+
+  const [schemaKey, ...targets] = args;
+  if (!schemaKey || targets.length === 0) {
+    usage();
+  }
+
+  const schema = await loadSchema(schemaKey);
+  const ajv = new Ajv({ allErrors: true, strict: false, allowUnionTypes: true });
+  ajv.addFormat("date-time", true);
+  const validate = ajv.compile(schema);
+
+  let ok = true;
+  for (const target of targets) {
+    try {
+      const resolved = path.resolve(target);
+      const raw = await readFile(resolved, "utf8");
+      const document = parseDocument(target, raw);
+      const valid = validate(document);
+      if (valid) {
+        console.log(`${target}: OK`);
+      } else {
+        ok = false;
+        console.error(`${target}: FAIL`);
+        for (const error of validate.errors ?? []) {
+          const location = error.instancePath ? error.instancePath : "/";
+          const message = error.message ?? "invalid";
+          console.error(`  - ${location}: ${message}`);
+        }
+      }
+    } catch (err) {
+      ok = false;
+      const message = err?.message ?? String(err);
+      console.error(`${target}: FAIL`);
+      for (const line of message.split(/\r?\n/)) {
+        console.error(`  - ${line}`);
+      }
+    }
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err?.message ?? err);
+  process.exit(99);
+});

--- a/tools/tf-lang-cli/tests/dot.duplicate-var.test.mjs
+++ b/tools/tf-lang-cli/tests/dot.duplicate-var.test.mjs
@@ -1,0 +1,21 @@
+// @tf-test kind=infra area=tools speed=fast deps=node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildDotGraph } from "../lib/dot.mjs";
+
+test("throws when multiple nodes publish the same output variable", () => {
+  const doc = {
+    pipeline_id: "demo",
+    nodes: [
+      { id: "first", out: "foo" },
+      { id: "second", out: "foo" },
+    ],
+  };
+
+  assert.throws(
+    () => buildDotGraph(doc),
+    /Output variable "foo" defined by multiple nodes: "first" and "second"/,
+  );
+});

--- a/tools/tf-lang-cli/tests/dot.unresolved-var.test.mjs
+++ b/tools/tf-lang-cli/tests/dot.unresolved-var.test.mjs
@@ -1,0 +1,34 @@
+// @tf-test kind=infra area=tools speed=fast deps=node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildDotGraph } from "../lib/dot.mjs";
+
+test("throws when inputs reference unresolved variables in strict mode", () => {
+  const doc = {
+    pipeline_id: "demo",
+    nodes: [
+      { id: "producer", out: "known" },
+      { id: "consumer", input: "@ghost" },
+    ],
+  };
+
+  assert.throws(
+    () => buildDotGraph(doc, { strict: true }),
+    /Unresolved input variable\(s\): "ghost"/,
+  );
+});
+
+test("allows unresolved variables when strict mode is disabled", () => {
+  const doc = {
+    pipeline_id: "demo",
+    nodes: [
+      { id: "consumer", input: "@ghost" },
+    ],
+  };
+
+  const dot = buildDotGraph(doc, { strict: false });
+  assert.match(dot, /"@ghost" -> "consumer"/);
+});
+

--- a/tools/tf-lang-cli/tests/validate.exit-code.test.mjs
+++ b/tools/tf-lang-cli/tests/validate.exit-code.test.mjs
@@ -1,0 +1,26 @@
+// @tf-test kind=infra area=tools speed=fast deps=node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+
+test("usage errors take precedence over validation failures", () => {
+  const tmp = mkdtempSync(join(os.tmpdir(), "tf-validate-exit-"));
+  const unknown = join(tmp, "mystery.txt");
+  const invalid = join(tmp, "bad.l0.json");
+
+  writeFileSync(unknown, "{}", "utf8");
+  writeFileSync(invalid, JSON.stringify({}), "utf8");
+
+  const result = spawnSync("node", ["tools/tf-lang-cli/index.mjs", "validate", unknown, invalid], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, `expected exit code 2, got ${result.status}`);
+  assert.match(result.stderr, /unable to infer schema/);
+  assert.match(result.stderr, /validation failed \[l0\]/);
+});


### PR DESCRIPTION
## Summary
- constrain L0 node kind, QoS, and algorithm fields to known enums for stricter schema validation
- infer effects summaries from node kinds when metadata is missing and add a friendly docs index tip
- broaden workflow triggers and diff detection to cover `.l0.yaml`/`.l0.yml` artifacts

## Testing
- pnpm -w run validate:l0 0.6/build/auto.fnol.fasttrack.v1.l0.json
- tmp=$(mktemp) && jq 'del(.effects)' 0.6/build/auto.fnol.fasttrack.v1.l0.json > "$tmp" && node tools/tf-lang-cli/index.mjs effects "$tmp"
- node scripts/build-docs.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dbf2249eec83208fc8e2b3b3d0a0fd