### PR TITLE
tighten quote pipeline references and guards

### DIFF
--- a/0.6/build/auto.fnol.fasttrack.v1.l0.json
+++ b/0.6/build/auto.fnol.fasttrack.v1.l0.json
@@ -1,7 +1,7 @@
 {
   "pipeline_id": "auto.fnol.fasttrack.v1",
   "created_at": "2025-09-30T11:37:59.839401Z",
-  "effects": "Outbound+Inbound",
+  "effects": "Outbound+Inbound+Entropy+Pure",
   "nodes": [
     {
       "id": "S_receive_fnol",
@@ -23,90 +23,76 @@
         "value": "@fnol_msg.body"
       },
       "out": {
-        "var": "fnol_valid"
+        "var": "validate_fnol_value"
       }
     },
     {
-      "id": "T_extract_policy_id",
-      "kind": "Transform",
-      "spec": {
-        "op": "get",
-        "path": "policy_id"
-      },
-      "in": {
-        "value": "@fnol_msg.body"
-      },
-      "out": {
-        "var": "policy_id"
-      }
-    },
-    {
-      "id": "K_policy",
+      "id": "K_get_policy",
       "kind": "Keypair",
       "algorithm": "Ed25519",
       "out": {
-        "var": "kp_policy"
+        "var": "kp_get_policy"
       }
     },
     {
-      "id": "T_policy_corr",
+      "id": "T_get_policy_corr",
       "kind": "Transform",
       "spec": {
         "op": "hash",
         "alg": "blake3"
       },
       "in": {
-        "k": "@kp_policy.public_key_pem",
+        "k": "@kp_get_policy.public_key_pem",
         "e": "api/policy/snapshot",
         "m": "GET",
         "q": {
-          "policy_id": "@policy_id"
+          "policy_id": "@fnol_msg.body.policy_id"
         }
       },
       "out": {
-        "var": "corr_policy"
+        "var": "corr_get_policy"
       }
     },
     {
-      "id": "T_policy_reply_to",
+      "id": "T_get_policy_reply_to",
       "kind": "Transform",
       "spec": {
         "op": "concat"
       },
       "in": {
         "a": "rpc:reply:",
-        "b": "@corr_policy"
+        "b": "@corr_get_policy"
       },
       "out": {
-        "var": "reply_to_policy"
+        "var": "reply_to_get_policy"
       }
     },
     {
-      "id": "P_policy_request",
+      "id": "P_get_policy_request",
       "kind": "Publish",
       "channel": "rpc:req:api/policy/snapshot",
       "qos": "at_least_once",
       "payload": {
         "method": "GET",
+        "corr": "@corr_get_policy",
+        "reply_to": "@reply_to_get_policy",
         "query": {
-          "policy_id": "@policy_id"
-        },
-        "corr": "@corr_policy",
-        "reply_to": "@reply_to_policy"
+          "policy_id": "@fnol_msg.body.policy_id"
+        }
       }
     },
     {
-      "id": "S_policy_reply",
+      "id": "S_get_policy_reply",
       "kind": "Subscribe",
-      "channel": "@reply_to_policy",
+      "channel": "@reply_to_get_policy",
       "qos": "at_least_once",
-      "filter": "@corr_policy",
+      "filter": "@corr_get_policy",
       "out": {
-        "var": "policy_snapshot"
+        "var": "get_policy_reply"
       }
     },
     {
-      "id": "T_severity",
+      "id": "T_score_severity",
       "kind": "Transform",
       "spec": {
         "op": "model_infer",
@@ -116,11 +102,11 @@
         "features": "@fnol_msg.body"
       },
       "out": {
-        "var": "sev_score"
+        "var": "score_severity_value"
       }
     },
     {
-      "id": "T_fraud",
+      "id": "T_score_fraud",
       "kind": "Transform",
       "spec": {
         "op": "model_infer",
@@ -130,7 +116,7 @@
         "features": "@fnol_msg.body"
       },
       "out": {
-        "var": "fraud_score"
+        "var": "score_fraud_value"
       }
     },
     {
@@ -142,27 +128,27 @@
       },
       "in": {
         "input": {
-          "severity": "@sev_score",
-          "fraud": "@fraud_score",
-          "policy": "@policy_snapshot.response"
+          "severity": "@score_severity_value",
+          "fraud": "@score_fraud_value",
+          "policy": "@get_policy_reply.response"
         }
       },
       "out": {
-        "var": "eligibility"
+        "var": "eligibility_value"
       }
     },
     {
-      "id": "T_branch_cond",
+      "id": "T_branch_1",
       "kind": "Transform",
       "spec": {
         "op": "eq"
       },
       "in": {
-        "left": "@eligibility.decision",
+        "left": "@eligibility_value.decision",
         "right": "allow"
       },
       "out": {
-        "var": "is_allow"
+        "var": "branch_1_value"
       }
     },
     {
@@ -172,7 +158,7 @@
       "out": {
         "var": "kp_consent"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
       "id": "T_consent_corr",
@@ -193,7 +179,7 @@
       "out": {
         "var": "corr_consent"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
       "id": "T_consent_reply_to",
@@ -208,26 +194,26 @@
       "out": {
         "var": "reply_to_consent"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
-      "id": "P_consent",
+      "id": "P_consent_request",
       "kind": "Publish",
       "channel": "rpc:req:api/consent/sign",
       "qos": "at_least_once",
       "payload": {
         "method": "POST",
+        "corr": "@corr_consent",
+        "reply_to": "@reply_to_consent",
         "body": {
           "doc": "fasttrack.pdf",
           "claimant": "@fnol_msg.body.party"
-        },
-        "corr": "@corr_consent",
-        "reply_to": "@reply_to_consent"
+        }
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
-      "id": "S_consent",
+      "id": "S_consent_reply",
       "kind": "Subscribe",
       "channel": "@reply_to_consent",
       "qos": "at_least_once",
@@ -235,7 +221,7 @@
       "out": {
         "var": "consent_reply"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
       "id": "K_payout",
@@ -244,7 +230,7 @@
       "out": {
         "var": "kp_payout"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
       "id": "T_payout_corr",
@@ -259,14 +245,14 @@
         "m": "POST",
         "b": {
           "claim": "@fnol_msg.body.claim_id",
-          "amount": "@eligibility.amount",
+          "amount": "@eligibility_value.amount",
           "channel": "SEPA"
         }
       },
       "out": {
         "var": "corr_payout"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
       "id": "T_payout_reply_to",
@@ -281,27 +267,27 @@
       "out": {
         "var": "reply_to_payout"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
-      "id": "P_payout",
+      "id": "P_payout_request",
       "kind": "Publish",
       "channel": "rpc:req:api/payments/payout",
       "qos": "at_least_once",
       "payload": {
         "method": "POST",
+        "corr": "@corr_payout",
+        "reply_to": "@reply_to_payout",
         "body": {
           "claim": "@fnol_msg.body.claim_id",
-          "amount": "@eligibility.amount",
+          "amount": "@eligibility_value.amount",
           "channel": "SEPA"
-        },
-        "corr": "@corr_payout",
-        "reply_to": "@reply_to_payout"
+        }
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
-      "id": "S_payout",
+      "id": "S_payout_reply",
       "kind": "Subscribe",
       "channel": "@reply_to_payout",
       "qos": "at_least_once",
@@ -309,10 +295,10 @@
       "out": {
         "var": "payout_reply"
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
-      "id": "P_metric_success",
+      "id": "P_emit_metric",
       "kind": "Publish",
       "channel": "metric:claims.fasttrack.success",
       "qos": "at_least_once",
@@ -320,10 +306,10 @@
         "value": 1,
         "unit": "count",
         "tags": {
-          "region": "@policy_snapshot.response.region"
+          "region": "@get_policy_reply.response.region"
         }
       },
-      "when": "@is_allow"
+      "when": "@branch_1_value"
     },
     {
       "id": "K_assign",
@@ -334,7 +320,7 @@
       },
       "when": {
         "op": "not",
-        "var": "is_allow"
+        "var": "branch_1_value"
       }
     },
     {
@@ -350,7 +336,7 @@
         "m": "POST",
         "b": {
           "claim": "@fnol_msg.body.claim_id",
-          "priority": "@sev_score.bucket"
+          "priority": "@score_severity_value.bucket"
         }
       },
       "out": {
@@ -358,7 +344,7 @@
       },
       "when": {
         "op": "not",
-        "var": "is_allow"
+        "var": "branch_1_value"
       }
     },
     {
@@ -376,30 +362,30 @@
       },
       "when": {
         "op": "not",
-        "var": "is_allow"
+        "var": "branch_1_value"
       }
     },
     {
-      "id": "P_assign",
+      "id": "P_assign_request",
       "kind": "Publish",
       "channel": "rpc:req:api/adjuster/assign",
       "qos": "at_least_once",
       "payload": {
         "method": "POST",
+        "corr": "@corr_assign",
+        "reply_to": "@reply_to_assign",
         "body": {
           "claim": "@fnol_msg.body.claim_id",
-          "priority": "@sev_score.bucket"
-        },
-        "corr": "@corr_assign",
-        "reply_to": "@reply_to_assign"
+          "priority": "@score_severity_value.bucket"
+        }
       },
       "when": {
         "op": "not",
-        "var": "is_allow"
+        "var": "branch_1_value"
       }
     },
     {
-      "id": "S_assign",
+      "id": "S_assign_reply",
       "kind": "Subscribe",
       "channel": "@reply_to_assign",
       "qos": "at_least_once",
@@ -409,7 +395,7 @@
       },
       "when": {
         "op": "not",
-        "var": "is_allow"
+        "var": "branch_1_value"
       }
     },
     {
@@ -431,11 +417,11 @@
       },
       "in": {
         "kind": "fasttrack.route",
-        "payload": "@eligibility",
+        "payload": "@eligibility_value",
         "ts": "2025-09-30T11:37:59.839401Z"
       },
       "out": {
-        "var": "record_digest"
+        "var": "record_digest_value"
       }
     },
     {
@@ -445,10 +431,10 @@
         "op": "encode_base58"
       },
       "in": {
-        "value": "@record_digest"
+        "value": "@record_digest_value"
       },
       "out": {
-        "var": "record_id"
+        "var": "record_id_value"
       }
     },
     {
@@ -457,9 +443,9 @@
       "channel": "policy:record",
       "qos": "at_least_once",
       "payload": {
-        "record_id": "@record_id",
+        "record_id": "@record_id_value",
         "kind": "fasttrack.route",
-        "payload": "@eligibility",
+        "payload": "@eligibility_value",
         "ts": "2025-09-30T11:37:59.839401Z"
       }
     }

--- a/0.6/build/auto.quote.bind.issue.v2.l0.json
+++ b/0.6/build/auto.quote.bind.issue.v2.l0.json
@@ -1,0 +1,307 @@
+{
+  "pipeline_id": "auto.quote.bind.issue.v2",
+  "created_at": "2025-09-30T15:36:45.280Z",
+  "effects": "Outbound+Inbound+Entropy+Pure",
+  "nodes": [
+    {
+      "id": "S_quote_quote",
+      "kind": "Subscribe",
+      "channel": "rpc:req:api/quote/submit",
+      "qos": "at_least_once",
+      "out": {
+        "var": "quote_msg"
+      }
+    },
+    {
+      "id": "T_validate_request",
+      "kind": "Transform",
+      "spec": {
+        "op": "jsonschema.validate",
+        "schema": "AutoQuoteRequestV2"
+      },
+      "in": {
+        "value": "@quote_msg.body"
+      },
+      "out": {
+        "var": "validate_request_value"
+      }
+    },
+    {
+      "id": "T_rate",
+      "kind": "Transform",
+      "spec": {
+        "op": "model_infer",
+        "model": "auto.quote.rate.v2"
+      },
+      "in": {
+        "features": "@quote_msg.body"
+      },
+      "out": {
+        "var": "rate_value"
+      }
+    },
+    {
+      "id": "T_risk_rules",
+      "kind": "Transform",
+      "spec": {
+        "op": "policy_eval",
+        "policy": "auto.quote.risk_rules.v2"
+      },
+      "in": {
+        "input": {
+          "quote": "@quote_msg.body",
+          "rate": "@rate_value"
+        }
+      },
+      "out": {
+        "var": "risk_rules_value"
+      }
+    },
+    {
+      "id": "T_offer",
+      "kind": "Transform",
+      "spec": {
+        "op": "compose",
+        "template": {
+          "quote_id": "@quote_msg.body.quote_id",
+          "premium": "@rate_value.premium",
+          "coverages": "@risk_rules_value.coverages",
+          "terms": "@risk_rules_value.terms"
+        }
+      },
+      "in": {},
+      "out": {
+        "var": "offer_value"
+      }
+    },
+    {
+      "id": "K_bind",
+      "kind": "Keypair",
+      "algorithm": "Ed25519",
+      "out": {
+        "var": "kp_bind"
+      }
+    },
+    {
+      "id": "T_bind_corr",
+      "kind": "Transform",
+      "spec": {
+        "op": "hash",
+        "alg": "blake3"
+      },
+      "in": {
+        "k": "@kp_bind.public_key_pem",
+        "e": "api/bindings/sign",
+        "m": "POST",
+        "b": {
+          "quote_id": "@quote_msg.body.quote_id",
+          "applicant": "@quote_msg.body.applicant",
+          "offer": "@offer_value"
+        }
+      },
+      "out": {
+        "var": "corr_bind"
+      }
+    },
+    {
+      "id": "T_bind_reply_to",
+      "kind": "Transform",
+      "spec": {
+        "op": "concat"
+      },
+      "in": {
+        "a": "rpc:reply:",
+        "b": "@corr_bind"
+      },
+      "out": {
+        "var": "reply_to_bind"
+      }
+    },
+    {
+      "id": "P_bind_request",
+      "kind": "Publish",
+      "channel": "rpc:req:api/bindings/sign",
+      "qos": "at_least_once",
+      "payload": {
+        "method": "POST",
+        "corr": "@corr_bind",
+        "reply_to": "@reply_to_bind",
+        "body": {
+          "quote_id": "@quote_msg.body.quote_id",
+          "applicant": "@quote_msg.body.applicant",
+          "offer": "@offer_value"
+        }
+      }
+    },
+    {
+      "id": "S_bind_reply",
+      "kind": "Subscribe",
+      "channel": "@reply_to_bind",
+      "qos": "at_least_once",
+      "filter": "@corr_bind",
+      "out": {
+        "var": "bind_reply"
+      }
+    },
+    {
+      "id": "K_issue",
+      "kind": "Keypair",
+      "algorithm": "Ed25519",
+      "out": {
+        "var": "kp_issue"
+      }
+    },
+    {
+      "id": "T_issue_corr",
+      "kind": "Transform",
+      "spec": {
+        "op": "hash",
+        "alg": "blake3"
+      },
+      "in": {
+        "k": "@kp_issue.public_key_pem",
+        "e": "api/policy/issue",
+        "m": "POST",
+        "b": {
+          "quote_id": "@quote_msg.body.quote_id",
+          "binding_id": "@bind_reply.response.binding_id"
+        }
+      },
+      "out": {
+        "var": "corr_issue"
+      }
+    },
+    {
+      "id": "T_issue_reply_to",
+      "kind": "Transform",
+      "spec": {
+        "op": "concat"
+      },
+      "in": {
+        "a": "rpc:reply:",
+        "b": "@corr_issue"
+      },
+      "out": {
+        "var": "reply_to_issue"
+      }
+    },
+    {
+      "id": "P_issue_request",
+      "kind": "Publish",
+      "channel": "rpc:req:api/policy/issue",
+      "qos": "at_least_once",
+      "payload": {
+        "method": "POST",
+        "corr": "@corr_issue",
+        "reply_to": "@reply_to_issue",
+        "body": {
+          "quote_id": "@quote_msg.body.quote_id",
+          "binding_id": "@bind_reply.response.binding_id"
+        }
+      }
+    },
+    {
+      "id": "S_issue_reply",
+      "kind": "Subscribe",
+      "channel": "@reply_to_issue",
+      "qos": "at_least_once",
+      "filter": "@corr_issue",
+      "out": {
+        "var": "issue_reply"
+      }
+    },
+    {
+      "id": "K_schedule_first_payment",
+      "kind": "Keypair",
+      "algorithm": "Ed25519",
+      "out": {
+        "var": "kp_schedule_first_payment"
+      }
+    },
+    {
+      "id": "T_schedule_first_payment_corr",
+      "kind": "Transform",
+      "spec": {
+        "op": "hash",
+        "alg": "blake3"
+      },
+      "in": {
+        "k": "@kp_schedule_first_payment.public_key_pem",
+        "e": "api/payments/schedule",
+        "m": "POST",
+        "b": {
+          "policy_id": "@issue_reply.response.policy_id",
+          "amount": "@offer_value.premium",
+          "due_at": "@issue_reply.response.first_due_at"
+        }
+      },
+      "out": {
+        "var": "corr_schedule_first_payment"
+      }
+    },
+    {
+      "id": "T_schedule_first_payment_reply_to",
+      "kind": "Transform",
+      "spec": {
+        "op": "concat"
+      },
+      "in": {
+        "a": "rpc:reply:",
+        "b": "@corr_schedule_first_payment"
+      },
+      "out": {
+        "var": "reply_to_schedule_first_payment"
+      }
+    },
+    {
+      "id": "P_schedule_first_payment_request",
+      "kind": "Publish",
+      "channel": "rpc:req:api/payments/schedule",
+      "qos": "at_least_once",
+      "payload": {
+        "method": "POST",
+        "corr": "@corr_schedule_first_payment",
+        "reply_to": "@reply_to_schedule_first_payment",
+        "body": {
+          "policy_id": "@issue_reply.response.policy_id",
+          "amount": "@offer_value.premium",
+          "due_at": "@issue_reply.response.first_due_at"
+        }
+      }
+    },
+    {
+      "id": "S_schedule_first_payment_reply",
+      "kind": "Subscribe",
+      "channel": "@reply_to_schedule_first_payment",
+      "qos": "at_least_once",
+      "filter": "@corr_schedule_first_payment",
+      "out": {
+        "var": "schedule_first_payment_reply"
+      }
+    },
+    {
+      "id": "P_metric",
+      "kind": "Publish",
+      "channel": "metric:quote.bind.issue.completed",
+      "qos": "at_least_once",
+      "payload": {
+        "value": 1,
+        "unit": "count",
+        "tags": {
+          "product": "@quote_msg.body.product",
+          "policy_id": "@issue_reply.response.policy_id"
+        }
+      }
+    },
+    {
+      "id": "P_ack",
+      "kind": "Publish",
+      "channel": "@quote_msg.reply_to",
+      "qos": "at_least_once",
+      "payload": {
+        "corr": "@quote_msg.corr",
+        "status": "accepted"
+      }
+    }
+  ]
+}

--- a/0.6/build/monitors.fasttrack-24h.l0.json
+++ b/0.6/build/monitors.fasttrack-24h.l0.json
@@ -1,0 +1,254 @@
+{
+  "bundle_id": "monitors.fasttrack-24h",
+  "created_at": "2025-09-30T15:39:24.496Z",
+  "effects": "Outbound+Inbound+Entropy+Pure",
+  "monitors": [
+    {
+      "monitor_id": "fasttrack.sla.start.v1",
+      "nodes": [
+        {
+          "id": "S_fasttrack_sla_start_v1_event",
+          "kind": "Subscribe",
+          "channel": "claims.eligibility",
+          "qos": "at_least_once",
+          "out": {
+            "var": "event_msg"
+          }
+        },
+        {
+          "id": "T_fasttrack_sla_start_v1_when_cond_1",
+          "kind": "Transform",
+          "spec": {
+            "op": "eq"
+          },
+          "in": {
+            "left": "@event_msg.decision",
+            "right": "allow"
+          },
+          "out": {
+            "var": "fasttrack_sla_start_v1_when_1_value"
+          }
+        },
+        {
+          "id": "K_schedule",
+          "kind": "Keypair",
+          "algorithm": "Ed25519",
+          "out": {
+            "var": "kp_schedule"
+          },
+          "when": "@fasttrack_sla_start_v1_when_1_value"
+        },
+        {
+          "id": "T_schedule_corr",
+          "kind": "Transform",
+          "spec": {
+            "op": "hash",
+            "alg": "blake3"
+          },
+          "in": {
+            "k": "@kp_schedule.public_key_pem",
+            "task_ref": "sla.fasttrack.deadline",
+            "trigger": {
+              "in_hours": 24,
+              "corr": "@event_msg.corr"
+            }
+          },
+          "out": {
+            "var": "corr_schedule"
+          },
+          "when": "@fasttrack_sla_start_v1_when_1_value"
+        },
+        {
+          "id": "T_schedule_reply_to",
+          "kind": "Transform",
+          "spec": {
+            "op": "concat"
+          },
+          "in": {
+            "a": "rpc:reply:",
+            "b": "@corr_schedule"
+          },
+          "out": {
+            "var": "reply_to_schedule"
+          },
+          "when": "@fasttrack_sla_start_v1_when_1_value"
+        },
+        {
+          "id": "P_schedule_request",
+          "kind": "Publish",
+          "channel": "rpc:req:scheduler.request",
+          "qos": "at_least_once",
+          "payload": {
+            "method": "POST",
+            "body": {
+              "task_ref": "sla.fasttrack.deadline",
+              "trigger": {
+                "in_hours": 24,
+                "corr": "@event_msg.corr"
+              }
+            },
+            "corr": "@corr_schedule",
+            "reply_to": "@reply_to_schedule"
+          },
+          "when": "@fasttrack_sla_start_v1_when_1_value"
+        },
+        {
+          "id": "S_schedule_reply",
+          "kind": "Subscribe",
+          "channel": "@reply_to_schedule",
+          "qos": "at_least_once",
+          "filter": "@corr_schedule",
+          "out": {
+            "var": "schedule_reply"
+          },
+          "when": "@fasttrack_sla_start_v1_when_1_value"
+        }
+      ]
+    },
+    {
+      "monitor_id": "fasttrack.sla.check.v1",
+      "nodes": [
+        {
+          "id": "S_fasttrack_sla_check_v1_event",
+          "kind": "Subscribe",
+          "channel": "process:event:sla.fasttrack.deadline",
+          "qos": "at_least_once",
+          "out": {
+            "var": "event_msg"
+          }
+        },
+        {
+          "id": "T_lookup",
+          "kind": "Transform",
+          "spec": {
+            "op": "lookup",
+            "entity": "claim",
+            "field": "payout_ack"
+          },
+          "in": {
+            "key": "@event_msg.corr"
+          },
+          "out": {
+            "var": "lookup_value"
+          }
+        },
+        {
+          "id": "T_branch_1_cond_1",
+          "kind": "Transform",
+          "spec": {
+            "op": "identity"
+          },
+          "in": {
+            "value": "@lookup_value.missing"
+          },
+          "out": {
+            "var": "branch_1_1_value"
+          }
+        },
+        {
+          "id": "P_breach_metric",
+          "kind": "Publish",
+          "channel": "metric:claims.fasttrack.breach",
+          "qos": "at_least_once",
+          "payload": {
+            "value": 1,
+            "unit": "count",
+            "tags": {
+              "corr": "@event_msg.corr"
+            }
+          },
+          "when": "@branch_1_1_value"
+        },
+        {
+          "id": "K_alert",
+          "kind": "Keypair",
+          "algorithm": "Ed25519",
+          "out": {
+            "var": "kp_alert"
+          },
+          "when": "@branch_1_1_value"
+        },
+        {
+          "id": "T_alert_corr",
+          "kind": "Transform",
+          "spec": {
+            "op": "hash",
+            "alg": "blake3"
+          },
+          "in": {
+            "k": "@kp_alert.public_key_pem",
+            "e": "api/alerts/create",
+            "m": "POST",
+            "b": {
+              "kind": "SLA_BREACH",
+              "corr": "@event_msg.corr"
+            }
+          },
+          "out": {
+            "var": "corr_alert"
+          },
+          "when": "@branch_1_1_value"
+        },
+        {
+          "id": "T_alert_reply_to",
+          "kind": "Transform",
+          "spec": {
+            "op": "concat"
+          },
+          "in": {
+            "a": "rpc:reply:",
+            "b": "@corr_alert"
+          },
+          "out": {
+            "var": "reply_to_alert"
+          },
+          "when": "@branch_1_1_value"
+        },
+        {
+          "id": "P_alert_request",
+          "kind": "Publish",
+          "channel": "rpc:req:api/alerts/create",
+          "qos": "at_least_once",
+          "payload": {
+            "method": "POST",
+            "corr": "@corr_alert",
+            "reply_to": "@reply_to_alert",
+            "body": {
+              "kind": "SLA_BREACH",
+              "corr": "@event_msg.corr"
+            }
+          },
+          "when": "@branch_1_1_value"
+        },
+        {
+          "id": "S_alert_reply",
+          "kind": "Subscribe",
+          "channel": "@reply_to_alert",
+          "qos": "at_least_once",
+          "filter": "@corr_alert",
+          "out": {
+            "var": "alert_reply"
+          },
+          "when": "@branch_1_1_value"
+        },
+        {
+          "id": "P_on_time_metric",
+          "kind": "Publish",
+          "channel": "metric:claims.fasttrack.on_time",
+          "qos": "at_least_once",
+          "payload": {
+            "value": 1,
+            "unit": "count",
+            "tags": {
+              "corr": "@event_msg.corr"
+            }
+          },
+          "when": {
+            "op": "not",
+            "var": "branch_1_1_value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/0.6/monitors/fasttrack-24h.l2.yaml
+++ b/0.6/monitors/fasttrack-24h.l2.yaml
@@ -1,0 +1,23 @@
+# TF-Lang · Monitors · Fast-Track 24h SLA (L2)
+monitors:
+  - monitor: "fasttrack.sla.start.v1"
+    on: obs.stream("claims.eligibility")
+    when: "@event.decision == 'allow'"
+    then:
+      - schedule: process.schedule(task_ref: "sla.fasttrack.deadline",
+                                   trigger: { in_hours: 24, corr: "@event.corr" })
+
+  - monitor: "fasttrack.sla.check.v1"
+    on: process.event("sla.fasttrack.deadline")
+    then:
+      - lookup: transform.lookup(entity: "claim", key: "@event.corr", field: "payout_ack")
+      - branch:
+          when: "@lookup.missing"
+          then:
+            - breach_metric: obs.emit_metric(name: "claims.fasttrack.breach", value: 1,
+                                            tags: { corr: "@event.corr" })
+            - alert: interaction.request(endpoint: "api/alerts/create", method: "POST",
+                                         body: { kind: "SLA_BREACH", corr: "@event.corr" })
+          else:
+            - on_time_metric: obs.emit_metric(name: "claims.fasttrack.on_time", value: 1,
+                                              tags: { corr: "@event.corr" })

--- a/0.6/pipelines/auto.quote.bind.issue.v2.l2.yaml
+++ b/0.6/pipelines/auto.quote.bind.issue.v2.l2.yaml
@@ -1,0 +1,42 @@
+# TF-Lang · Insurance Example · Quote → Bind → Issue v2 (L2)
+pipeline: "auto.quote.bind.issue.v2"
+description: >
+  Receive an auto quote request, validate the payload, rate the risk, apply underwriting
+  rules, and return a bindable offer. When the applicant signs, issue the policy, schedule
+  the first payment, and emit operational telemetry.
+inputs:
+  - quote: interaction.receive(endpoint: "api/quote/submit", qos: "at_least_once")
+
+steps:
+  - validate_request: transform.validate(schema: "AutoQuoteRequestV2", input: "@quote.body")
+
+  - rate: transform.model_infer(model: "auto.quote.rate.v2", input: "@quote.body")
+
+  - risk_rules: policy.evaluate(policy: "auto.quote.risk_rules.v2",
+                                input: { quote: "@quote.body", rate: "@rate_out" })
+
+  - offer: transform.compose(template: { quote_id: "@quote.body.quote_id",
+                                          premium: "@rate_out.premium",
+                                          coverages: "@risk_rules_out.coverages",
+                                          terms: "@risk_rules_out.terms" })
+
+  - bind: interaction.request(endpoint: "api/bindings/sign", method: "POST",
+                               body: { quote_id: "@quote.body.quote_id",
+                                       applicant: "@quote.body.applicant",
+                                       offer: "@offer_out" })
+
+  - issue: interaction.request(endpoint: "api/policy/issue", method: "POST",
+                                body: { quote_id: "@quote.body.quote_id",
+                                        binding_id: "@bind.response.binding_id" })
+
+  - schedule_first_payment: interaction.request(endpoint: "api/payments/schedule", method: "POST",
+                                                 body: { policy_id: "@issue.response.policy_id",
+                                                         amount: "@offer_out.premium",
+                                                         due_at: "@issue.response.first_due_at" })
+
+  - metric: obs.emit_metric(name: "quote.bind.issue.completed", value: 1,
+                             tags: { product: "@quote.body.product",
+                                     policy_id: "@issue.response.policy_id" })
+
+outputs:
+  - ack: interaction.reply(to: "@quote", status: "accepted")

--- a/0.6/tests/_util/l0-checks.mjs
+++ b/0.6/tests/_util/l0-checks.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+
+export function extractNodes(doc) {
+  if (Array.isArray(doc?.nodes)) return doc.nodes;
+  if (Array.isArray(doc?.monitors)) {
+    return doc.monitors.flatMap((monitor) => monitor.nodes ?? []);
+  }
+  throw new Error('Unsupported L0 document shape');
+}
+
+export function assertKernelOnly(doc, kinds = ['Transform', 'Publish', 'Subscribe', 'Keypair']) {
+  const allowed = new Set(kinds);
+  const nodes = extractNodes(doc);
+  for (const node of nodes) {
+    assert(allowed.has(node.kind), `Unexpected kernel kind ${node.kind} on node ${node.id}`);
+  }
+}
+
+export function assertRpcPairings(doc) {
+  const nodes = extractNodes(doc);
+  const publishes = nodes.filter((node) => node.kind === 'Publish' && typeof node.channel === 'string' && node.channel.startsWith('rpc:req:'));
+  assert(publishes.length > 0, 'No rpc:req publishes found');
+  const subscribes = nodes.filter((node) => node.kind === 'Subscribe');
+  for (const publish of publishes) {
+    const payload = publish.payload ?? {};
+    assert(Object.prototype.hasOwnProperty.call(payload, 'corr'), `RPC publish ${publish.id} missing corr`);
+    assert(Object.prototype.hasOwnProperty.call(payload, 'reply_to'), `RPC publish ${publish.id} missing reply_to`);
+    const { corr: corrRef, reply_to: replyTo } = payload;
+    const hasMatch = subscribes.some((sub) => sub.channel === replyTo && sub.filter === corrRef);
+    assert(hasMatch, `RPC publish ${publish.id} lacks matching subscribe for ${replyTo}`);
+  }
+}
+
+export function assertNoPiiInMetricTags(doc, banned = ['name', 'email', 'phone']) {
+  const nodes = extractNodes(doc);
+  const metrics = nodes.filter((node) => node.kind === 'Publish' && typeof node.channel === 'string' && node.channel.startsWith('metric:'));
+  assert(metrics.length > 0, 'No metric publishes found');
+  const forbidden = new Set(banned.map((key) => key.toLowerCase()));
+  for (const publish of metrics) {
+    const tags = publish.payload?.tags ?? {};
+    for (const key of Object.keys(tags)) {
+      assert(!forbidden.has(key.toLowerCase()), `Metric ${publish.id} contains forbidden tag key: ${key}`);
+    }
+  }
+}

--- a/0.6/tests/monitors-fasttrack-24h.spec.mjs
+++ b/0.6/tests/monitors-fasttrack-24h.spec.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import process from 'node:process';
+
+function fail(msg) {
+  console.error('FAIL:', msg);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log('OK  :', msg);
+}
+
+const argIndex = process.argv.indexOf('--l0');
+if (argIndex < 0 || argIndex + 1 >= process.argv.length) fail('Missing --l0 <path>');
+const l0Path = process.argv[argIndex + 1];
+const doc = JSON.parse(fs.readFileSync(l0Path, 'utf8'));
+
+const monitors = doc.monitors ?? [];
+const allNodes = monitors.flatMap((m) => m.nodes ?? []);
+
+if (allNodes.length === 0) fail('No monitor nodes found');
+
+const rpcPublishes = allNodes.filter((node) => node.kind === 'Publish' && typeof node.channel === 'string' && node.channel.startsWith('rpc:req:'));
+const subscribes = allNodes.filter((node) => node.kind === 'Subscribe');
+
+for (const node of rpcPublishes) {
+  const payload = node.payload || {};
+  if (!Object.prototype.hasOwnProperty.call(payload, 'corr')) {
+    fail(`RPC publish ${node.id} missing corr`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(payload, 'reply_to')) {
+    fail(`RPC publish ${node.id} missing reply_to`);
+  }
+  const replyTo = payload.reply_to;
+  const corrRef = payload.corr;
+  const hasSubscribe = subscribes.some((sub) => sub.channel === replyTo && sub.filter === corrRef);
+  if (!hasSubscribe) {
+    fail(`RPC publish ${node.id} lacks matching subscribe for ${replyTo}`);
+  }
+}
+if (rpcPublishes.length > 0) ok('All rpc:req publishes carry corr/reply_to with matching replies.');
+
+const metricPublishes = allNodes.filter((node) => node.kind === 'Publish' && typeof node.channel === 'string' && node.channel.startsWith('metric:'));
+const forbidden = new Set(['name', 'email', 'phone']);
+for (const node of metricPublishes) {
+  const tags = (node.payload && node.payload.tags) || {};
+  for (const key of Object.keys(tags)) {
+    if (forbidden.has(key.toLowerCase())) {
+      fail(`Metric ${node.id} contains forbidden tag key: ${key}`);
+    }
+  }
+}
+if (metricPublishes.length > 0) ok('Metric publishes avoid PII tag keys.');
+
+const effectSet = new Set((doc.effects || '').split('+').filter(Boolean));
+if (!effectSet.has('Outbound')) {
+  fail('Effects summary missing Outbound');
+}
+const hasReplySubscribe = subscribes.some((node) => typeof node.channel === 'string' && node.channel.startsWith('@reply_to_'));
+if (hasReplySubscribe && !effectSet.has('Inbound')) {
+  fail('Effects summary missing Inbound for reply subscriptions');
+}
+ok('Effects summary includes required capabilities.');
+
+console.log('\nAll checks passed.');

--- a/0.6/tests/monitors-fasttrack-24h.spec.mjs
+++ b/0.6/tests/monitors-fasttrack-24h.spec.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import process from 'node:process';
+import {
+  assertKernelOnly,
+  assertRpcPairings,
+  assertNoPiiInMetricTags,
+  extractNodes,
+} from './_util/l0-checks.mjs';
 
 function fail(msg) {
   console.error('FAIL:', msg);
@@ -11,53 +17,32 @@ function ok(msg) {
   console.log('OK  :', msg);
 }
 
+function runCheck(label, fn) {
+  try {
+    fn();
+    ok(label);
+  } catch (err) {
+    fail(err?.message ?? String(err));
+  }
+}
+
 const argIndex = process.argv.indexOf('--l0');
 if (argIndex < 0 || argIndex + 1 >= process.argv.length) fail('Missing --l0 <path>');
 const l0Path = process.argv[argIndex + 1];
 const doc = JSON.parse(fs.readFileSync(l0Path, 'utf8'));
 
-const monitors = doc.monitors ?? [];
-const allNodes = monitors.flatMap((m) => m.nodes ?? []);
+const nodes = extractNodes(doc);
+if (nodes.length === 0) fail('No monitor nodes found');
 
-if (allNodes.length === 0) fail('No monitor nodes found');
-
-const rpcPublishes = allNodes.filter((node) => node.kind === 'Publish' && typeof node.channel === 'string' && node.channel.startsWith('rpc:req:'));
-const subscribes = allNodes.filter((node) => node.kind === 'Subscribe');
-
-for (const node of rpcPublishes) {
-  const payload = node.payload || {};
-  if (!Object.prototype.hasOwnProperty.call(payload, 'corr')) {
-    fail(`RPC publish ${node.id} missing corr`);
-  }
-  if (!Object.prototype.hasOwnProperty.call(payload, 'reply_to')) {
-    fail(`RPC publish ${node.id} missing reply_to`);
-  }
-  const replyTo = payload.reply_to;
-  const corrRef = payload.corr;
-  const hasSubscribe = subscribes.some((sub) => sub.channel === replyTo && sub.filter === corrRef);
-  if (!hasSubscribe) {
-    fail(`RPC publish ${node.id} lacks matching subscribe for ${replyTo}`);
-  }
-}
-if (rpcPublishes.length > 0) ok('All rpc:req publishes carry corr/reply_to with matching replies.');
-
-const metricPublishes = allNodes.filter((node) => node.kind === 'Publish' && typeof node.channel === 'string' && node.channel.startsWith('metric:'));
-const forbidden = new Set(['name', 'email', 'phone']);
-for (const node of metricPublishes) {
-  const tags = (node.payload && node.payload.tags) || {};
-  for (const key of Object.keys(tags)) {
-    if (forbidden.has(key.toLowerCase())) {
-      fail(`Metric ${node.id} contains forbidden tag key: ${key}`);
-    }
-  }
-}
-if (metricPublishes.length > 0) ok('Metric publishes avoid PII tag keys.');
+runCheck('Monitor bundle is kernel-only.', () => assertKernelOnly(doc));
+runCheck('All rpc:req publishes carry corr/reply_to with matching replies.', () => assertRpcPairings(doc));
+runCheck('Metric publishes avoid PII tag keys.', () => assertNoPiiInMetricTags(doc));
 
 const effectSet = new Set((doc.effects || '').split('+').filter(Boolean));
 if (!effectSet.has('Outbound')) {
   fail('Effects summary missing Outbound');
 }
-const hasReplySubscribe = subscribes.some((node) => typeof node.channel === 'string' && node.channel.startsWith('@reply_to_'));
+const hasReplySubscribe = nodes.some((node) => node.kind === 'Subscribe' && typeof node.channel === 'string' && node.channel.startsWith('@reply_to_'));
 if (hasReplySubscribe && !effectSet.has('Inbound')) {
   fail('Effects summary missing Inbound for reply subscriptions');
 }

--- a/0.6/tests/quote-bind-issue.spec.mjs
+++ b/0.6/tests/quote-bind-issue.spec.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import process from 'node:process';
+import {
+  assertKernelOnly,
+  assertRpcPairings,
+  assertNoPiiInMetricTags,
+} from './_util/l0-checks.mjs';
 
 function fail(msg) {
   console.error('FAIL:', msg);
@@ -11,42 +16,22 @@ function ok(msg) {
   console.log('OK  :', msg);
 }
 
+function runCheck(label, fn) {
+  try {
+    fn();
+    ok(label);
+  } catch (err) {
+    fail(err?.message ?? String(err));
+  }
+}
+
 const argIndex = process.argv.indexOf('--l0');
 if (argIndex < 0 || argIndex + 1 >= process.argv.length) fail('Missing --l0 <path>');
 const l0Path = process.argv[argIndex + 1];
 const doc = JSON.parse(fs.readFileSync(l0Path, 'utf8'));
 
-const rpcPublishes = doc.nodes.filter((n) => n.kind === 'Publish' && typeof n.channel === 'string' && n.channel.startsWith('rpc:req:'));
-const subscribes = doc.nodes.filter((n) => n.kind === 'Subscribe');
-if (rpcPublishes.length === 0) fail('No rpc:req publishes found');
-for (const node of rpcPublishes) {
-  const payload = node.payload || {};
-  if (!Object.prototype.hasOwnProperty.call(payload, 'corr')) {
-    fail(`RPC publish ${node.id} missing corr`);
-  }
-  if (!Object.prototype.hasOwnProperty.call(payload, 'reply_to')) {
-    fail(`RPC publish ${node.id} missing reply_to`);
-  }
-  const replyTo = payload.reply_to;
-  const corrRef = payload.corr;
-  const hasSubscribe = subscribes.some((sub) => sub.channel === replyTo && sub.filter === corrRef);
-  if (!hasSubscribe) {
-    fail(`RPC publish ${node.id} lacks matching subscribe for ${replyTo}`);
-  }
-}
-ok('All rpc:req publishes carry corr/reply_to with matching replies.');
-
-const metricPublishes = doc.nodes.filter((n) => n.kind === 'Publish' && typeof n.channel === 'string' && n.channel.startsWith('metric:'));
-if (metricPublishes.length === 0) fail('No metric publishes found');
-const forbidden = new Set(['name', 'email', 'phone']);
-for (const node of metricPublishes) {
-  const tags = (node.payload && node.payload.tags) || {};
-  for (const key of Object.keys(tags)) {
-    if (forbidden.has(key.toLowerCase())) {
-      fail(`Metric ${node.id} contains forbidden tag key: ${key}`);
-    }
-  }
-}
-ok('Metric publishes avoid PII tag keys.');
+runCheck('All nodes are kernel primitives.', () => assertKernelOnly(doc));
+runCheck('All rpc:req publishes carry corr/reply_to with matching replies.', () => assertRpcPairings(doc));
+runCheck('Metric publishes avoid PII tag keys.', () => assertNoPiiInMetricTags(doc));
 
 console.log('\nAll checks passed.');

--- a/0.6/tests/quote-bind-issue.spec.mjs
+++ b/0.6/tests/quote-bind-issue.spec.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import process from 'node:process';
+
+function fail(msg) {
+  console.error('FAIL:', msg);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log('OK  :', msg);
+}
+
+const argIndex = process.argv.indexOf('--l0');
+if (argIndex < 0 || argIndex + 1 >= process.argv.length) fail('Missing --l0 <path>');
+const l0Path = process.argv[argIndex + 1];
+const doc = JSON.parse(fs.readFileSync(l0Path, 'utf8'));
+
+const rpcPublishes = doc.nodes.filter((n) => n.kind === 'Publish' && typeof n.channel === 'string' && n.channel.startsWith('rpc:req:'));
+const subscribes = doc.nodes.filter((n) => n.kind === 'Subscribe');
+if (rpcPublishes.length === 0) fail('No rpc:req publishes found');
+for (const node of rpcPublishes) {
+  const payload = node.payload || {};
+  if (!Object.prototype.hasOwnProperty.call(payload, 'corr')) {
+    fail(`RPC publish ${node.id} missing corr`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(payload, 'reply_to')) {
+    fail(`RPC publish ${node.id} missing reply_to`);
+  }
+  const replyTo = payload.reply_to;
+  const corrRef = payload.corr;
+  const hasSubscribe = subscribes.some((sub) => sub.channel === replyTo && sub.filter === corrRef);
+  if (!hasSubscribe) {
+    fail(`RPC publish ${node.id} lacks matching subscribe for ${replyTo}`);
+  }
+}
+ok('All rpc:req publishes carry corr/reply_to with matching replies.');
+
+const metricPublishes = doc.nodes.filter((n) => n.kind === 'Publish' && typeof n.channel === 'string' && n.channel.startsWith('metric:'));
+if (metricPublishes.length === 0) fail('No metric publishes found');
+const forbidden = new Set(['name', 'email', 'phone']);
+for (const node of metricPublishes) {
+  const tags = (node.payload && node.payload.tags) || {};
+  for (const key of Object.keys(tags)) {
+    if (forbidden.has(key.toLowerCase())) {
+      fail(`Metric ${node.id} contains forbidden tag key: ${key}`);
+    }
+  }
+}
+ok('Metric publishes avoid PII tag keys.');
+
+console.log('\nAll checks passed.');

--- a/diagrams/auto.fnol.fasttrack.v1.dot
+++ b/diagrams/auto.fnol.fasttrack.v1.dot
@@ -1,0 +1,95 @@
+digraph G {
+  rankdir=LR;
+  n0 [label="S_receive_fnol
+rpc:req:api/fnol/submit"];
+  n1 [label="T_validate_fnol
+jsonschema.validate"];
+  n0 -> n1;
+  n2 [label="K_get_policy
+Ed25519"];
+  n1 -> n2;
+  n3 [label="T_get_policy_corr
+hash"];
+  n2 -> n3;
+  n4 [label="T_get_policy_reply_to
+concat"];
+  n3 -> n4;
+  n5 [label="P_get_policy_request
+rpc:req:api/policy/snapshot"];
+  n4 -> n5;
+  n6 [label="S_get_policy_reply
+@reply_to_get_policy"];
+  n5 -> n6;
+  n7 [label="T_score_severity
+model_infer"];
+  n6 -> n7;
+  n8 [label="T_score_fraud
+model_infer"];
+  n7 -> n8;
+  n9 [label="T_eligibility
+policy_eval"];
+  n8 -> n9;
+  n10 [label="T_branch_1
+eq"];
+  n9 -> n10;
+  n11 [label="K_consent
+Ed25519"];
+  n10 -> n11;
+  n12 [label="T_consent_corr
+hash"];
+  n11 -> n12;
+  n13 [label="T_consent_reply_to
+concat"];
+  n12 -> n13;
+  n14 [label="P_consent_request
+rpc:req:api/consent/sign"];
+  n13 -> n14;
+  n15 [label="S_consent_reply
+@reply_to_consent"];
+  n14 -> n15;
+  n16 [label="K_payout
+Ed25519"];
+  n15 -> n16;
+  n17 [label="T_payout_corr
+hash"];
+  n16 -> n17;
+  n18 [label="T_payout_reply_to
+concat"];
+  n17 -> n18;
+  n19 [label="P_payout_request
+rpc:req:api/payments/payout"];
+  n18 -> n19;
+  n20 [label="S_payout_reply
+@reply_to_payout"];
+  n19 -> n20;
+  n21 [label="P_emit_metric
+metric:claims.fasttrack.success"];
+  n20 -> n21;
+  n22 [label="K_assign
+Ed25519"];
+  n21 -> n22;
+  n23 [label="T_assign_corr
+hash"];
+  n22 -> n23;
+  n24 [label="T_assign_reply_to
+concat"];
+  n23 -> n24;
+  n25 [label="P_assign_request
+rpc:req:api/adjuster/assign"];
+  n24 -> n25;
+  n26 [label="S_assign_reply
+@reply_to_assign"];
+  n25 -> n26;
+  n27 [label="P_ack
+@fnol_msg.reply_to"];
+  n26 -> n27;
+  n28 [label="T_record_digest
+digest"];
+  n27 -> n28;
+  n29 [label="T_record_id
+encode_base58"];
+  n28 -> n29;
+  n30 [label="P_record
+policy:record"];
+  n29 -> n30;
+}

--- a/diagrams/auto.fnol.fasttrack.v1.dot
+++ b/diagrams/auto.fnol.fasttrack.v1.dot
@@ -1,95 +1,146 @@
 digraph G {
   rankdir=LR;
   n0 [label="S_receive_fnol
-rpc:req:api/fnol/submit"];
+Subscribe: rpc:req:api/fnol/submit"];
   n1 [label="T_validate_fnol
-jsonschema.validate"];
-  n0 -> n1;
+Transform: jsonschema.validate"];
   n2 [label="K_get_policy
-Ed25519"];
-  n1 -> n2;
+Keypair: Ed25519"];
   n3 [label="T_get_policy_corr
-hash"];
-  n2 -> n3;
+Transform: hash"];
   n4 [label="T_get_policy_reply_to
-concat"];
-  n3 -> n4;
+Transform: concat"];
   n5 [label="P_get_policy_request
-rpc:req:api/policy/snapshot"];
-  n4 -> n5;
+Publish: rpc:req:api/policy/snapshot"];
   n6 [label="S_get_policy_reply
-@reply_to_get_policy"];
-  n5 -> n6;
+Subscribe: @reply_to_get_policy"];
   n7 [label="T_score_severity
-model_infer"];
-  n6 -> n7;
+Transform: model_infer"];
   n8 [label="T_score_fraud
-model_infer"];
-  n7 -> n8;
+Transform: model_infer"];
   n9 [label="T_eligibility
-policy_eval"];
-  n8 -> n9;
+Transform: policy_eval"];
   n10 [label="T_branch_1
-eq"];
-  n9 -> n10;
+Transform: eq"];
   n11 [label="K_consent
-Ed25519"];
-  n10 -> n11;
+Keypair: Ed25519
+when: @branch_1_value"];
   n12 [label="T_consent_corr
-hash"];
-  n11 -> n12;
+Transform: hash
+when: @branch_1_value"];
   n13 [label="T_consent_reply_to
-concat"];
-  n12 -> n13;
+Transform: concat
+when: @branch_1_value"];
   n14 [label="P_consent_request
-rpc:req:api/consent/sign"];
-  n13 -> n14;
+Publish: rpc:req:api/consent/sign
+when: @branch_1_value"];
   n15 [label="S_consent_reply
-@reply_to_consent"];
-  n14 -> n15;
+Subscribe: @reply_to_consent
+when: @branch_1_value"];
   n16 [label="K_payout
-Ed25519"];
-  n15 -> n16;
+Keypair: Ed25519
+when: @branch_1_value"];
   n17 [label="T_payout_corr
-hash"];
-  n16 -> n17;
+Transform: hash
+when: @branch_1_value"];
   n18 [label="T_payout_reply_to
-concat"];
-  n17 -> n18;
+Transform: concat
+when: @branch_1_value"];
   n19 [label="P_payout_request
-rpc:req:api/payments/payout"];
-  n18 -> n19;
+Publish: rpc:req:api/payments/payout
+when: @branch_1_value"];
   n20 [label="S_payout_reply
-@reply_to_payout"];
-  n19 -> n20;
+Subscribe: @reply_to_payout
+when: @branch_1_value"];
   n21 [label="P_emit_metric
-metric:claims.fasttrack.success"];
-  n20 -> n21;
+Publish: metric:claims.fasttrack.success
+when: @branch_1_value"];
   n22 [label="K_assign
-Ed25519"];
-  n21 -> n22;
+Keypair: Ed25519
+when: ¬branch_1_value"];
   n23 [label="T_assign_corr
-hash"];
-  n22 -> n23;
+Transform: hash
+when: ¬branch_1_value"];
   n24 [label="T_assign_reply_to
-concat"];
-  n23 -> n24;
+Transform: concat
+when: ¬branch_1_value"];
   n25 [label="P_assign_request
-rpc:req:api/adjuster/assign"];
-  n24 -> n25;
+Publish: rpc:req:api/adjuster/assign
+when: ¬branch_1_value"];
   n26 [label="S_assign_reply
-@reply_to_assign"];
-  n25 -> n26;
+Subscribe: @reply_to_assign
+when: ¬branch_1_value"];
   n27 [label="P_ack
-@fnol_msg.reply_to"];
-  n26 -> n27;
+Publish: @fnol_msg.reply_to"];
   n28 [label="T_record_digest
-digest"];
-  n27 -> n28;
+Transform: digest"];
   n29 [label="T_record_id
-encode_base58"];
-  n28 -> n29;
+Transform: encode_base58"];
   n30 [label="P_record
-policy:record"];
+Publish: policy:record"];
+  n0 -> n1;
+  n2 -> n3;
+  n0 -> n3;
+  n3 -> n4;
+  n3 -> n5;
+  n4 -> n5;
+  n0 -> n5;
+  n4 -> n6;
+  n3 -> n6;
+  n0 -> n7;
+  n0 -> n8;
+  n7 -> n9;
+  n8 -> n9;
+  n6 -> n9;
+  n9 -> n10;
+  n10 -> n11 [style=dashed];
+  n11 -> n12;
+  n0 -> n12;
+  n10 -> n12 [style=dashed];
+  n12 -> n13;
+  n10 -> n13 [style=dashed];
+  n12 -> n14;
+  n13 -> n14;
+  n0 -> n14;
+  n10 -> n14 [style=dashed];
+  n13 -> n15;
+  n12 -> n15;
+  n10 -> n15 [style=dashed];
+  n10 -> n16 [style=dashed];
+  n16 -> n17;
+  n0 -> n17;
+  n9 -> n17;
+  n10 -> n17 [style=dashed];
+  n17 -> n18;
+  n10 -> n18 [style=dashed];
+  n17 -> n19;
+  n18 -> n19;
+  n0 -> n19;
+  n9 -> n19;
+  n10 -> n19 [style=dashed];
+  n18 -> n20;
+  n17 -> n20;
+  n10 -> n20 [style=dashed];
+  n6 -> n21;
+  n10 -> n21 [style=dashed];
+  n10 -> n22 [style=dashed];
+  n22 -> n23;
+  n0 -> n23;
+  n7 -> n23;
+  n10 -> n23 [style=dashed];
+  n23 -> n24;
+  n10 -> n24 [style=dashed];
+  n23 -> n25;
+  n24 -> n25;
+  n0 -> n25;
+  n7 -> n25;
+  n10 -> n25 [style=dashed];
+  n24 -> n26;
+  n23 -> n26;
+  n10 -> n26 [style=dashed];
+  n0 -> n27;
+  n9 -> n28;
+  n28 -> n29;
   n29 -> n30;
+  n9 -> n30;
 }

--- a/diagrams/auto.quote.bind.issue.v2.dot
+++ b/diagrams/auto.quote.bind.issue.v2.dot
@@ -1,0 +1,68 @@
+digraph G {
+  rankdir=LR;
+  n0 [label="S_quote_quote
+rpc:req:api/quote/submit"];
+  n1 [label="T_validate_request
+jsonschema.validate"];
+  n0 -> n1;
+  n2 [label="T_rate
+model_infer"];
+  n1 -> n2;
+  n3 [label="T_risk_rules
+policy_eval"];
+  n2 -> n3;
+  n4 [label="T_offer
+compose"];
+  n3 -> n4;
+  n5 [label="K_bind
+Ed25519"];
+  n4 -> n5;
+  n6 [label="T_bind_corr
+hash"];
+  n5 -> n6;
+  n7 [label="T_bind_reply_to
+concat"];
+  n6 -> n7;
+  n8 [label="P_bind_request
+rpc:req:api/bindings/sign"];
+  n7 -> n8;
+  n9 [label="S_bind_reply
+@reply_to_bind"];
+  n8 -> n9;
+  n10 [label="K_issue
+Ed25519"];
+  n9 -> n10;
+  n11 [label="T_issue_corr
+hash"];
+  n10 -> n11;
+  n12 [label="T_issue_reply_to
+concat"];
+  n11 -> n12;
+  n13 [label="P_issue_request
+rpc:req:api/policy/issue"];
+  n12 -> n13;
+  n14 [label="S_issue_reply
+@reply_to_issue"];
+  n13 -> n14;
+  n15 [label="K_schedule_first_payment
+Ed25519"];
+  n14 -> n15;
+  n16 [label="T_schedule_first_payment_corr
+hash"];
+  n15 -> n16;
+  n17 [label="T_schedule_first_payment_reply_to
+concat"];
+  n16 -> n17;
+  n18 [label="P_schedule_first_payment_request
+rpc:req:api/payments/schedule"];
+  n17 -> n18;
+  n19 [label="S_schedule_first_payment_reply
+@reply_to_schedule_first_payment"];
+  n18 -> n19;
+  n20 [label="P_metric
+metric:quote.bind.issue.completed"];
+  n19 -> n20;
+  n21 [label="P_ack
+@quote_msg.reply_to"];
+  n20 -> n21;
+}

--- a/diagrams/auto.quote.bind.issue.v2.dot
+++ b/diagrams/auto.quote.bind.issue.v2.dot
@@ -1,68 +1,87 @@
 digraph G {
   rankdir=LR;
   n0 [label="S_quote_quote
-rpc:req:api/quote/submit"];
+Subscribe: rpc:req:api/quote/submit"];
   n1 [label="T_validate_request
-jsonschema.validate"];
-  n0 -> n1;
+Transform: jsonschema.validate"];
   n2 [label="T_rate
-model_infer"];
-  n1 -> n2;
+Transform: model_infer"];
   n3 [label="T_risk_rules
-policy_eval"];
-  n2 -> n3;
+Transform: policy_eval"];
   n4 [label="T_offer
-compose"];
-  n3 -> n4;
+Transform: compose"];
   n5 [label="K_bind
-Ed25519"];
-  n4 -> n5;
+Keypair: Ed25519"];
   n6 [label="T_bind_corr
-hash"];
-  n5 -> n6;
+Transform: hash"];
   n7 [label="T_bind_reply_to
-concat"];
-  n6 -> n7;
+Transform: concat"];
   n8 [label="P_bind_request
-rpc:req:api/bindings/sign"];
-  n7 -> n8;
+Publish: rpc:req:api/bindings/sign"];
   n9 [label="S_bind_reply
-@reply_to_bind"];
-  n8 -> n9;
+Subscribe: @reply_to_bind"];
   n10 [label="K_issue
-Ed25519"];
-  n9 -> n10;
+Keypair: Ed25519"];
   n11 [label="T_issue_corr
-hash"];
-  n10 -> n11;
+Transform: hash"];
   n12 [label="T_issue_reply_to
-concat"];
-  n11 -> n12;
+Transform: concat"];
   n13 [label="P_issue_request
-rpc:req:api/policy/issue"];
-  n12 -> n13;
+Publish: rpc:req:api/policy/issue"];
   n14 [label="S_issue_reply
-@reply_to_issue"];
-  n13 -> n14;
+Subscribe: @reply_to_issue"];
   n15 [label="K_schedule_first_payment
-Ed25519"];
-  n14 -> n15;
+Keypair: Ed25519"];
   n16 [label="T_schedule_first_payment_corr
-hash"];
-  n15 -> n16;
+Transform: hash"];
   n17 [label="T_schedule_first_payment_reply_to
-concat"];
-  n16 -> n17;
+Transform: concat"];
   n18 [label="P_schedule_first_payment_request
-rpc:req:api/payments/schedule"];
-  n17 -> n18;
+Publish: rpc:req:api/payments/schedule"];
   n19 [label="S_schedule_first_payment_reply
-@reply_to_schedule_first_payment"];
-  n18 -> n19;
+Subscribe: @reply_to_schedule_first_payment"];
   n20 [label="P_metric
-metric:quote.bind.issue.completed"];
-  n19 -> n20;
+Publish: metric:quote.bind.issue.completed"];
   n21 [label="P_ack
-@quote_msg.reply_to"];
-  n20 -> n21;
+Publish: @quote_msg.reply_to"];
+  n0 -> n1;
+  n0 -> n2;
+  n0 -> n3;
+  n2 -> n3;
+  n0 -> n4;
+  n2 -> n4;
+  n3 -> n4;
+  n5 -> n6;
+  n0 -> n6;
+  n4 -> n6;
+  n6 -> n7;
+  n6 -> n8;
+  n7 -> n8;
+  n0 -> n8;
+  n4 -> n8;
+  n7 -> n9;
+  n6 -> n9;
+  n10 -> n11;
+  n0 -> n11;
+  n9 -> n11;
+  n11 -> n12;
+  n11 -> n13;
+  n12 -> n13;
+  n0 -> n13;
+  n9 -> n13;
+  n12 -> n14;
+  n11 -> n14;
+  n15 -> n16;
+  n14 -> n16;
+  n4 -> n16;
+  n16 -> n17;
+  n16 -> n18;
+  n17 -> n18;
+  n14 -> n18;
+  n4 -> n18;
+  n17 -> n19;
+  n16 -> n19;
+  n0 -> n20;
+  n14 -> n20;
+  n0 -> n21;
 }

--- a/diagrams/monitors.fasttrack-24h.dot
+++ b/diagrams/monitors.fasttrack-24h.dot
@@ -3,56 +3,86 @@ digraph G {
   subgraph cluster_0 {
     label="fasttrack.sla.start.v1";
     m0_n0 [label="S_fasttrack_sla_start_v1_event
-Subscribe"];
+Subscribe: claims.eligibility"];
     m0_n1 [label="T_fasttrack_sla_start_v1_when_cond_1
-Transform"];
-    m0_n0 -> m0_n1;
+Transform: eq"];
     m0_n2 [label="K_schedule
-Keypair"];
-    m0_n1 -> m0_n2;
+Keypair: Ed25519
+when: @fasttrack_sla_start_v1_when_1_value"];
     m0_n3 [label="T_schedule_corr
-Transform"];
-    m0_n2 -> m0_n3;
+Transform: hash
+when: @fasttrack_sla_start_v1_when_1_value"];
     m0_n4 [label="T_schedule_reply_to
-Transform"];
-    m0_n3 -> m0_n4;
+Transform: concat
+when: @fasttrack_sla_start_v1_when_1_value"];
     m0_n5 [label="P_schedule_request
-Publish"];
-    m0_n4 -> m0_n5;
+Publish: rpc:req:scheduler.request
+when: @fasttrack_sla_start_v1_when_1_value"];
     m0_n6 [label="S_schedule_reply
-Subscribe"];
-    m0_n5 -> m0_n6;
+Subscribe: @reply_to_schedule
+when: @fasttrack_sla_start_v1_when_1_value"];
+    m0_n0 -> m0_n1;
+    m0_n1 -> m0_n2 [style=dashed];
+    m0_n2 -> m0_n3;
+    m0_n0 -> m0_n3;
+    m0_n1 -> m0_n3 [style=dashed];
+    m0_n3 -> m0_n4;
+    m0_n1 -> m0_n4 [style=dashed];
+    m0_n0 -> m0_n5;
+    m0_n3 -> m0_n5;
+    m0_n4 -> m0_n5;
+    m0_n1 -> m0_n5 [style=dashed];
+    m0_n4 -> m0_n6;
+    m0_n3 -> m0_n6;
+    m0_n1 -> m0_n6 [style=dashed];
   }
   subgraph cluster_1 {
     label="fasttrack.sla.check.v1";
     m1_n0 [label="S_fasttrack_sla_check_v1_event
-Subscribe"];
+Subscribe: process:event:sla.fasttrack.deadline"];
     m1_n1 [label="T_lookup
-Transform"];
-    m1_n0 -> m1_n1;
+Transform: lookup"];
     m1_n2 [label="T_branch_1_cond_1
-Transform"];
-    m1_n1 -> m1_n2;
+Transform: identity"];
     m1_n3 [label="P_breach_metric
-Publish"];
-    m1_n2 -> m1_n3;
+Publish: metric:claims.fasttrack.breach
+when: @branch_1_1_value"];
     m1_n4 [label="K_alert
-Keypair"];
-    m1_n3 -> m1_n4;
+Keypair: Ed25519
+when: @branch_1_1_value"];
     m1_n5 [label="T_alert_corr
-Transform"];
-    m1_n4 -> m1_n5;
+Transform: hash
+when: @branch_1_1_value"];
     m1_n6 [label="T_alert_reply_to
-Transform"];
-    m1_n5 -> m1_n6;
+Transform: concat
+when: @branch_1_1_value"];
     m1_n7 [label="P_alert_request
-Publish"];
-    m1_n6 -> m1_n7;
+Publish: rpc:req:api/alerts/create
+when: @branch_1_1_value"];
     m1_n8 [label="S_alert_reply
-Subscribe"];
-    m1_n7 -> m1_n8;
+Subscribe: @reply_to_alert
+when: @branch_1_1_value"];
     m1_n9 [label="P_on_time_metric
-Publish"];
-    m1_n8 -> m1_n9;
+Publish: metric:claims.fasttrack.on_time
+when: ¬branch_1_1_value"];
+    m1_n0 -> m1_n1;
+    m1_n1 -> m1_n2;
+    m1_n0 -> m1_n3;
+    m1_n2 -> m1_n3 [style=dashed];
+    m1_n2 -> m1_n4 [style=dashed];
+    m1_n4 -> m1_n5;
+    m1_n0 -> m1_n5;
+    m1_n2 -> m1_n5 [style=dashed];
+    m1_n5 -> m1_n6;
+    m1_n2 -> m1_n6 [style=dashed];
+    m1_n5 -> m1_n7;
+    m1_n6 -> m1_n7;
+    m1_n0 -> m1_n7;
+    m1_n2 -> m1_n7 [style=dashed];
+    m1_n6 -> m1_n8;
+    m1_n5 -> m1_n8;
+    m1_n2 -> m1_n8 [style=dashed];
+    m1_n0 -> m1_n9;
+    m1_n2 -> m1_n9 [style=dashed];
   }
 }

--- a/diagrams/monitors.fasttrack-24h.dot
+++ b/diagrams/monitors.fasttrack-24h.dot
@@ -1,0 +1,58 @@
+digraph G {
+  rankdir=LR;
+  subgraph cluster_0 {
+    label="fasttrack.sla.start.v1";
+    m0_n0 [label="S_fasttrack_sla_start_v1_event
+Subscribe"];
+    m0_n1 [label="T_fasttrack_sla_start_v1_when_cond_1
+Transform"];
+    m0_n0 -> m0_n1;
+    m0_n2 [label="K_schedule
+Keypair"];
+    m0_n1 -> m0_n2;
+    m0_n3 [label="T_schedule_corr
+Transform"];
+    m0_n2 -> m0_n3;
+    m0_n4 [label="T_schedule_reply_to
+Transform"];
+    m0_n3 -> m0_n4;
+    m0_n5 [label="P_schedule_request
+Publish"];
+    m0_n4 -> m0_n5;
+    m0_n6 [label="S_schedule_reply
+Subscribe"];
+    m0_n5 -> m0_n6;
+  }
+  subgraph cluster_1 {
+    label="fasttrack.sla.check.v1";
+    m1_n0 [label="S_fasttrack_sla_check_v1_event
+Subscribe"];
+    m1_n1 [label="T_lookup
+Transform"];
+    m1_n0 -> m1_n1;
+    m1_n2 [label="T_branch_1_cond_1
+Transform"];
+    m1_n1 -> m1_n2;
+    m1_n3 [label="P_breach_metric
+Publish"];
+    m1_n2 -> m1_n3;
+    m1_n4 [label="K_alert
+Keypair"];
+    m1_n3 -> m1_n4;
+    m1_n5 [label="T_alert_corr
+Transform"];
+    m1_n4 -> m1_n5;
+    m1_n6 [label="T_alert_reply_to
+Transform"];
+    m1_n5 -> m1_n6;
+    m1_n7 [label="P_alert_request
+Publish"];
+    m1_n6 -> m1_n7;
+    m1_n8 [label="S_alert_reply
+Subscribe"];
+    m1_n7 -> m1_n8;
+    m1_n9 [label="P_on_time_metric
+Publish"];
+    m1_n8 -> m1_n9;
+  }
+}

--- a/docs/0.6/index.md
+++ b/docs/0.6/index.md
@@ -1,0 +1,5 @@
+# TF-Lang v0.6 Pipelines
+
+- [Auto FNOL Fast-Track](pipelines/fnol-fasttrack.md)
+- [Auto Quote → Bind → Issue](pipelines/quote-bind-issue.md)
+- [Fast-Track 24h SLA Monitors](monitors/fasttrack-24h.md)

--- a/docs/0.6/monitors/fasttrack-24h.md
+++ b/docs/0.6/monitors/fasttrack-24h.md
@@ -1,0 +1,70 @@
+# Fast-Track 24h SLA Monitors
+
+The fast-track 24h monitors start a deadline when eligibility decisions allow the claim
+and watch for payout acknowledgements. If the payout confirmation is missing when the
+scheduled timer fires, the monitors publish a breach metric and alert; otherwise they
+record an on-time metric.
+
+If generated, open [diagrams/monitors.fasttrack-24h.svg](../../diagrams/monitors.fasttrack-24h.svg)
+for a zoomable view of the graph.
+
+```dot
+digraph G {
+  rankdir=LR;
+  subgraph cluster_0 {
+    label="fasttrack.sla.start.v1";
+    m0_n0 [label="S_fasttrack_sla_start_v1_event
+Subscribe"];
+    m0_n1 [label="T_fasttrack_sla_start_v1_when_cond_1
+Transform"];
+    m0_n0 -> m0_n1;
+    m0_n2 [label="K_schedule
+Keypair"];
+    m0_n1 -> m0_n2;
+    m0_n3 [label="T_schedule_corr
+Transform"];
+    m0_n2 -> m0_n3;
+    m0_n4 [label="T_schedule_reply_to
+Transform"];
+    m0_n3 -> m0_n4;
+    m0_n5 [label="P_schedule_request
+Publish"];
+    m0_n4 -> m0_n5;
+    m0_n6 [label="S_schedule_reply
+Subscribe"];
+    m0_n5 -> m0_n6;
+  }
+  subgraph cluster_1 {
+    label="fasttrack.sla.check.v1";
+    m1_n0 [label="S_fasttrack_sla_check_v1_event
+Subscribe"];
+    m1_n1 [label="T_lookup
+Transform"];
+    m1_n0 -> m1_n1;
+    m1_n2 [label="T_branch_1_cond_1
+Transform"];
+    m1_n1 -> m1_n2;
+    m1_n3 [label="P_breach_metric
+Publish"];
+    m1_n2 -> m1_n3;
+    m1_n4 [label="K_alert
+Keypair"];
+    m1_n3 -> m1_n4;
+    m1_n5 [label="T_alert_corr
+Transform"];
+    m1_n4 -> m1_n5;
+    m1_n6 [label="T_alert_reply_to
+Transform"];
+    m1_n5 -> m1_n6;
+    m1_n7 [label="P_alert_request
+Publish"];
+    m1_n6 -> m1_n7;
+    m1_n8 [label="S_alert_reply
+Subscribe"];
+    m1_n7 -> m1_n8;
+    m1_n9 [label="P_on_time_metric
+Publish"];
+    m1_n8 -> m1_n9;
+  }
+}
+```

--- a/docs/0.6/pipelines/quote-bind-issue.md
+++ b/docs/0.6/pipelines/quote-bind-issue.md
@@ -1,0 +1,79 @@
+# Auto Quote → Bind → Issue (v2)
+
+The quote pipeline validates incoming requests, prices the risk, applies underwriting
+rules, and composes a bindable offer. Once the applicant signs, it issues the policy,
+schedules the first payment, and emits operational telemetry for tracking.
+
+If generated, open [diagrams/auto.quote.bind.issue.v2.svg](../../diagrams/auto.quote.bind.issue.v2.svg)
+for a zoomable view of the graph.
+
+```dot
+digraph G {
+  rankdir=LR;
+  n0 [label="S_quote_quote
+rpc:req:api/quote/submit"];
+  n1 [label="T_validate_request
+jsonschema.validate"];
+  n0 -> n1;
+  n2 [label="T_rate
+model_infer"];
+  n1 -> n2;
+  n3 [label="T_risk_rules
+policy_eval"];
+  n2 -> n3;
+  n4 [label="T_offer
+compose"];
+  n3 -> n4;
+  n5 [label="K_bind
+Ed25519"];
+  n4 -> n5;
+  n6 [label="T_bind_corr
+hash"];
+  n5 -> n6;
+  n7 [label="T_bind_reply_to
+concat"];
+  n6 -> n7;
+  n8 [label="P_bind_request
+rpc:req:api/bindings/sign"];
+  n7 -> n8;
+  n9 [label="S_bind_reply
+@reply_to_bind"];
+  n8 -> n9;
+  n10 [label="K_issue
+Ed25519"];
+  n9 -> n10;
+  n11 [label="T_issue_corr
+hash"];
+  n10 -> n11;
+  n12 [label="T_issue_reply_to
+concat"];
+  n11 -> n12;
+  n13 [label="P_issue_request
+rpc:req:api/policy/issue"];
+  n12 -> n13;
+  n14 [label="S_issue_reply
+@reply_to_issue"];
+  n13 -> n14;
+  n15 [label="K_schedule_first_payment
+Ed25519"];
+  n14 -> n15;
+  n16 [label="T_schedule_first_payment_corr
+hash"];
+  n15 -> n16;
+  n17 [label="T_schedule_first_payment_reply_to
+concat"];
+  n16 -> n17;
+  n18 [label="P_schedule_first_payment_request
+rpc:req:api/payments/schedule"];
+  n17 -> n18;
+  n19 [label="S_schedule_first_payment_reply
+@reply_to_schedule_first_payment"];
+  n18 -> n19;
+  n20 [label="P_metric
+metric:quote.bind.issue.completed"];
+  n19 -> n20;
+  n21 [label="P_ack
+@quote_msg.reply_to"];
+  n20 -> n21;
+}
+```

--- a/packages/expander/common.mjs
+++ b/packages/expander/common.mjs
@@ -1,0 +1,85 @@
+import { parse as parseYaml } from 'yaml';
+
+function parenBalance(str) {
+  return (str.match(/\(/g) || []).length - (str.match(/\)/g) || []).length;
+}
+
+export function quoteCalls(src) {
+  const lines = src.split(/\r?\n/);
+  const out = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(/^(\s*(?:-\s+)?[A-Za-z0-9_]+:\s*)([A-Za-z0-9_.]+\()(.*)$/);
+    if (match) {
+      let call = match[2] + match[3];
+      let depth = parenBalance(match[2]) + parenBalance(match[3]);
+      while (depth > 0 && i + 1 < lines.length) {
+        const next = lines[++i];
+        call += `\n${next.trim()}`;
+        depth += parenBalance(next);
+      }
+      call = call.replace(/\s*\n\s*/g, ' ');
+      call = call.replace(/"/g, '\\"');
+      out.push(`${match[1]}"${call}"`);
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+export function parseCall(raw) {
+  if (raw == null) throw new Error('missing macro invocation');
+  if (typeof raw === 'object') {
+    if (typeof raw.macro === 'string') {
+      return { macro: raw.macro, args: raw.args ?? {} };
+    }
+    const entries = Object.entries(raw);
+    if (entries.length !== 1) throw new Error(`invalid call object: ${JSON.stringify(raw)}`);
+    const [macro, args] = entries[0];
+    if (typeof args === 'string') return parseCall(args);
+    if (Array.isArray(args)) return { macro, args: { __args: args } };
+    return { macro, args: args ?? {} };
+  }
+  if (typeof raw !== 'string') throw new Error(`unsupported call type: ${typeof raw}`);
+  const match = raw.match(/^([A-Za-z0-9_.]+)\((.*)\)$/);
+  if (!match) throw new Error(`invalid call syntax: ${raw}`);
+  const [, macro, argsRaw] = match;
+  const trimmed = argsRaw.trim();
+  if (!trimmed) return { macro, args: {} };
+  if (trimmed.includes(':')) return { macro, args: parseYaml(`{ ${trimmed} }`) };
+  const positional = parseYaml(`[${trimmed}]`);
+  return { macro, args: { __args: positional } };
+}
+
+export function slug(value) {
+  return String(value)
+    .replace(/[^A-Za-z0-9_]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+export function nodeId(prefix, index) {
+  return `${prefix}_${index}`;
+}
+
+const EFFECT_MAP = {
+  Publish: 'Outbound',
+  Subscribe: 'Inbound',
+  Keypair: 'Entropy',
+  Transform: 'Pure',
+};
+
+export function computeEffects(nodes) {
+  const seen = new Set();
+  for (const node of nodes) {
+    const effect = EFFECT_MAP[node.kind];
+    if (!effect) throw new Error(`unsupported kernel kind: ${node.kind}`);
+    seen.add(effect);
+  }
+  const order = ['Outbound', 'Inbound', 'Entropy', 'Pure'];
+  const values = order.filter((effect) => seen.has(effect));
+  if (values.length === 0) return 'Pure';
+  return values.join('+');
+}

--- a/scripts/assert-kernel-only.mjs
+++ b/scripts/assert-kernel-only.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const allowed = new Set(['Transform', 'Publish', 'Subscribe', 'Keypair']);
+
+if (process.argv.length < 3) {
+  console.error('usage: assert-kernel-only <l0.json>');
+  process.exit(2);
+}
+
+const doc = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const nodes = Array.isArray(doc.nodes)
+  ? doc.nodes
+  : (doc.monitors ?? []).flatMap((monitor) => monitor.nodes ?? []);
+
+const bad = nodes.filter((node) => !allowed.has(node.kind));
+
+if (bad.length > 0) {
+  console.error('Non-kernel kinds found:', bad.map((node) => `${node.id}:${node.kind}`).join(', '));
+  process.exit(1);
+}
+
+console.log('Kernel-only OK');

--- a/scripts/monitor-effects.mjs
+++ b/scripts/monitor-effects.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+function usage() {
+  console.error('usage: monitor-effects <monitors.l0.json>');
+  process.exit(2);
+}
+
+const EFFECT_LABELS = {
+  Publish: 'Outbound',
+  Subscribe: 'Inbound',
+  Keypair: 'Entropy',
+  Transform: 'Pure',
+};
+
+function describeEffect(node) {
+  const effect = EFFECT_LABELS[node.kind];
+  if (!effect) throw new Error(`unsupported kernel kind: ${node.kind}`);
+  return effect;
+}
+
+function collect(nodes, prefix) {
+  const rows = [];
+  nodes.forEach((node, idx) => {
+    const effect = describeEffect(node);
+    rows.push({
+      effect,
+      label: `${prefix} :: ${node.id} [${node.kind}]`,
+    });
+  });
+  return rows;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length < 1) usage();
+  const doc = JSON.parse(fs.readFileSync(argv[0], 'utf8'));
+  for (const monitor of doc.monitors ?? []) {
+    const rows = collect(monitor.nodes ?? [], monitor.monitor_id ?? 'unknown');
+    for (const row of rows) {
+      console.log(`${row.effect.padEnd(8)} | ${row.label}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err?.message ?? err);
+  process.exit(1);
+});

--- a/scripts/monitor-expand.mjs
+++ b/scripts/monitor-expand.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+function usage() {
+  console.error('usage: monitor-expand <input.l2.yaml> <output.l0.json>');
+  process.exit(2);
+}
+
+function quoteCalls(src) {
+  const lines = src.split(/\r?\n/);
+  const out = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(/^(\s*(?:-\s+)?[A-Za-z0-9_]+:\s*)([A-Za-z0-9_.]+\()(.*)$/);
+    if (match) {
+      let call = match[2] + match[3];
+      let depth = (match[2].match(/\(/g) || []).length - (match[2].match(/\)/g) || []).length;
+      depth += (match[3].match(/\(/g) || []).length - (match[3].match(/\)/g) || []).length;
+      while (depth > 0 && i + 1 < lines.length) {
+        const next = lines[++i];
+        call += `\n${next.trim()}`;
+        depth += (next.match(/\(/g) || []).length - (next.match(/\)/g) || []).length;
+      }
+      call = call.replace(/\s*\n\s*/g, ' ');
+      call = call.replace(/"/g, '\\"');
+      out.push(`${match[1]}"${call}"`);
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+function parseCall(str) {
+  const match = str.match(/^([A-Za-z0-9_.]+)\((.*)\)$/);
+  if (!match) throw new Error(`invalid call syntax: ${str}`);
+  const [, macro, argsRaw] = match;
+  const trimmed = argsRaw.trim();
+  if (!trimmed) return { macro, args: {} };
+  if (trimmed.includes(':')) return { macro, args: parseYaml(`{ ${trimmed} }`) };
+  const positional = parseYaml(`[${trimmed}]`);
+  return { macro, args: { __args: positional } };
+}
+
+function slug(value) {
+  return String(value)
+    .replace(/[^A-Za-z0-9_]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+function id(prefix, name) {
+  return `${prefix}_${slug(name)}`;
+}
+
+const ALLOWED_KINDS = new Set(['Transform', 'Publish', 'Subscribe', 'Keypair']);
+
+function computeEffects(nodes) {
+  const seen = new Set();
+  for (const node of nodes) {
+    switch (node.kind) {
+      case 'Publish':
+        seen.add('Outbound');
+        break;
+      case 'Subscribe':
+        seen.add('Inbound');
+        break;
+      case 'Keypair':
+        seen.add('Entropy');
+        break;
+      case 'Transform':
+        seen.add('Pure');
+        break;
+      default:
+        throw new Error(`unsupported kernel kind: ${node.kind}`);
+    }
+  }
+  const order = ['Outbound', 'Inbound', 'Entropy', 'Pure'];
+  const values = order.filter((effect) => seen.has(effect));
+  if (values.length === 0) return 'Pure';
+  return values.join('+');
+}
+
+class MonitorCompiler {
+  constructor(definition, outputPath) {
+    this.definition = definition;
+    this.outputPath = outputPath;
+    this.bundleId = path.basename(outputPath, '.l0.json');
+    this.createdAt = this.readExistingCreatedAt();
+    this.conditionIndex = 0;
+    this.branchIndex = 0;
+  }
+
+  readExistingCreatedAt() {
+    if (!fs.existsSync(this.outputPath)) return new Date().toISOString();
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.outputPath, 'utf8'));
+      return parsed.created_at ?? new Date().toISOString();
+    } catch {
+      return new Date().toISOString();
+    }
+  }
+
+  resolveRef(ref, refs) {
+    if (typeof ref !== 'string' || !ref.startsWith('@')) return ref;
+    const pathExpr = ref.slice(1);
+    const [head, ...rest] = pathExpr.split('.');
+    const mapped = refs.get(head) ?? `@${head}`;
+    if (rest.length === 0) return mapped;
+    const suffix = rest.join('.');
+    return mapped.startsWith('@') ? `${mapped}.${suffix}` : `@${mapped}.${suffix}`;
+  }
+
+  resolveValue(value, refs) {
+    if (Array.isArray(value)) return value.map((v) => this.resolveValue(v, refs));
+    if (value && typeof value === 'object') {
+      const out = {};
+      for (const [k, v] of Object.entries(value)) out[k] = this.resolveValue(v, refs);
+      return out;
+    }
+    if (typeof value === 'string') return this.resolveRef(value, refs);
+    return value;
+  }
+
+  addNode(nodes, node, whenClause) {
+    if (!ALLOWED_KINDS.has(node.kind)) {
+      throw new Error(`invalid kernel kind: ${node.kind}`);
+    }
+    const finalNode = { ...node };
+    if (whenClause) finalNode.when = whenClause;
+    nodes.push(finalNode);
+  }
+
+  compileCondition(condition, refs, nodes, label, whenClause) {
+    if (typeof condition !== 'string') throw new Error(`unsupported condition: ${JSON.stringify(condition)}`);
+    const eqMatch = condition.match(/^@([A-Za-z0-9_.]+)\s*==\s*'([^']+)'$/);
+    const condVar = `${slug(label)}_${++this.conditionIndex}_value`;
+    if (eqMatch) {
+      const leftExpr = this.resolveRef(`@${eqMatch[1]}`, refs);
+      const rightValue = eqMatch[2];
+      this.addNode(nodes, {
+        id: id('T', `${label}_cond_${this.conditionIndex}`),
+        kind: 'Transform',
+        spec: { op: 'eq' },
+        in: { left: leftExpr, right: rightValue },
+        out: { var: condVar },
+      }, whenClause);
+    } else {
+      const valueExpr = this.resolveRef(condition, refs);
+      this.addNode(nodes, {
+        id: id('T', `${label}_cond_${this.conditionIndex}`),
+        kind: 'Transform',
+        spec: { op: 'identity' },
+        in: { value: valueExpr },
+        out: { var: condVar },
+      }, whenClause);
+    }
+    return {
+      thenWhen: `@${condVar}`,
+      elseWhen: { op: 'not', var: condVar },
+      condVar,
+    };
+  }
+
+  expandProcessSchedule(name, call, refs, nodes, whenClause) {
+    const taskRef = call.args.task_ref;
+    const trigger = this.resolveValue(call.args.trigger ?? {}, refs);
+    const kpVar = `kp_${slug(name)}`;
+    this.addNode(nodes, {
+      id: id('K', name),
+      kind: 'Keypair',
+      algorithm: 'Ed25519',
+      out: { var: kpVar },
+    }, whenClause);
+    const corrVar = `corr_${slug(name)}`;
+    this.addNode(nodes, {
+      id: `${id('T', name)}_corr`,
+      kind: 'Transform',
+      spec: { op: 'hash', alg: 'blake3' },
+      in: { k: `@${kpVar}.public_key_pem`, task_ref: taskRef, trigger },
+      out: { var: corrVar },
+    }, whenClause);
+    const replyToVar = `reply_to_${slug(name)}`;
+    this.addNode(nodes, {
+      id: `${id('T', name)}_reply_to`,
+      kind: 'Transform',
+      spec: { op: 'concat' },
+      in: { a: 'rpc:reply:', b: `@${corrVar}` },
+      out: { var: replyToVar },
+    }, whenClause);
+    this.addNode(nodes, {
+      id: id('P', `${name}_request`),
+      kind: 'Publish',
+      channel: 'rpc:req:scheduler.request',
+      qos: 'at_least_once',
+      payload: {
+        method: 'POST',
+        body: { task_ref: taskRef, trigger },
+        corr: `@${corrVar}`,
+        reply_to: `@${replyToVar}`,
+      },
+    }, whenClause);
+    const replyMsgVar = `${slug(name)}_reply`;
+    this.addNode(nodes, {
+      id: id('S', `${name}_reply`),
+      kind: 'Subscribe',
+      channel: `@${replyToVar}`,
+      qos: 'at_least_once',
+      filter: `@${corrVar}`,
+      out: { var: replyMsgVar },
+    }, whenClause);
+    refs.set(name, `@${replyMsgVar}`);
+  }
+
+  expandTransformLookup(name, call, refs, nodes, whenClause) {
+    const entity = call.args.entity;
+    const field = call.args.field;
+    const keyValue = this.resolveValue(call.args.key, refs);
+    const outVar = `${slug(name)}_value`;
+    this.addNode(nodes, {
+      id: id('T', name),
+      kind: 'Transform',
+      spec: { op: 'lookup', entity, field },
+      in: { key: keyValue },
+      out: { var: outVar },
+    }, whenClause);
+    refs.set(name, `@${outVar}`);
+  }
+
+  expandEmitMetric(name, call, refs, nodes, whenClause) {
+    const metricName = call.args.name;
+    const value = this.resolveValue(call.args.value ?? 1, refs);
+    const tags = this.resolveValue(call.args.tags ?? {}, refs);
+    this.addNode(nodes, {
+      id: id('P', name),
+      kind: 'Publish',
+      channel: `metric:${metricName}`,
+      qos: 'at_least_once',
+      payload: { value, unit: 'count', tags },
+    }, whenClause);
+  }
+
+  expandInteractionRequest(name, call, refs, nodes, whenClause) {
+    const endpoint = call.args.endpoint;
+    const method = call.args.method ?? 'POST';
+    const body = call.args.body ? this.resolveValue(call.args.body, refs) : undefined;
+    const query = call.args.query ? this.resolveValue(call.args.query, refs) : undefined;
+    const kpVar = `kp_${slug(name)}`;
+    this.addNode(nodes, {
+      id: id('K', name),
+      kind: 'Keypair',
+      algorithm: 'Ed25519',
+      out: { var: kpVar },
+    }, whenClause);
+    const corrVar = `corr_${slug(name)}`;
+    const corrInput = { k: `@${kpVar}.public_key_pem`, e: endpoint, m: method };
+    if (body !== undefined) corrInput.b = body;
+    if (query !== undefined) corrInput.q = query;
+    this.addNode(nodes, {
+      id: `${id('T', name)}_corr`,
+      kind: 'Transform',
+      spec: { op: 'hash', alg: 'blake3' },
+      in: corrInput,
+      out: { var: corrVar },
+    }, whenClause);
+    const replyToVar = `reply_to_${slug(name)}`;
+    this.addNode(nodes, {
+      id: `${id('T', name)}_reply_to`,
+      kind: 'Transform',
+      spec: { op: 'concat' },
+      in: { a: 'rpc:reply:', b: `@${corrVar}` },
+      out: { var: replyToVar },
+    }, whenClause);
+    const payload = { method, corr: `@${corrVar}`, reply_to: `@${replyToVar}` };
+    if (body !== undefined) payload.body = body;
+    if (query !== undefined) payload.query = query;
+    this.addNode(nodes, {
+      id: id('P', `${name}_request`),
+      kind: 'Publish',
+      channel: `rpc:req:${endpoint}`,
+      qos: 'at_least_once',
+      payload,
+    }, whenClause);
+    const replyMsgVar = `${slug(name)}_reply`;
+    this.addNode(nodes, {
+      id: id('S', `${name}_reply`),
+      kind: 'Subscribe',
+      channel: `@${replyToVar}`,
+      qos: 'at_least_once',
+      filter: `@${corrVar}`,
+      out: { var: replyMsgVar },
+    }, whenClause);
+    refs.set(name, `@${replyMsgVar}`);
+  }
+
+  expandBranch(branchDef, refs, nodes, whenClause) {
+    const branchIdx = (this.branchIndex += 1);
+    const label = `branch_${branchIdx}`;
+    const { thenWhen, elseWhen } = this.compileCondition(branchDef.when, refs, nodes, label, whenClause);
+    for (const step of branchDef.then ?? []) this.expandAction(step, refs, nodes, thenWhen);
+    for (const step of branchDef.else ?? []) this.expandAction(step, refs, nodes, elseWhen);
+  }
+
+  expandAction(step, refs, nodes, whenClause) {
+    const entries = Object.entries(step);
+    if (entries.length !== 1) throw new Error('invalid monitor action');
+    const [name, raw] = entries[0];
+    if (name === 'branch') {
+      this.expandBranch(raw, refs, nodes, whenClause);
+      return;
+    }
+    const call = typeof raw === 'string' ? parseCall(raw) : parseCall(raw.call ?? raw);
+    switch (call.macro) {
+      case 'process.schedule':
+        this.expandProcessSchedule(name, call, refs, nodes, whenClause);
+        break;
+      case 'transform.lookup':
+        this.expandTransformLookup(name, call, refs, nodes, whenClause);
+        break;
+      case 'obs.emit_metric':
+        this.expandEmitMetric(name, call, refs, nodes, whenClause);
+        break;
+      case 'interaction.request':
+        this.expandInteractionRequest(name, call, refs, nodes, whenClause);
+        break;
+      default:
+        throw new Error(`unsupported monitor macro: ${call.macro}`);
+    }
+  }
+
+  compileMonitor(entry) {
+    const monitorId = entry.monitor;
+    const nodes = [];
+    const refs = new Map();
+    const onCall = parseCall(entry.on);
+    let channel;
+    switch (onCall.macro) {
+      case 'obs.stream': {
+        const arg = Array.isArray(onCall.args.__args) ? onCall.args.__args[0] : onCall.args.channel;
+        if (!arg) throw new Error('obs.stream requires a channel');
+        channel = arg;
+        break;
+      }
+      case 'process.event': {
+        const arg = Array.isArray(onCall.args.__args) ? onCall.args.__args[0] : onCall.args.name;
+        if (!arg) throw new Error('process.event requires a name');
+        channel = `process:event:${arg}`;
+        break;
+      }
+      default:
+        throw new Error(`unsupported monitor source: ${onCall.macro}`);
+    }
+    const eventVar = 'event_msg';
+    this.addNode(nodes, {
+      id: id('S', `${monitorId}_event`),
+      kind: 'Subscribe',
+      channel,
+      qos: 'at_least_once',
+      out: { var: eventVar },
+    }, null);
+    refs.set('event', `@${eventVar}`);
+
+    let baseWhen = null;
+    if (entry.when) {
+      const { thenWhen } = this.compileCondition(entry.when, refs, nodes, `${monitorId}_when`, null);
+      baseWhen = thenWhen;
+    }
+
+    for (const action of entry.then ?? []) this.expandAction(action, refs, nodes, baseWhen);
+
+    return { monitor_id: monitorId, nodes };
+  }
+
+  build() {
+    const monitors = [];
+    for (const entry of this.definition.monitors ?? []) {
+      this.conditionIndex = 0;
+      this.branchIndex = 0;
+      monitors.push(this.compileMonitor(entry));
+    }
+    const allNodes = monitors.flatMap((m) => m.nodes);
+    return {
+      bundle_id: this.bundleId,
+      created_at: this.createdAt,
+      effects: computeEffects(allNodes),
+      monitors,
+    };
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length < 2) usage();
+  const [inputPath, outputPath] = argv;
+  const raw = fs.readFileSync(inputPath, 'utf8');
+  const processed = quoteCalls(raw);
+  const def = parseYaml(processed);
+  const compiler = new MonitorCompiler(def, outputPath);
+  const l0 = compiler.build();
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(l0, null, 2)}\n`, 'utf8');
+}
+
+main().catch((err) => {
+  console.error(err?.message ?? err);
+  process.exit(1);
+});

--- a/scripts/pipeline-expand.mjs
+++ b/scripts/pipeline-expand.mjs
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+function usage() {
+  console.error('usage: pipeline-expand <input.l2.yaml> <output.l0.json>');
+  process.exit(2);
+}
+
+function quoteCalls(src) {
+  const lines = src.split(/\r?\n/);
+  const out = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(/^(\s*-\s+[A-Za-z0-9_]+:\s*)([A-Za-z0-9_.]+\()(.*)$/);
+    if (match) {
+      let call = match[2] + match[3];
+      let depth = (match[2].match(/\(/g) || []).length - (match[2].match(/\)/g) || []).length;
+      depth += (match[3].match(/\(/g) || []).length - (match[3].match(/\)/g) || []).length;
+      while (depth > 0 && i + 1 < lines.length) {
+        const next = lines[++i];
+        call += `\n${next.trim()}`;
+        depth += (next.match(/\(/g) || []).length - (next.match(/\)/g) || []).length;
+      }
+      call = call.replace(/\s*\n\s*/g, ' ');
+      call = call.replace(/"/g, '\\"');
+      out.push(`${match[1]}"${call}"`);
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+function parseCall(str) {
+  const match = str.match(/^([A-Za-z0-9_.]+)\((.*)\)$/);
+  if (!match) throw new Error(`invalid call syntax: ${str}`);
+  const [, macro, argsRaw] = match;
+  const trimmed = argsRaw.trim();
+  if (!trimmed) return { macro, args: {} };
+  if (trimmed.includes(':')) return { macro, args: parseYaml(`{ ${trimmed} }`) };
+  const positional = parseYaml(`[${trimmed}]`);
+  return { macro, args: { __args: positional } };
+}
+
+function slug(value) {
+  return String(value)
+    .replace(/[^A-Za-z0-9_]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+function id(prefix, name) {
+  return `${prefix}_${slug(name)}`;
+}
+
+const ALLOWED_KINDS = new Set(['Transform', 'Publish', 'Subscribe', 'Keypair']);
+
+function computeEffects(nodes) {
+  const seen = new Set();
+  for (const node of nodes) {
+    switch (node.kind) {
+      case 'Publish':
+        seen.add('Outbound');
+        break;
+      case 'Subscribe':
+        seen.add('Inbound');
+        break;
+      case 'Keypair':
+        seen.add('Entropy');
+        break;
+      case 'Transform':
+        seen.add('Pure');
+        break;
+      default:
+        throw new Error(`unsupported kernel kind: ${node.kind}`);
+    }
+  }
+  const order = ['Outbound', 'Inbound', 'Entropy', 'Pure'];
+  const values = order.filter((effect) => seen.has(effect));
+  if (values.length === 0) return 'Pure';
+  return values.join('+');
+}
+
+class PipelineBuilder {
+  constructor(def, existing) {
+    this.pipelineId = def.pipeline;
+    this.description = def.description ?? '';
+    this.createdAt = existing?.created_at ?? new Date().toISOString();
+    this.nodes = [];
+    this.refs = new Map();
+    this.msgInfo = new Map();
+    this.branchIndex = 0;
+  }
+
+  registerRef(name, value, { synonyms = [] } = {}) {
+    const entries = new Set([name, ...synonyms]);
+    for (const entry of entries) {
+      if (!entry) continue;
+      const variants = new Set([entry, slug(entry)]);
+      for (const variant of variants) {
+        if (!variant) continue;
+        this.refs.set(variant, value);
+      }
+    }
+  }
+
+  resolveRef(ref) {
+    if (typeof ref !== 'string' || !ref.startsWith('@')) return ref;
+    const pathExpr = ref.slice(1);
+    const [head, ...rest] = pathExpr.split('.');
+    const mapped = this.refs.get(head) ?? `@${head}`;
+    if (rest.length === 0) return mapped;
+    const suffix = rest.join('.');
+    if (mapped.startsWith('@')) return `${mapped}.${suffix}`;
+    return `@${mapped}.${suffix}`;
+  }
+
+  resolveValue(value) {
+    if (Array.isArray(value)) return value.map((v) => this.resolveValue(v));
+    if (value && typeof value === 'object') {
+      const out = {};
+      for (const [k, v] of Object.entries(value)) out[k] = this.resolveValue(v);
+      return out;
+    }
+    if (typeof value === 'string') return this.resolveRef(value);
+    return value;
+  }
+
+  addNode(node, whenClause) {
+    if (!ALLOWED_KINDS.has(node.kind)) {
+      throw new Error(`invalid kernel kind: ${node.kind}`);
+    }
+    const finalNode = { ...node };
+    if (whenClause) finalNode.when = whenClause;
+    this.nodes.push(finalNode);
+  }
+
+  addInput(name, call) {
+    if (call.macro !== 'interaction.receive') throw new Error(`unsupported input macro: ${call.macro}`);
+    const endpoint = call.args.endpoint;
+    const qos = call.args.qos ?? 'at_least_once';
+    const parts = String(endpoint).split('/').filter(Boolean);
+    const resource = parts.length >= 2 ? parts[1] : parts[parts.length - 1] ?? name;
+    const varName = `${slug(resource)}_msg`;
+    const nodeId = `S_${slug(name)}_${slug(resource)}`;
+    this.addNode({
+      id: nodeId,
+      kind: 'Subscribe',
+      channel: `rpc:req:${endpoint}`,
+      qos,
+      out: { var: varName },
+    });
+    this.registerRef(name, `@${varName}`, { synonyms: [`${name}_msg`, `${slug(name)}_msg`] });
+    this.msgInfo.set(name, { varName });
+  }
+
+  addTransform(name, spec, input, outVar, whenClause) {
+    this.addNode({
+      id: id('T', name),
+      kind: 'Transform',
+      spec,
+      in: input,
+      out: { var: outVar },
+    }, whenClause);
+    const base = slug(name);
+    const aliases = new Set([
+      `${name}_value`,
+      `${name}_out`,
+      `${base}_value`,
+      `${base}_out`,
+      outVar,
+    ]);
+    this.registerRef(name, `@${outVar}`, { synonyms: Array.from(aliases) });
+  }
+
+  expandValidate(name, call, whenClause) {
+    const schema = call.args.schema;
+    const input = this.resolveValue(call.args.input);
+    const varName = `${slug(name)}_value`;
+    this.addTransform(name, { op: 'jsonschema.validate', schema }, { value: input }, varName, whenClause);
+  }
+
+  expandModelInfer(name, call, whenClause) {
+    const model = call.args.model;
+    const features = this.resolveValue(call.args.input ?? call.args.features ?? call.args.payload);
+    const varName = `${slug(name)}_value`;
+    this.addTransform(name, { op: 'model_infer', model }, { features }, varName, whenClause);
+  }
+
+  expandPolicyEval(name, call, whenClause) {
+    const policy = call.args.policy;
+    const input = this.resolveValue(call.args.input ?? {});
+    const varName = `${slug(name)}_value`;
+    this.addTransform(name, { op: 'policy_eval', policy }, { input }, varName, whenClause);
+  }
+
+  expandGenericTransform(name, call, whenClause) {
+    const [, op = 'custom'] = call.macro.split('.', 2);
+    const spec = { op };
+    const inputKeys = new Set(['input', 'value', 'left', 'right', 'lhs', 'rhs', 'data', 'payload']);
+    const input = {};
+    for (const [key, raw] of Object.entries(call.args)) {
+      const resolved = this.resolveValue(raw);
+      if (inputKeys.has(key)) {
+        input[key] = resolved;
+      } else {
+        spec[key] = resolved;
+      }
+    }
+    const inObject = Object.keys(input).length > 0 ? input : {};
+    const varName = `${slug(name)}_value`;
+    this.addTransform(name, spec, inObject, varName, whenClause);
+  }
+
+  expandRequest(name, call, whenClause) {
+    const endpoint = call.args.endpoint;
+    const method = call.args.method ?? 'POST';
+    const body = call.args.body ? this.resolveValue(call.args.body) : undefined;
+    const query = call.args.query ? this.resolveValue(call.args.query) : undefined;
+    const kpVar = `kp_${slug(name)}`;
+    this.addNode({
+      id: id('K', name),
+      kind: 'Keypair',
+      algorithm: 'Ed25519',
+      out: { var: kpVar },
+    }, whenClause);
+    const corrVar = `corr_${slug(name)}`;
+    const corrInput = {
+      k: `@${kpVar}.public_key_pem`,
+      e: endpoint,
+      m: method,
+    };
+    if (body !== undefined) corrInput.b = body;
+    if (query !== undefined) corrInput.q = query;
+    this.addNode({
+      id: `${id('T', name)}_corr`,
+      kind: 'Transform',
+      spec: { op: 'hash', alg: 'blake3' },
+      in: corrInput,
+      out: { var: corrVar },
+    }, whenClause);
+    const replyVar = `reply_to_${slug(name)}`;
+    this.addNode({
+      id: `${id('T', name)}_reply_to`,
+      kind: 'Transform',
+      spec: { op: 'concat' },
+      in: { a: 'rpc:reply:', b: `@${corrVar}` },
+      out: { var: replyVar },
+    }, whenClause);
+    const payload = {
+      method,
+      corr: `@${corrVar}`,
+      reply_to: `@${replyVar}`,
+    };
+    if (body !== undefined) payload.body = body;
+    if (query !== undefined) payload.query = query;
+    this.addNode({
+      id: id('P', `${name}_request`),
+      kind: 'Publish',
+      channel: `rpc:req:${endpoint}`,
+      qos: 'at_least_once',
+      payload,
+    }, whenClause);
+    const replyMsgVar = `${slug(name)}_reply`;
+    this.addNode({
+      id: id('S', `${name}_reply`),
+      kind: 'Subscribe',
+      channel: `@${replyVar}`,
+      qos: 'at_least_once',
+      filter: `@${corrVar}`,
+      out: { var: replyMsgVar },
+    }, whenClause);
+    this.registerRef(name, `@${replyMsgVar}`, { synonyms: [`${name}_reply`, `${slug(name)}_reply`] });
+  }
+
+  expandEmitMetric(name, call, whenClause) {
+    const metricName = call.args.name;
+    const value = this.resolveValue(call.args.value ?? 1);
+    const tags = call.args.tags ? this.resolveValue(call.args.tags) : undefined;
+    const payload = { value, unit: 'count' };
+    if (tags) payload.tags = tags;
+    this.addNode({
+      id: id('P', name),
+      kind: 'Publish',
+      channel: `metric:${metricName}`,
+      qos: 'at_least_once',
+      payload,
+    }, whenClause);
+  }
+
+  expandReply(name, call, whenClause) {
+    const toExpr = this.resolveRef(call.args.to);
+    const base = toExpr.startsWith('@') ? toExpr : `@${toExpr}`;
+    const channel = `${base}.reply_to`;
+    const payload = { corr: `${base}.corr` };
+    for (const [k, v] of Object.entries(call.args)) {
+      if (k === 'to') continue;
+      payload[k] = this.resolveValue(v);
+    }
+    this.addNode({
+      id: id('P', name),
+      kind: 'Publish',
+      channel,
+      qos: 'at_least_once',
+      payload,
+    }, whenClause);
+  }
+
+  expandRecord(name, call, whenClause) {
+    const kindValue = call.args.kind;
+    const payloadExpr = this.resolveValue(call.args.payload);
+    const digestVar = `${slug(name)}_digest_value`;
+    this.addNode({
+      id: `${id('T', name)}_digest`,
+      kind: 'Transform',
+      spec: { op: 'digest', alg: 'blake3' },
+      in: { kind: kindValue, payload: payloadExpr, ts: this.createdAt },
+      out: { var: digestVar },
+    }, whenClause);
+    const idVar = `${slug(name)}_id_value`;
+    this.addNode({
+      id: `${id('T', name)}_id`,
+      kind: 'Transform',
+      spec: { op: 'encode_base58' },
+      in: { value: `@${digestVar}` },
+      out: { var: idVar },
+    }, whenClause);
+    this.addNode({
+      id: id('P', name),
+      kind: 'Publish',
+      channel: 'policy:record',
+      qos: 'at_least_once',
+      payload: { record_id: `@${idVar}`, kind: kindValue, payload: payloadExpr, ts: this.createdAt },
+    }, whenClause);
+  }
+
+  expandStep(name, call, whenClause) {
+    switch (call.macro) {
+      case 'transform.validate':
+        this.expandValidate(name, call, whenClause);
+        break;
+      case 'transform.model_infer':
+        this.expandModelInfer(name, call, whenClause);
+        break;
+      case 'policy.evaluate':
+        this.expandPolicyEval(name, call, whenClause);
+        break;
+      case 'interaction.request':
+        this.expandRequest(name, call, whenClause);
+        break;
+      case 'obs.emit_metric':
+        this.expandEmitMetric(name, call, whenClause);
+        break;
+      case 'interaction.reply':
+        this.expandReply(name, call, whenClause);
+        break;
+      case 'policy.record_decision':
+        this.expandRecord(name, call, whenClause);
+        break;
+      default:
+        if (call.macro.startsWith('transform.')) {
+          this.expandGenericTransform(name, call, whenClause);
+          break;
+        }
+        throw new Error(`unsupported macro: ${call.macro}`);
+    }
+  }
+
+  expandBranch(branchDef, whenClause) {
+    const cond = branchDef.when;
+    const eqMatch = typeof cond === 'string' ? cond.match(/^@([A-Za-z0-9_.]+)\s*==\s*'([^']+)'$/) : null;
+    if (!eqMatch) throw new Error(`unsupported branch condition: ${cond}`);
+    const branchIdx = (this.branchIndex += 1);
+    const condVar = `branch_${branchIdx}_value`;
+    const leftExpr = this.resolveRef(`@${eqMatch[1]}`);
+    const rightValue = eqMatch[2];
+    this.addNode({
+      id: `T_branch_${branchIdx}`,
+      kind: 'Transform',
+      spec: { op: 'eq' },
+      in: { left: leftExpr, right: rightValue },
+      out: { var: condVar },
+    }, whenClause);
+    const thenWhen = `@${condVar}`;
+    const elseWhen = { op: 'not', var: condVar };
+    for (const step of branchDef.then ?? []) this.processStep(step, thenWhen);
+    for (const step of branchDef.else ?? []) this.processStep(step, elseWhen);
+  }
+
+  processStep(step, whenClause) {
+    const entries = Object.entries(step);
+    if (entries.length !== 1) throw new Error('invalid step entry');
+    const [name, value] = entries[0];
+    if (name === 'branch') {
+      this.expandBranch(value, whenClause);
+      return;
+    }
+    const call = typeof value === 'string' ? parseCall(value) : parseCall(value.call ?? value);
+    this.expandStep(name, call, whenClause);
+  }
+
+  build(def) {
+    for (const input of def.inputs ?? []) {
+      const [name, value] = Object.entries(input)[0];
+      const call = parseCall(typeof value === 'string' ? value : value.call ?? value);
+      this.addInput(name, call);
+    }
+    for (const step of def.steps ?? []) this.processStep(step, null);
+    for (const output of def.outputs ?? []) this.processStep(output, null);
+    return {
+      pipeline_id: this.pipelineId,
+      created_at: this.createdAt,
+      effects: computeEffects(this.nodes),
+      nodes: this.nodes,
+    };
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length < 2) usage();
+  const [inputPath, outputPath] = argv;
+  const raw = fs.readFileSync(inputPath, 'utf8');
+  const processed = quoteCalls(raw);
+  const def = parseYaml(processed);
+  let existing = null;
+  if (fs.existsSync(outputPath)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    } catch {
+      existing = null;
+    }
+  }
+  const builder = new PipelineBuilder(def, existing);
+  const l0 = builder.build(def);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(l0, null, 2)}\n`, 'utf8');
+}
+
+main().catch((err) => {
+  console.error(err?.message ?? err);
+  process.exit(1);
+});

--- a/tasks/run-examples.sh
+++ b/tasks/run-examples.sh
@@ -1,23 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
+pipelines_built=0
+monitors_built=0
+diagrams_written=0
 # Pipelines
 node scripts/pipeline-expand.mjs 0.6/pipelines/auto.fnol.fasttrack.v1.l2.yaml 0.6/build/auto.fnol.fasttrack.v1.l0.json
+((pipelines_built+=1))
 node scripts/assert-kernel-only.mjs 0.6/build/auto.fnol.fasttrack.v1.l0.json
 node 0.6/tests/fnol-fasttrack.spec.mjs --l0 0.6/build/auto.fnol.fasttrack.v1.l0.json
 node scripts/pipeline-expand.mjs 0.6/pipelines/auto.quote.bind.issue.v2.l2.yaml 0.6/build/auto.quote.bind.issue.v2.l0.json
+((pipelines_built+=1))
 node scripts/assert-kernel-only.mjs 0.6/build/auto.quote.bind.issue.v2.l0.json
 node 0.6/tests/quote-bind-issue.spec.mjs --l0 0.6/build/auto.quote.bind.issue.v2.l0.json
 # Monitors
 node scripts/monitor-expand.mjs 0.6/monitors/fasttrack-24h.l2.yaml 0.6/build/monitors.fasttrack-24h.l0.json
+((monitors_built+=1))
 node scripts/assert-kernel-only.mjs 0.6/build/monitors.fasttrack-24h.l0.json
 node 0.6/tests/monitors-fasttrack-24h.spec.mjs --l0 0.6/build/monitors.fasttrack-24h.l0.json
 # Diagrams
 node tools/tf-lang-cli/index.mjs graph 0.6/build/auto.fnol.fasttrack.v1.l0.json > diagrams/auto.fnol.fasttrack.v1.dot
+((diagrams_written+=1))
 node tools/tf-lang-cli/index.mjs graph 0.6/build/auto.quote.bind.issue.v2.l0.json > diagrams/auto.quote.bind.issue.v2.dot
+((diagrams_written+=1))
 node tools/tf-lang-cli/index.mjs graph 0.6/build/monitors.fasttrack-24h.l0.json > diagrams/monitors.fasttrack-24h.dot
+((diagrams_written+=1))
 if command -v dot >/dev/null 2>&1; then
   dot -Tsvg diagrams/auto.fnol.fasttrack.v1.dot -o diagrams/auto.fnol.fasttrack.v1.svg
   dot -Tsvg diagrams/auto.quote.bind.issue.v2.dot -o diagrams/auto.quote.bind.issue.v2.svg
   dot -Tsvg diagrams/monitors.fasttrack-24h.dot -o diagrams/monitors.fasttrack-24h.svg
 fi
 echo "All examples OK."
+echo "Summary: ${pipelines_built} pipelines, ${monitors_built} monitor bundles, ${diagrams_written} diagrams."

--- a/tasks/run-examples.sh
+++ b/tasks/run-examples.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Pipelines
+node scripts/pipeline-expand.mjs 0.6/pipelines/auto.fnol.fasttrack.v1.l2.yaml 0.6/build/auto.fnol.fasttrack.v1.l0.json
+node scripts/assert-kernel-only.mjs 0.6/build/auto.fnol.fasttrack.v1.l0.json
+node 0.6/tests/fnol-fasttrack.spec.mjs --l0 0.6/build/auto.fnol.fasttrack.v1.l0.json
+node scripts/pipeline-expand.mjs 0.6/pipelines/auto.quote.bind.issue.v2.l2.yaml 0.6/build/auto.quote.bind.issue.v2.l0.json
+node scripts/assert-kernel-only.mjs 0.6/build/auto.quote.bind.issue.v2.l0.json
+node 0.6/tests/quote-bind-issue.spec.mjs --l0 0.6/build/auto.quote.bind.issue.v2.l0.json
+# Monitors
+node scripts/monitor-expand.mjs 0.6/monitors/fasttrack-24h.l2.yaml 0.6/build/monitors.fasttrack-24h.l0.json
+node scripts/assert-kernel-only.mjs 0.6/build/monitors.fasttrack-24h.l0.json
+node 0.6/tests/monitors-fasttrack-24h.spec.mjs --l0 0.6/build/monitors.fasttrack-24h.l0.json
+# Diagrams
+node tools/tf-lang-cli/index.mjs graph 0.6/build/auto.fnol.fasttrack.v1.l0.json > diagrams/auto.fnol.fasttrack.v1.dot
+node tools/tf-lang-cli/index.mjs graph 0.6/build/auto.quote.bind.issue.v2.l0.json > diagrams/auto.quote.bind.issue.v2.dot
+node tools/tf-lang-cli/index.mjs graph 0.6/build/monitors.fasttrack-24h.l0.json > diagrams/monitors.fasttrack-24h.dot
+if command -v dot >/dev/null 2>&1; then
+  dot -Tsvg diagrams/auto.fnol.fasttrack.v1.dot -o diagrams/auto.fnol.fasttrack.v1.svg
+  dot -Tsvg diagrams/auto.quote.bind.issue.v2.dot -o diagrams/auto.quote.bind.issue.v2.svg
+  dot -Tsvg diagrams/monitors.fasttrack-24h.dot -o diagrams/monitors.fasttrack-24h.svg
+fi
+echo "All examples OK."

--- a/tasks/run-fnol.sh
+++ b/tasks/run-fnol.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+node scripts/pipeline-expand.mjs 0.6/pipelines/auto.fnol.fasttrack.v1.l2.yaml 0.6/build/auto.fnol.fasttrack.v1.l0.json
+node 0.6/tests/fnol-fasttrack.spec.mjs --l0 0.6/build/auto.fnol.fasttrack.v1.l0.json

--- a/tools/tf-lang-cli/lib/dot.mjs
+++ b/tools/tf-lang-cli/lib/dot.mjs
@@ -1,0 +1,160 @@
+function graphLabel(value) {
+  return String(value).replace(/"/g, '\\"');
+}
+
+function formatWhenClause(when) {
+  if (when == null) return null;
+  if (typeof when === 'string') return when;
+  if (typeof when === 'object') {
+    if (when.op === 'not' && typeof when.var === 'string') return `¬${when.var}`;
+    if (typeof when.var === 'string') {
+      return when.var.startsWith('@') ? when.var : `@${when.var}`;
+    }
+  }
+  return JSON.stringify(when);
+}
+
+function extractWhenVars(when) {
+  if (when == null) return [];
+  if (typeof when === 'string') {
+    const match = when.match(/^@([A-Za-z0-9_]+)/);
+    return match ? [match[1]] : [];
+  }
+  if (typeof when === 'object') {
+    if (typeof when.var === 'string') return [when.var.replace(/^@/, '')];
+    if (when.op === 'not' && typeof when.var === 'string') return [when.var.replace(/^@/, '')];
+  }
+  return [];
+}
+
+function formatNodeLabel(node) {
+  const parts = [node.id];
+  switch (node.kind) {
+    case 'Publish':
+      parts.push(`Publish: ${node.channel ?? ''}`);
+      break;
+    case 'Subscribe':
+      parts.push(`Subscribe: ${node.channel ?? ''}`);
+      break;
+    case 'Transform':
+      parts.push(`Transform: ${node.spec?.op ?? ''}`);
+      break;
+    case 'Keypair':
+      parts.push(`Keypair: ${node.algorithm ?? ''}`);
+      break;
+    default:
+      parts.push(node.kind ?? '');
+      break;
+  }
+  const whenText = formatWhenClause(node.when);
+  if (whenText) parts.push(`when: ${whenText}`);
+  return parts.filter(Boolean).join('\n');
+}
+
+function collectVarProducers(nodes) {
+  const map = new Map();
+  nodes.forEach((node, idx) => {
+    const outVar = node.out?.var;
+    if (typeof outVar === 'string') {
+      map.set(outVar, idx);
+    }
+  });
+  return map;
+}
+
+function collectRefs(value, acc) {
+  if (value == null) return;
+  if (typeof value === 'string') {
+    if (value.startsWith('@')) {
+      const match = value.slice(1).match(/^([A-Za-z0-9_]+)/);
+      if (match) acc.add(match[1]);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectRefs(item, acc));
+    return;
+  }
+  if (typeof value === 'object') {
+    Object.values(value).forEach((item) => collectRefs(item, acc));
+  }
+}
+
+function collectNodeRefs(node) {
+  const refs = new Set();
+  const skip = new Set(['id', 'kind', 'out', 'when', 'monitor_id', 'pipeline_id', 'description', 'created_at', 'effects']);
+  for (const [key, value] of Object.entries(node)) {
+    if (skip.has(key)) continue;
+    collectRefs(value, refs);
+  }
+  return refs;
+}
+
+function buildGraphElements(nodes, { prefix, indent, showWhenEdges }) {
+  const lines = [];
+  const edges = [];
+  const seen = new Set();
+  const producers = collectVarProducers(nodes);
+
+  nodes.forEach((node, idx) => {
+    const nodeName = `${prefix}${idx}`;
+    const label = graphLabel(formatNodeLabel(node));
+    lines.push(`${indent}${nodeName} [label="${label}"];`);
+    const refs = collectNodeRefs(node);
+    refs.forEach((ref) => {
+      const srcIdx = producers.get(ref);
+      if (srcIdx == null || srcIdx === idx) return;
+      const edge = `${indent}${prefix}${srcIdx} -> ${nodeName};`;
+      if (!seen.has(edge)) {
+        seen.add(edge);
+        edges.push(edge);
+      }
+    });
+    if (showWhenEdges) {
+      const guardVars = extractWhenVars(node.when);
+      guardVars.forEach((varName) => {
+        const srcIdx = producers.get(varName);
+        if (srcIdx == null || srcIdx === idx) return;
+        const edge = `${indent}${prefix}${srcIdx} -> ${nodeName} [style=dashed];`;
+        if (!seen.has(edge)) {
+          seen.add(edge);
+          edges.push(edge);
+        }
+      });
+    }
+  });
+
+  return { nodeLines: lines, edgeLines: edges };
+}
+
+export function renderPipelineGraph(doc, options = {}) {
+  const showWhenEdges = options.showWhenEdges !== false;
+  const nodes = Array.isArray(doc.nodes) ? doc.nodes : [];
+  const { nodeLines, edgeLines } = buildGraphElements(nodes, {
+    prefix: 'n',
+    indent: '  ',
+    showWhenEdges,
+  });
+  return ['digraph G {', '  rankdir=LR;', ...nodeLines, ...edgeLines, '}'].join('\n');
+}
+
+export function renderMonitorGraph(doc, options = {}) {
+  const showWhenEdges = options.showWhenEdges !== false;
+  const monitors = Array.isArray(doc.monitors) ? doc.monitors : [];
+  const lines = ['digraph G {', '  rankdir=LR;'];
+  monitors.forEach((monitor, monitorIdx) => {
+    const clusterName = `cluster_${monitorIdx}`;
+    lines.push(`  subgraph ${clusterName} {`);
+    lines.push(`    label="${graphLabel(monitor.monitor_id ?? `monitor_${monitorIdx}`)}";`);
+    const { nodeLines, edgeLines } = buildGraphElements(monitor.nodes ?? [], {
+      prefix: `m${monitorIdx}_n`,
+      indent: '    ',
+      showWhenEdges,
+    });
+    lines.push(...nodeLines);
+    lines.push(...edgeLines);
+    lines.push('  }');
+  });
+  lines.push('}');
+  return lines.join('\n');
+}

--- a/tools/tf-lang-cli/tests/dot.branching.test.mjs
+++ b/tools/tf-lang-cli/tests/dot.branching.test.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { renderPipelineGraph } from "../lib/dot.mjs";
+
+const doc = {
+  nodes: [
+    {
+      id: "T_branch_1",
+      kind: "Transform",
+      spec: { op: "eq" },
+      in: { left: "@input_value", right: "allow" },
+      out: { var: "branch_1_value" },
+    },
+    {
+      id: "P_then_path",
+      kind: "Publish",
+      channel: "metric:then",
+      qos: "at_least_once",
+      payload: { value: 1 },
+      when: "@branch_1_value",
+    },
+    {
+      id: "P_else_path",
+      kind: "Publish",
+      channel: "metric:else",
+      qos: "at_least_once",
+      payload: { value: 1 },
+      when: { op: "not", var: "branch_1_value" },
+    },
+  ],
+};
+
+const dot = renderPipelineGraph(doc);
+const lines = dot.split("\n");
+
+assert(dot.includes("P_then_path") && dot.includes("when: @branch_1_value"), "then branch label should include when guard");
+assert(dot.includes("P_else_path") && dot.includes("when: ¬branch_1_value"), "else branch label should include negated guard");
+
+const guardEdges = lines.filter((line) => line.includes("[style=dashed]"));
+assert.strictEqual(guardEdges.length, 2, "expected dashed guard edges for both branches");
+assert(guardEdges.every((line) => line.includes("n0 ->")), "guard edges should originate from the condition var producer");
+
+const dotNoGuards = renderPipelineGraph(doc, { showWhenEdges: false });
+assert(!dotNoGuards.includes("[style=dashed]"), "suppressed guard edges should not render dashed edges");
+assert(dotNoGuards.includes("when: @branch_1_value") && dotNoGuards.includes("when: ¬branch_1_value"), "labels should retain when annotations when guard edges hidden");
+
+console.log("dot.branching.test.mjs OK");


### PR DESCRIPTION
## Summary
- normalize transform reference aliases in the pipeline expander so the quote→bind→issue L0 emits consistent *_value variables
- strengthen the quote→bind→issue test with RPC publish/subscribe pairing and add a reusable kernel-only guard wired into the examples runner with optional SVG rendering
- note the SVG diagram outputs in the pipeline and monitor docs for easier browsing

## Testing
- bash tasks/run-examples.sh

------
https://chatgpt.com/codex/tasks/task_e_68dbf56e706c832095f2614fd554f019