### PR TITLE
Add policy enforcement macro and tighten RPC transforms

### DIFF
--- a/docs/0.6/index.md
+++ b/docs/0.6/index.md
@@ -14,4 +14,11 @@
 
 ---
 
+## Macro laws
+
+- `state.merge@crdt.gcounter` – associative, commutative, idempotent merge of grow-only counters.
+- `process.retry` – retry-safe when the wrapped RPC produces a stable `corr` (idempotent-by-corr).
+
+---
+
 [Back to top](#tf-lang-v06-specification)

--- a/packages/expander/catalog/policy.enforce.json
+++ b/packages/expander/catalog/policy.enforce.json
@@ -1,0 +1,17 @@
+{
+  "macro": "policy.enforce",
+  "domain": "policy",
+  "summary": "Evaluate a policy deterministically and audit the decision via policy:enforce.",
+  "expansion": {
+    "pattern": "transform+publish",
+    "nodes": ["Transform(policy_eval)", "Publish"],
+    "publish": {
+      "channel": "policy:enforce",
+      "payload": ["decision", "inputs"],
+      "effects": ["Pure", "Outbound"]
+    }
+  },
+  "notes": [
+    "policy_eval is a deterministic stub (no IO); publish emits decision + original inputs for audit."
+  ]
+}

--- a/packages/expander/catalog/process.await.all.json
+++ b/packages/expander/catalog/process.await.all.json
@@ -1,0 +1,13 @@
+{
+  "macro": "process.await.all",
+  "domain": "process",
+  "summary": "Wait for all reply_to channels and aggregate their messages in order.",
+  "expansion": {
+    "pattern": "pure+subscribe",
+    "nodes": ["Subscribe*", "Transform(await.all)"]
+  },
+  "laws": [],
+  "notes": [
+    "Deterministic aggregation; transform returns array aligned with source ordering."
+  ]
+}

--- a/packages/expander/catalog/process.await.any.json
+++ b/packages/expander/catalog/process.await.any.json
@@ -1,0 +1,14 @@
+{
+  "macro": "process.await.any",
+  "domain": "process",
+  "summary": "Fan-in multiple reply_to channels and pick the first delivered message deterministically.",
+  "expansion": {
+    "pattern": "pure+subscribe",
+    "nodes": ["Subscribe*", "Transform(await.any)"]
+  },
+  "laws": [],
+  "notes": [
+    "Subscriptions listen on provided reply_to channels optionally filtered by corr.",
+    "await.any transform chooses the first non-null event in declaration order (deterministic)."
+  ]
+}

--- a/packages/expander/catalog/process.retry.json
+++ b/packages/expander/catalog/process.retry.json
@@ -1,0 +1,27 @@
+{
+  "macro": "process.retry",
+  "domain": "process",
+  "summary": "Wrap an RPC call with retry planning via rpc:req:retry/plan using deterministic retry_key.",
+  "expansion": {
+    "pattern": "rpc",
+    "request_channel": "rpc:req:retry/plan",
+    "reply_pattern": "corr/reply_to",
+    "nodes": ["Keypair", "Transform(hash retry_key)", "Transform(hash corr)", "Transform(concat)", "Publish", "Subscribe"],
+    "payload": {
+      "body": {
+        "fields": ["retry_key", "policy", "target_corr"]
+      }
+    }
+  },
+  "laws": [
+    {
+      "kind": "idempotent",
+      "description": "Retry planner is safe when wrapped RPC corr is stable; prover checks corr ancestry."
+    }
+  ],
+  "notes": [
+    "retry_key := hash(blake3, target corr + policy) so duplicate planning converges.",
+    "Publish/Subscribe remain kernel-only; actual retry executor lives downstream.",
+    "corr/reply_to handshake stays canonical; planner response is filtered by corr."
+  ]
+}

--- a/packages/expander/catalog/process.saga.json
+++ b/packages/expander/catalog/process.saga.json
@@ -1,0 +1,15 @@
+{
+  "macro": "process.saga",
+  "domain": "process",
+  "summary": "Plan saga steps/compensations as a pure transform.",
+  "expansion": {
+    "pattern": "pure-transform",
+    "transform": "process.saga.plan",
+    "inputs": ["steps", "compensations"],
+    "output": "{saga_id, steps, compensations}"
+  },
+  "laws": [],
+  "notes": [
+    "saga_id computed via blake3 hash of canonical step lists; no external IO."
+  ]
+}

--- a/packages/expander/catalog/process.timeout.json
+++ b/packages/expander/catalog/process.timeout.json
@@ -1,0 +1,23 @@
+{
+  "macro": "process.timeout",
+  "domain": "process",
+  "summary": "Schedule a timeout trigger via rpc:req:scheduler.request using corr/reply_to envelope.",
+  "expansion": {
+    "pattern": "rpc",
+    "request_channel": "rpc:req:scheduler.request",
+    "reply_pattern": "corr/reply_to",
+    "payload": {
+      "body": "trigger = {kind: timeout, ms, reply_to}"
+    },
+    "nodes": ["Keypair", "Transform(hash blake3)", "Transform(concat)", "Publish", "Subscribe"]
+  },
+  "laws": [
+    {
+      "kind": "idempotent",
+      "description": "Stable corr derived from canonical hash proves retry-safe scheduling."
+    }
+  ],
+  "notes": [
+    "Deterministic trigger planning only; scheduling handshake stays within kernel primitives."
+  ]
+}

--- a/packages/expander/catalog/state.diff.json
+++ b/packages/expander/catalog/state.diff.json
@@ -1,0 +1,15 @@
+{
+  "macro": "state.diff",
+  "domain": "state",
+  "summary": "Pure transform that computes {added, removed, changed} between two state objects.",
+  "expansion": {
+    "pattern": "pure-transform",
+    "transform": "state_diff",
+    "inputs": ["base|left", "target|right"],
+    "output": "diff object"
+  },
+  "laws": [],
+  "notes": [
+    "No IO performed; arrays/scalars treated as atomic leaves with fallback change entry."
+  ]
+}

--- a/packages/expander/catalog/state.merge.json
+++ b/packages/expander/catalog/state.merge.json
@@ -1,0 +1,25 @@
+{
+  "macro": "state.merge",
+  "domain": "state",
+  "summary": "Merge patches into base state using either jsonpatch or CRDT g-counter semantics.",
+  "strategies": {
+    "jsonpatch": {
+      "transform": "jsonpatch.apply",
+      "laws": [],
+      "notes": [
+        "Order-sensitive patch application over plain objects only; no algebraic guarantees."
+      ]
+    },
+    "crdt.gcounter": {
+      "transform": "crdt.gcounter.merge",
+      "laws": [
+        { "kind": "associative" },
+        { "kind": "commutative" },
+        { "kind": "idempotent" }
+      ],
+      "notes": [
+        "Element-wise max merge for grow-only counters; total derived from component maxima."
+      ]
+    }
+  }
+}

--- a/packages/expander/catalog/state.snapshot.json
+++ b/packages/expander/catalog/state.snapshot.json
@@ -1,0 +1,22 @@
+{
+  "macro": "state.snapshot",
+  "domain": "state",
+  "summary": "Fetch a canonical state snapshot via RPC using corr/reply_to flow.",
+  "expansion": {
+    "pattern": "rpc",
+    "request_channel": "rpc:req:state/snapshot",
+    "reply_pattern": "corr/reply_to",
+    "nodes": ["Keypair", "Transform(hash blake3)", "Transform(concat)", "Publish", "Subscribe"]
+  },
+  "laws": [
+    {
+      "kind": "idempotent",
+      "by": "stable corr hash",
+      "description": "Stable corr hashed from canonical request makes retries idempotent."
+    }
+  ],
+  "notes": [
+    "Expander materializes an Ed25519 keypair for signing the canonical request body.",
+    "corr is derived from hash(blake3) of {k,e,m,body}; reply_to is rpc:reply:<corr>."
+  ]
+}

--- a/packages/expander/catalog/state.version.json
+++ b/packages/expander/catalog/state.version.json
@@ -1,0 +1,22 @@
+{
+  "macro": "state.version",
+  "domain": "state",
+  "summary": "Submit a changeset for versioning an entity via the state/version RPC endpoint.",
+  "expansion": {
+    "pattern": "rpc",
+    "request_channel": "rpc:req:state/version",
+    "reply_pattern": "corr/reply_to",
+    "payload": "POST body {entity_id, changeset}",
+    "nodes": ["Keypair", "Transform(hash blake3)", "Transform(concat)", "Publish", "Subscribe"]
+  },
+  "laws": [
+    {
+      "kind": "idempotent",
+      "by": "stable corr hash",
+      "description": "Hash(blake3) of the canonical request stabilizes corr for retries."
+    }
+  ],
+  "notes": [
+    "changeset payload is passed through unchanged; macro emits kernel-only graph."
+  ]
+}

--- a/packages/expander/tests/policy.enforce.test.mjs
+++ b/packages/expander/tests/policy.enforce.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { expandPipelineFromYaml } from '../../expander/expand.mjs';
+
+const l2 = `
+pipeline: "unit.policy"
+steps:
+  - enforce: policy.enforce(policy: { name: "fraud-check" }, input: { actor: "acct:1", amount: 250 })
+`;
+
+const dag = expandPipelineFromYaml(l2);
+
+const kernelKinds = new Set(['Keypair', 'Transform', 'Publish', 'Subscribe']);
+assert.equal(dag.nodes.every((node) => kernelKinds.has(node.kind)), true, 'only kernel nodes expected');
+
+const byId = Object.fromEntries(dag.nodes.map((node) => [node.id, node]));
+
+const evalNode = byId.T_enforce;
+assert.equal(evalNode?.spec?.op, 'policy_eval');
+assert.equal(evalNode?.out?.var, 'enf_enforce');
+
+const publishNode = byId.P_enforce;
+assert.equal(publishNode?.channel, 'policy:enforce');
+assert.equal(publishNode?.payload?.decision, '@enf_enforce');
+assert.deepEqual(publishNode?.payload?.inputs, { actor: 'acct:1', amount: 250 });
+
+console.log('policy.enforce macro expansion OK');

--- a/packages/expander/tests/process.macros.test.mjs
+++ b/packages/expander/tests/process.macros.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { expandPipelineFromYaml } from '../../expander/expand.mjs';
+
+const l2 = `
+pipeline: "unit.process"
+steps:
+  - req: interaction.request(endpoint: "api/payments/payout", method: "POST", body: { claim: "X", amount: 100 })
+  - plan: process.retry(req: "@req", policy: { max_attempts: 3 })
+  - any: process.await.any(sources: [
+        { channel: "@req.reply_to", filter: "@req.corr" },
+        { channel: "@plan.reply_to", filter: "@plan.corr" }
+      ])
+  - all: process.await.all(sources: [
+        { channel: "@req.reply_to", filter: "@req.corr" },
+        { channel: "@plan.reply_to", filter: "@plan.corr" }
+      ])
+  - wait: process.timeout(ms: 5000, reply_to: "@req.reply_to")
+  - saga: process.saga(steps: ["reserve", "charge"], compensations: ["cancel", "refund"])
+`;
+
+const dag = expandPipelineFromYaml(l2);
+
+const byId = Object.fromEntries(dag.nodes.map((node) => [node.id, node]));
+
+const retryKey = byId.T_plan_retry_key;
+assert.equal(retryKey?.spec?.op, 'hash');
+assert.equal(retryKey?.in?.target_corr, '@req.corr');
+
+const planPublish = byId.P_plan;
+assert.equal(planPublish?.channel, 'rpc:req:retry/plan');
+assert.equal(planPublish?.payload?.body?.policy?.max_attempts, 3);
+assert.equal(planPublish?.payload?.body?.retry_key, `@${retryKey.out.var}`);
+assert.equal(planPublish?.payload?.body?.target_corr, '@req.corr');
+
+const planSubscribe = byId.S_plan;
+assert.equal(planSubscribe?.channel, `@${byId.T_plan_reply_to.out.var}`);
+assert.equal(planSubscribe?.filter, `@${byId.T_plan_corr.out.var}`);
+
+const anyTransform = byId.T_any;
+assert.equal(anyTransform?.spec?.op, 'await.any');
+assert.deepEqual(anyTransform?.in?.events, ['@any_0', '@any_1']);
+const anySubs = [byId.S_any_0, byId.S_any_1];
+assert.equal(anySubs.length, 2);
+assert.equal(anySubs[0]?.channel, '@req.reply_to');
+assert.equal(anySubs[1]?.channel, '@plan.reply_to');
+
+const allTransform = byId.T_all;
+assert.equal(allTransform?.spec?.op, 'await.all');
+assert.deepEqual(allTransform?.in?.events, ['@all_0', '@all_1']);
+
+const timeoutPublish = byId.P_wait;
+assert.equal(timeoutPublish?.channel, 'rpc:req:scheduler.request');
+assert.deepEqual(timeoutPublish?.payload?.body, {
+  trigger: { kind: 'timeout', ms: 5000, reply_to: '@req.reply_to' },
+});
+
+const sagaTransform = byId.T_saga;
+assert.equal(sagaTransform?.spec?.op, 'process.saga.plan');
+assert.deepEqual(sagaTransform?.in, {
+  steps: ['reserve', 'charge'],
+  compensations: ['cancel', 'refund'],
+});
+
+console.log('process macros expansion OK');

--- a/packages/expander/tests/state.macros.test.mjs
+++ b/packages/expander/tests/state.macros.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { expandPipelineFromYaml } from '../../expander/expand.mjs';
+
+const l2 = `
+pipeline: "unit.state"
+steps:
+  - snap: state.snapshot(entity_id: "acct:123")
+  - ver: state.version(entity_id: "acct:123", changeset: { balance: 200, version: 2 })
+  - delta: state.diff(left: { balance: 100 }, right: { balance: 120, status: "open" })
+  - merge_patch: state.merge(base: { balance: 100 }, patch: [
+        { op: "replace", path: "/balance", value: 120 },
+        { op: "add", path: "/status", value: "open" }
+      ], strategy: "jsonpatch")
+  - merge_counter: state.merge(base: { a: 1, b: 4 }, patch: { a: 5, c: 2 }, strategy: "crdt.gcounter")
+`;
+
+const dag = expandPipelineFromYaml(l2);
+
+const kernelKinds = new Set(['Keypair', 'Transform', 'Publish', 'Subscribe']);
+assert.equal(dag.nodes.every((node) => kernelKinds.has(node.kind)), true, 'only kernel nodes expected');
+
+const byId = Object.fromEntries(dag.nodes.map((node) => [node.id, node]));
+
+const snapPub = byId.P_snap;
+assert.equal(snapPub?.channel, 'rpc:req:state/snapshot');
+assert.deepEqual(snapPub?.payload?.body, { entity_id: 'acct:123' });
+assert.equal(snapPub?.payload?.corr, `@${byId.T_snap_corr.out.var}`);
+assert.equal(snapPub?.payload?.reply_to, `@${byId.T_snap_reply_to.out.var}`);
+const snapSub = byId.S_snap;
+assert.equal(snapSub?.channel, `@${byId.T_snap_reply_to.out.var}`);
+assert.equal(snapSub?.filter, `@${byId.T_snap_corr.out.var}`);
+
+const verPub = byId.P_ver;
+assert.equal(verPub?.channel, 'rpc:req:state/version');
+assert.deepEqual(verPub?.payload?.body, { entity_id: 'acct:123', changeset: { balance: 200, version: 2 } });
+
+const diffNode = byId.T_delta;
+assert.equal(diffNode?.spec?.op, 'state_diff');
+assert.deepEqual(diffNode?.in, { base: { balance: 100 }, target: { balance: 120, status: 'open' } });
+
+const mergePatch = byId.T_merge_patch;
+assert.equal(mergePatch?.spec?.op, 'jsonpatch.apply');
+assert.ok(Array.isArray(mergePatch?.notes), 'jsonpatch merge notes should be present');
+
+const mergeCounter = byId.T_merge_counter;
+assert.equal(mergeCounter?.spec?.op, 'crdt.gcounter.merge');
+assert.ok(Array.isArray(mergeCounter?.laws), 'crdt merge should advertise laws');
+assert.deepEqual(
+  mergeCounter.laws.map((law) => law.kind).sort(),
+  ['associative', 'commutative', 'idempotent']
+);
+
+console.log('state macros expansion OK');

--- a/packages/runtime/run.mjs
+++ b/packages/runtime/run.mjs
@@ -13,6 +13,19 @@ export const DETERMINISTIC_TRANSFORMS = new Set([
   'encode_base58',
   'model_infer',
   'policy_eval',
+  'state_diff',
+  'jsonpatch.apply',
+  'crdt.gcounter.merge',
+  'await.any',
+  'await.all',
+  'time.parseTimestamp',
+  'time.align',
+  'time.windowKey',
+  'auth.sign',
+  'auth.verify',
+  'auth.mint_token',
+  'auth.check_token',
+  'process.saga.plan',
 ]);
 
 export function stableStringify(value) {
@@ -26,6 +39,188 @@ export function stableStringify(value) {
     .sort()
     .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
   return `{${entries.join(',')}}`;
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return false;
+  if (value instanceof Uint8Array) return false;
+  if (Buffer.isBuffer(value)) return false;
+  return true;
+}
+
+function stateDiff(base, target) {
+  const result = { added: {}, removed: {}, changed: {} };
+  if (!isPlainObject(base) || !isPlainObject(target)) {
+    // Non-object inputs are treated as leaf states; differences surface as a root "" change entry.
+    if (stableStringify(base) !== stableStringify(target)) {
+      result.changed[''] = { from: base, to: target };
+    }
+    return result;
+  }
+  for (const key of Object.keys(target)) {
+    if (!(key in base)) {
+      result.added[key] = deepClone(target[key]);
+    }
+  }
+  for (const key of Object.keys(base)) {
+    if (!(key in target)) {
+      result.removed[key] = deepClone(base[key]);
+    }
+  }
+  for (const key of Object.keys(target)) {
+    if (!(key in base)) continue;
+    const left = base[key];
+    const right = target[key];
+    if (isPlainObject(left) && isPlainObject(right)) {
+      const nested = stateDiff(left, right);
+      if (
+        Object.keys(nested.added).length
+        || Object.keys(nested.removed).length
+        || Object.keys(nested.changed).length
+      ) {
+        result.changed[key] = nested;
+      }
+      continue;
+    }
+    if (stableStringify(left) !== stableStringify(right)) {
+      result.changed[key] = { from: deepClone(left), to: deepClone(right) };
+    }
+  }
+  return result;
+}
+
+function decodePointerSegment(segment) {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function applyJsonPatch(base = {}, operations = []) {
+  if (!isPlainObject(base)) {
+    throw new Error('jsonpatch.apply: base document must be a plain object');
+  }
+  if (!Array.isArray(operations)) {
+    throw new Error('jsonpatch.apply: patch must be an array');
+  }
+  let result = deepClone(base);
+  const ensureContainer = (value, path) => {
+    if (!isPlainObject(value)) {
+      throw new Error(`jsonpatch.apply: path ${path} does not reference an object`);
+    }
+    return value;
+  };
+  operations.forEach((operation, index) => {
+    if (!operation || typeof operation !== 'object') {
+      throw new Error(`jsonpatch.apply: operation at index ${index} must be an object`);
+    }
+    const type = operation.op;
+    if (!['add', 'replace', 'remove'].includes(type)) {
+      throw new Error(`jsonpatch.apply: unsupported op "${type}" at index ${index}`);
+    }
+    const path = typeof operation.path === 'string' ? operation.path : '';
+    const segments = path === ''
+      ? []
+      : path
+        .split('/')
+        .slice(1)
+        .map((segment) => decodePointerSegment(segment));
+    if (segments.length === 0) {
+      throw new Error('jsonpatch.apply: root operations are not supported');
+    }
+    let cursor = result;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const key = segments[i];
+      if (!Object.prototype.hasOwnProperty.call(cursor, key) || cursor[key] === undefined) {
+        if (type === 'add') {
+          cursor[key] = {};
+        } else {
+          throw new Error(`jsonpatch.apply: missing path segment "${key}" at index ${index}`);
+        }
+      }
+      cursor[key] = ensureContainer(cursor[key], path);
+      cursor = cursor[key];
+    }
+    const leaf = segments[segments.length - 1];
+    cursor = ensureContainer(cursor, path);
+    if (type === 'remove') {
+      delete cursor[leaf];
+      return;
+    }
+    cursor[leaf] = deepClone(operation.value);
+  });
+  return result;
+}
+
+function mergeGCounter(base = {}, patch = {}) {
+  const counts = {};
+  const keys = new Set([...Object.keys(base || {}), ...Object.keys(patch || {})]);
+  for (const key of keys) {
+    const left = Number(base?.[key] ?? 0);
+    const right = Number(patch?.[key] ?? 0);
+    counts[key] = Math.max(left, right);
+  }
+  const total = Object.values(counts).reduce((sum, value) => sum + Number(value ?? 0), 0);
+  return { counts, total };
+}
+
+const UNIT_MS = {
+  millisecond: 1,
+  second: 1000,
+  minute: 60 * 1000,
+  hour: 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+};
+
+function parseTimestampInput(value) {
+  if (value === undefined || value === null) {
+    throw new Error('time.parseTimestamp: value is required');
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      throw new Error(`time.parseTimestamp: unable to parse "${value}"`);
+    }
+    return parsed;
+  }
+  throw new Error(`time.parseTimestamp: unsupported value type ${typeof value}`);
+}
+
+function resolveIntervalMs(spec = {}) {
+  if (spec.interval_ms !== undefined) {
+    const value = Number(spec.interval_ms);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error('time.align: interval_ms must be a positive number');
+    }
+    return value;
+  }
+  const unit = spec.unit || spec.granularity || 'minute';
+  const base = UNIT_MS[unit];
+  if (!base) {
+    throw new Error(`time.align: unsupported unit "${unit}"`);
+  }
+  const step = spec.step !== undefined ? Number(spec.step) : 1;
+  if (!Number.isFinite(step) || step <= 0) {
+    throw new Error('time.align: step must be a positive number');
+  }
+  return base * step;
+}
+
+function alignTimestamp(epochMs, intervalMs) {
+  return Math.floor(epochMs / intervalMs) * intervalMs;
+}
+
+function formatIso(epochMs) {
+  return new Date(epochMs).toISOString();
+}
+
+function computeSagaId(steps = [], compensations = []) {
+  const serialized = stableStringify({ steps, compensations });
+  return hashPayload(serialized, { alg: 'blake3' });
 }
 
 function toBuffer(value) {
@@ -225,6 +420,79 @@ function evaluateTransform(node, context) {
         reason: 'stub-allow',
         input,
       };
+    case 'state_diff':
+      return stateDiff(input.base ?? {}, input.target ?? {});
+    case 'jsonpatch.apply':
+      return applyJsonPatch(input.base ?? {}, input.patch ?? input.operations ?? []);
+    case 'crdt.gcounter.merge':
+      return mergeGCounter(input.base ?? {}, input.patch ?? {});
+    case 'await.any': {
+      const events = Array.isArray(input.events) ? input.events : [];
+      for (let i = 0; i < events.length; i += 1) {
+        const event = events[i];
+        if (event !== undefined && event !== null) {
+          return { index: i, event };
+        }
+      }
+      return { index: -1, event: null };
+    }
+    case 'await.all':
+      return (Array.isArray(input.events) ? input.events : []).map((event) => (event === undefined ? null : event));
+    case 'time.parseTimestamp': {
+      const epochMs = parseTimestampInput(input.value ?? input.timestamp ?? input.time);
+      return { epoch_ms: epochMs, iso: formatIso(epochMs) };
+    }
+    case 'time.align': {
+      const epochMs = parseTimestampInput(input.value ?? input.timestamp ?? input.time);
+      const intervalMs = resolveIntervalMs(spec);
+      const aligned = alignTimestamp(epochMs, intervalMs);
+      return { epoch_ms: aligned, iso: formatIso(aligned), interval_ms: intervalMs };
+    }
+    case 'time.windowKey': {
+      const epochMs = parseTimestampInput(input.value ?? input.timestamp ?? input.time);
+      const intervalMs = resolveIntervalMs(spec);
+      const start = alignTimestamp(epochMs, intervalMs);
+      const end = start + intervalMs;
+      return {
+        start_ms: start,
+        end_ms: end,
+        key: `${formatIso(start)}/${formatIso(end)}`,
+        interval_ms: intervalMs,
+      };
+    }
+    case 'auth.sign': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ key: input.key, payload: input.payload, alg });
+      return { signature: hashPayload(payload, { alg }), alg };
+    }
+    case 'auth.verify': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ key: input.key, payload: input.payload, alg });
+      const expected = hashPayload(payload, { alg });
+      const provided = String(input.signature ?? '');
+      return { valid: expected === provided, expected, provided, alg };
+    }
+    case 'auth.mint_token': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ secret: input.secret, claims: input.claims, alg });
+      const digest = hashPayload(payload, { alg });
+      const token = `tok_${encodeBase58(digest)}`;
+      return { token, claims: deepClone(input.claims ?? {}), alg };
+    }
+    case 'auth.check_token': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ secret: input.secret, claims: input.claims, alg });
+      const digest = hashPayload(payload, { alg });
+      const expected = `tok_${encodeBase58(digest)}`;
+      const provided = String(input.token ?? '');
+      return { valid: expected === provided, expected, provided, alg };
+    }
+    case 'process.saga.plan': {
+      const steps = Array.isArray(input.steps) ? deepClone(input.steps) : [];
+      const compensations = Array.isArray(input.compensations) ? deepClone(input.compensations) : [];
+      const sagaId = computeSagaId(steps, compensations);
+      return { saga_id: sagaId, steps, compensations };
+    }
     default:
       throw new Error(`unsupported transform op: ${op}`);
   }

--- a/packages/transform/index.mjs
+++ b/packages/transform/index.mjs
@@ -43,7 +43,7 @@ function stateDiff(base, target) {
   };
 
   if (!isPlainObject(base) || !isPlainObject(target)) {
-    // Arrays/scalars are treated as leaf states; when different, the root "" key captures the change.
+    // Non-object inputs are treated as leaf states; differences surface as a root "" change entry.
     const equal = stableStringify(base) === stableStringify(target);
     if (!equal) {
       result.changed[''] = { from: base, to: target };
@@ -80,6 +80,162 @@ function stateDiff(base, target) {
   }
 
   return result;
+}
+
+function cloneValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneValue(item));
+  }
+  if (isPlainObject(value)) {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = cloneValue(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+function decodePointerSegment(segment) {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function applyJsonPatch(base = {}, operations = []) {
+  if (!isPlainObject(base)) {
+    throw new Error('jsonpatch.apply: base document must be a plain object');
+  }
+  if (!Array.isArray(operations)) {
+    throw new Error('jsonpatch.apply: patch must be an array of operations');
+  }
+
+  let result = cloneValue(base);
+
+  const ensureContainer = (container, path) => {
+    if (!isPlainObject(container)) {
+      throw new Error(`jsonpatch.apply: path ${path} does not reference an object`);
+    }
+    return container;
+  };
+
+  operations.forEach((operation, index) => {
+    if (!operation || typeof operation !== 'object') {
+      throw new Error(`jsonpatch.apply: operation at index ${index} must be an object`);
+    }
+    const type = operation.op;
+    if (!['add', 'replace', 'remove'].includes(type)) {
+      throw new Error(`jsonpatch.apply: unsupported op "${type}" at index ${index}`);
+    }
+    const path = typeof operation.path === 'string' ? operation.path : '';
+    const segments = path === ''
+      ? []
+      : path
+        .split('/')
+        .slice(1)
+        .map((segment) => decodePointerSegment(segment));
+
+    if (segments.length === 0) {
+      throw new Error('jsonpatch.apply: root operations are not supported');
+    }
+
+    let cursor = result;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const key = segments[i];
+      if (!Object.prototype.hasOwnProperty.call(cursor, key) || cursor[key] === undefined) {
+        if (type === 'add') {
+          cursor[key] = {};
+        } else {
+          throw new Error(`jsonpatch.apply: missing path segment "${key}" for op at index ${index}`);
+        }
+      }
+      cursor[key] = ensureContainer(cursor[key], path);
+      cursor = cursor[key];
+    }
+
+    const leaf = segments[segments.length - 1];
+    cursor = ensureContainer(cursor, path);
+
+    if (type === 'remove') {
+      delete cursor[leaf];
+      return;
+    }
+
+    cursor[leaf] = cloneValue(operation.value);
+  });
+
+  return result;
+}
+
+function mergeGCounter(base = {}, patch = {}) {
+  const result = {};
+  const keys = new Set([...Object.keys(base || {}), ...Object.keys(patch || {})]);
+  for (const key of keys) {
+    const left = Number(base?.[key] ?? 0);
+    const right = Number(patch?.[key] ?? 0);
+    result[key] = Math.max(left, right);
+  }
+  const total = Object.values(result).reduce((sum, value) => sum + Number(value ?? 0), 0);
+  return { counts: result, total };
+}
+
+function parseTimestampInput(value) {
+  if (value === undefined || value === null) {
+    throw new Error('time.parseTimestamp: value is required');
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      throw new Error(`time.parseTimestamp: unable to parse "${value}"`);
+    }
+    return parsed;
+  }
+  throw new Error(`time.parseTimestamp: unsupported value type ${typeof value}`);
+}
+
+const UNIT_MS = {
+  millisecond: 1,
+  second: 1000,
+  minute: 60 * 1000,
+  hour: 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+};
+
+function resolveIntervalMs(spec = {}) {
+  if (spec.interval_ms !== undefined) {
+    const value = Number(spec.interval_ms);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error('time.align: interval_ms must be a positive number');
+    }
+    return value;
+  }
+  const unit = spec.unit || spec.granularity || 'minute';
+  const base = UNIT_MS[unit];
+  if (!base) {
+    throw new Error(`time.align: unsupported unit "${unit}"`);
+  }
+  const step = spec.step !== undefined ? Number(spec.step) : 1;
+  if (!Number.isFinite(step) || step <= 0) {
+    throw new Error('time.align: step must be a positive number');
+  }
+  return base * step;
+}
+
+function alignTimestamp(timestampMs, intervalMs) {
+  return Math.floor(timestampMs / intervalMs) * intervalMs;
+}
+
+function formatIso(epochMs) {
+  return new Date(epochMs).toISOString();
+}
+
+function computeSagaId(steps = [], compensations = []) {
+  const payload = stableStringify({ steps, compensations });
+  return hashBlake3(payload);
 }
 
 export function runTransform(spec, input = {}) {
@@ -158,6 +314,87 @@ export function runTransform(spec, input = {}) {
       const base = input.base ?? {};
       const target = input.target ?? {};
       return stateDiff(base, target);
+    }
+    case 'jsonpatch.apply': {
+      // Minimal JSON Patch implementation (objects only, add/replace/remove).
+      const base = input.base ?? {};
+      const patch = input.patch ?? input.operations ?? [];
+      return applyJsonPatch(base, patch);
+    }
+    case 'crdt.gcounter.merge': {
+      const base = input.base ?? {};
+      const patch = input.patch ?? {};
+      return mergeGCounter(base, patch);
+    }
+    case 'await.any': {
+      const events = Array.isArray(input.events) ? input.events : [];
+      for (let i = 0; i < events.length; i += 1) {
+        const event = events[i];
+        if (event !== undefined && event !== null) {
+          return { index: i, event };
+        }
+      }
+      return { index: -1, event: null };
+    }
+    case 'await.all': {
+      const events = Array.isArray(input.events) ? input.events : [];
+      return events.map((event) => (event === undefined ? null : event));
+    }
+    case 'time.parseTimestamp': {
+      const epochMs = parseTimestampInput(input.value ?? input.timestamp ?? input.time);
+      return { epoch_ms: epochMs, iso: formatIso(epochMs) };
+    }
+    case 'time.align': {
+      const epochMs = parseTimestampInput(input.value ?? input.timestamp ?? input.time);
+      const intervalMs = resolveIntervalMs(spec);
+      const aligned = alignTimestamp(epochMs, intervalMs);
+      return { epoch_ms: aligned, iso: formatIso(aligned), interval_ms: intervalMs };
+    }
+    case 'time.windowKey': {
+      const epochMs = parseTimestampInput(input.value ?? input.timestamp ?? input.time);
+      const intervalMs = resolveIntervalMs(spec);
+      const start = alignTimestamp(epochMs, intervalMs);
+      const end = start + intervalMs;
+      return {
+        start_ms: start,
+        end_ms: end,
+        key: `${formatIso(start)}/${formatIso(end)}`,
+        interval_ms: intervalMs,
+      };
+    }
+    case 'auth.sign': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ key: input.key, payload: input.payload, alg });
+      const signature = hashBlake3(payload);
+      return { signature, alg };
+    }
+    case 'auth.verify': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ key: input.key, payload: input.payload, alg });
+      const expected = hashBlake3(payload);
+      const provided = String(input.signature ?? '');
+      return { valid: expected === provided, alg, expected, provided };
+    }
+    case 'auth.mint_token': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ secret: input.secret, claims: input.claims, alg });
+      const digest = digestBlake3(payload);
+      const token = `tok_${encodeBase58(digest)}`;
+      return { token, claims: cloneValue(input.claims ?? {}), alg };
+    }
+    case 'auth.check_token': {
+      const alg = spec.alg ?? 'blake3';
+      const payload = stableStringify({ secret: input.secret, claims: input.claims, alg });
+      const digest = digestBlake3(payload);
+      const expected = `tok_${encodeBase58(digest)}`;
+      const provided = String(input.token ?? '');
+      return { valid: expected === provided, alg, expected, provided };
+    }
+    case 'process.saga.plan': {
+      const steps = Array.isArray(input.steps) ? cloneValue(input.steps) : [];
+      const compensations = Array.isArray(input.compensations) ? cloneValue(input.compensations) : [];
+      const sagaId = computeSagaId(steps, compensations);
+      return { saga_id: sagaId, steps, compensations };
     }
     default:
       throw new Error(`Unsupported transform op: ${op}`);

--- a/packages/transform/tests/auth.test.mjs
+++ b/packages/transform/tests/auth.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { runTransform } from '../index.mjs';
+
+const payload = { amount: 250, currency: 'USD' };
+const key = 'agent-secret';
+
+const signature = runTransform({ op: 'auth.sign' }, { key, payload });
+assert.match(signature.signature, /^[0-9a-f]+$/);
+
+const verify = runTransform({ op: 'auth.verify' }, { key, payload, signature: signature.signature });
+assert.equal(verify.valid, true);
+
+const claims = { sub: 'acct:123', scope: ['payments:write'] };
+const token = runTransform({ op: 'auth.mint_token' }, { secret: 'shared-secret', claims });
+assert.ok(token.token.startsWith('tok_'));
+
+const check = runTransform({ op: 'auth.check_token' }, { secret: 'shared-secret', claims, token: token.token });
+assert.equal(check.valid, true);
+
+console.log('auth transforms OK');

--- a/packages/transform/tests/jsonpatch.test.mjs
+++ b/packages/transform/tests/jsonpatch.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { runTransform } from '../index.mjs';
+
+const base = { balance: 100 };
+const patch = [
+  { op: 'add', path: '/temp', value: 'stage' },
+  { op: 'replace', path: '/balance', value: 120 },
+  { op: 'remove', path: '/temp' }
+];
+
+const result = runTransform({ op: 'jsonpatch.apply' }, { base, patch });
+assert.deepEqual(result, { balance: 120 });
+assert.deepEqual(base, { balance: 100 }, 'base should remain unchanged');
+
+const reversed = runTransform({ op: 'jsonpatch.apply' }, { base, patch: [...patch].reverse() });
+assert.deepEqual(reversed, { balance: 120, temp: 'stage' });
+assert.notDeepEqual(result, reversed, 'patch application order must matter for jsonpatch');
+
+assert.throws(
+  () => runTransform({ op: 'jsonpatch.apply' }, { base, patch: [{ op: 'replace', path: '', value: {} }] }),
+  /root operations are not supported/,
+  'root replacements must be rejected',
+);
+
+assert.throws(
+  () => runTransform({ op: 'jsonpatch.apply' }, { base: { list: [] }, patch: [{ op: 'add', path: '/list/0', value: 1 }] }),
+  /does not reference an object/,
+  'array segments are not supported',
+);
+
+assert.throws(
+  () => runTransform({ op: 'jsonpatch.apply' }, { base: 5, patch }),
+  /base document must be a plain object/,
+  'non-object base should fail',
+);
+
+console.log('jsonpatch.apply transform OK');

--- a/packages/transform/tests/time.test.mjs
+++ b/packages/transform/tests/time.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { runTransform } from '../index.mjs';
+
+const parsed = runTransform({ op: 'time.parseTimestamp' }, { value: '2024-05-01T12:34:56Z' });
+assert.equal(parsed.iso, '2024-05-01T12:34:56.000Z');
+assert.equal(typeof parsed.epoch_ms, 'number');
+
+const aligned = runTransform({ op: 'time.align', unit: 'hour' }, { timestamp: parsed.epoch_ms + 15 * 60 * 1000 });
+assert.equal(aligned.iso, '2024-05-01T12:00:00.000Z');
+assert.equal(aligned.interval_ms, 60 * 60 * 1000);
+
+const window = runTransform({ op: 'time.windowKey', unit: 'hour' }, { timestamp: parsed.epoch_ms });
+assert.equal(window.key, '2024-05-01T12:00:00.000Z/2024-05-01T13:00:00.000Z');
+assert.equal(window.interval_ms, 60 * 60 * 1000);
+assert.equal(window.start_ms, aligned.epoch_ms);
+assert.equal(window.end_ms, aligned.epoch_ms + aligned.interval_ms);
+
+console.log('time transforms OK');


### PR DESCRIPTION
## Summary
- add a policy.enforce macro that evaluates policy_eval deterministically and publishes policy:enforce with catalog coverage and a macro test
- extract a shared expandRpc helper for state/process macros so corr/reply envelopes and retry payloads stay canonical, updating catalogs and expectations
- enrich CRDT merge reporting and harden jsonpatch/state_diff semantics while documenting macro laws

## Testing
- node --test packages/expander/tests/*.test.mjs
- node --test packages/transform/tests/*.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dc6f9981708320b5f2772cdd6590d4