### PR TITLE
Polish law checks and CLI outputs

### DIFF
--- a/docs/0.6/index.md
+++ b/docs/0.6/index.md
@@ -4,6 +4,16 @@
 - [Auto Quote → Bind → Issue](pipelines/quote-bind-issue.md)
 - [Fast-Track 24h SLA Monitors](monitors/fasttrack-24h.md)
 
+# Prover roadmap
+
+- [Lean 4 prover skeleton](../../prover/lean/README.md)
+
+## Law checks
+
+- Run human-readable checks with `tf laws --check <pipeline.l0.json> --goal branch-exclusive` to review PASS/WARN/ERROR entries and any counterexamples found within the boolean bound (`--max-bools N`, default 8).
+- Use machine-readable mode with `tf laws --check <pipeline.l0.json> --goal branch-exclusive --json [--policy path] [--caps path]` to feed the same policy/capability inputs as CI and capture structured results.
+- `WARN` entries document gaps (e.g., missing metadata or plaintext alongside ciphertext) but do not fail builds; teams can layer stricter policies later if needed.
+
 # TF-Lang v0.6 Specification
 
 > Generated from `spec/v0.6`

--- a/laws/_util.mjs
+++ b/laws/_util.mjs
@@ -1,0 +1,9 @@
+export function ensurePublishNodes({ publishNodes = [], nodes = [] } = {}) {
+  if (Array.isArray(publishNodes) && publishNodes.length > 0) {
+    return publishNodes.map((entry) => (entry && entry.node ? entry : { node: entry }));
+  }
+  if (!Array.isArray(nodes)) return [];
+  return nodes
+    .filter((n) => n && typeof n === 'object' && n.kind === 'Publish')
+    .map((node) => ({ node }));
+}

--- a/laws/branch_exclusive.mjs
+++ b/laws/branch_exclusive.mjs
@@ -441,7 +441,7 @@ export async function checkBranchExclusive({ nodes = [] } = {}) {
     results.push(result);
   }
 
-  const ok = results.every((entry) => entry.ok !== false);
+  const ok = results.every((entry) => entry.ok);
   return { ok, results };
 }
 

--- a/laws/branch_exclusive.mjs
+++ b/laws/branch_exclusive.mjs
@@ -1,0 +1,448 @@
+import { proveGuardExclusive } from '../packages/prover/z3.mjs';
+
+const POSITIVE_PATHS = new Set(['then', 'true', 'yes', 'allow', 'positive']);
+const NEGATIVE_PATHS = new Set(['else', 'false', 'no', 'deny', 'negative']);
+
+function describeValue(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+}
+
+function stripOuterParens(text) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+  let result = text.trim();
+  while (result.startsWith('(') && result.endsWith(')')) {
+    const inner = result.slice(1, -1).trim();
+    if (inner.length === 0 || inner === result) {
+      break;
+    }
+    result = inner;
+  }
+  return result;
+}
+
+function normalizeIdentifier(text) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+  let candidate = stripOuterParens(text);
+  let updated = true;
+  while (updated) {
+    updated = false;
+    if (candidate.startsWith('@')) {
+      candidate = candidate.slice(1).trim();
+      updated = true;
+      continue;
+    }
+    if (candidate.startsWith('¬')) {
+      candidate = candidate.slice(1).trim();
+      updated = true;
+      continue;
+    }
+    if (candidate.startsWith('!')) {
+      candidate = candidate.slice(1).trim();
+      updated = true;
+      continue;
+    }
+    if (/^not\b/i.test(candidate)) {
+      candidate = candidate.replace(/^not\b/i, '').trim();
+      updated = true;
+    }
+  }
+  candidate = stripOuterParens(candidate).trim();
+  return candidate;
+}
+
+function parseGuard(when) {
+  const base = {
+    kind: 'unknown',
+    text: describeValue(when),
+    normalized: null,
+    var: null,
+    negated: false,
+    supported: false,
+  };
+
+  if (typeof when === 'boolean') {
+    return {
+      ...base,
+      kind: 'const',
+      text: String(when),
+    };
+  }
+
+  if (typeof when === 'string') {
+    const stripped = stripOuterParens(when);
+    if (stripped.length === 0) {
+      return base;
+    }
+    const lower = stripped.toLowerCase();
+    if (lower === 'true' || lower === 'false') {
+      return {
+        ...base,
+        kind: 'const',
+        text: lower,
+      };
+    }
+
+    let negated = false;
+    let body = stripped;
+    let updated = true;
+    while (updated) {
+      updated = false;
+      const trimmed = body.trim();
+      if (trimmed.startsWith('¬')) {
+        negated = !negated;
+        body = trimmed.slice(1);
+        updated = true;
+        continue;
+      }
+      if (trimmed.startsWith('!')) {
+        negated = !negated;
+        body = trimmed.slice(1);
+        updated = true;
+        continue;
+      }
+      if (/^not\b/i.test(trimmed)) {
+        negated = !negated;
+        body = trimmed.replace(/^not\b/i, '');
+        updated = true;
+        continue;
+      }
+    }
+    body = stripOuterParens(body).trim();
+    if (body.startsWith('@')) {
+      body = body.slice(1);
+    }
+    const match = body.match(/^[A-Za-z0-9_.:]+/);
+    if (match) {
+      const variable = match[0];
+      return {
+        kind: 'var',
+        text: negated ? `¬@${variable}` : `@${variable}`,
+        normalized: `@${variable}`,
+        var: variable,
+        negated,
+        supported: true,
+      };
+    }
+    return base;
+  }
+
+  if (when && typeof when === 'object') {
+    if (typeof when.op === 'string' && when.op.toLowerCase() === 'not' && typeof when.var === 'string') {
+      const variable = normalizeIdentifier(when.var);
+      if (variable) {
+        return {
+          kind: 'var',
+          text: `¬@${variable}`,
+          normalized: `@${variable}`,
+          var: variable,
+          negated: true,
+          supported: true,
+        };
+      }
+    }
+    if (typeof when.var === 'string') {
+      const variable = normalizeIdentifier(when.var);
+      if (variable) {
+        return {
+          kind: 'var',
+          text: `@${variable}`,
+          normalized: `@${variable}`,
+          var: variable,
+          negated: false,
+          supported: true,
+        };
+      }
+    }
+    return {
+      ...base,
+      kind: 'complex',
+    };
+  }
+
+  return base;
+}
+
+function extractBranchMeta(node) {
+  const meta = node && typeof node === 'object' ? node.metadata : null;
+  if (!meta || typeof meta !== 'object') {
+    return null;
+  }
+  const branch = meta.branch && typeof meta.branch === 'object' ? meta.branch : null;
+  const candidates = [
+    branch?.id,
+    branch?.branch_id,
+    branch?.name,
+    branch?.group,
+    meta.branch_id,
+    meta.branchId,
+  ];
+  const id = candidates.find((value) => typeof value === 'string' && value.length > 0) ?? null;
+  const pathCandidates = [branch?.path, branch?.side, branch?.role, meta.branch_path, meta.branchPath];
+  const rawPath = pathCandidates.find((value) => typeof value === 'string' && value.length > 0) ?? null;
+  return {
+    id,
+    path: rawPath,
+  };
+}
+
+function normalizePath(path) {
+  if (!path || typeof path !== 'string') {
+    return null;
+  }
+  const normalized = path.trim().toLowerCase();
+  if (POSITIVE_PATHS.has(normalized)) {
+    return 'positive';
+  }
+  if (NEGATIVE_PATHS.has(normalized)) {
+    return 'negative';
+  }
+  return null;
+}
+
+function determinePolarity(metaPath, guard) {
+  const metaPolarity = normalizePath(metaPath);
+  if (metaPolarity) {
+    return metaPolarity;
+  }
+  if (guard.kind === 'var') {
+    return guard.negated ? 'negative' : 'positive';
+  }
+  return 'unknown';
+}
+
+function createGroup(key, source) {
+  return {
+    key,
+    source,
+    positive: [],
+    negative: [],
+    neutral: [],
+    guardVars: new Set(),
+    hasMismatch: false,
+  };
+}
+
+function buildGroups(nodes = []) {
+  const groups = new Map();
+  const fallback = new Map();
+
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') {
+      continue;
+    }
+    const guard = parseGuard(node.when);
+    const meta = extractBranchMeta(node);
+    const targetKey = meta?.id;
+    const metadataPolarity = normalizePath(meta?.path);
+    const guardPolarity = guard.kind === 'var' ? (guard.negated ? 'negative' : 'positive') : null;
+    const mismatch = Boolean(metadataPolarity && guardPolarity && metadataPolarity !== guardPolarity);
+
+    const entry = {
+      id: node.id ?? null,
+      guard,
+      path: meta?.path ?? null,
+      metadataPolarity,
+      guardPolarity,
+      metadataGuardMismatch: mismatch,
+    };
+
+    if (guard.kind === 'var' && guard.var) {
+      entry.guardVar = guard.var;
+    }
+
+    if (targetKey) {
+      if (!groups.has(targetKey)) {
+        groups.set(targetKey, createGroup(targetKey, 'metadata'));
+      }
+      const group = groups.get(targetKey);
+      if (entry.guardVar) {
+        group.guardVars.add(entry.guardVar);
+      }
+      const polarity = determinePolarity(meta?.path, guard);
+      if (mismatch) {
+        group.hasMismatch = true;
+      }
+      if (polarity === 'positive') {
+        group.positive.push(entry);
+      } else if (polarity === 'negative') {
+        group.negative.push(entry);
+      } else {
+        group.neutral.push(entry);
+      }
+      continue;
+    }
+
+    if (guard.kind === 'var' && guard.var) {
+      if (!fallback.has(guard.var)) {
+        fallback.set(guard.var, createGroup(guard.var, 'guard'));
+      }
+      const group = fallback.get(guard.var);
+      group.guardVars.add(guard.var);
+      if (guard.negated) {
+        group.negative.push(entry);
+      } else {
+        group.positive.push(entry);
+      }
+    }
+  }
+
+  const output = [...groups.values()];
+  for (const group of fallback.values()) {
+    if (group.positive.length > 0 && group.negative.length > 0) {
+      output.push(group);
+    }
+  }
+  return output;
+}
+
+function formatEntry(entry) {
+  return {
+    id: entry.id,
+    path: entry.path ?? null,
+    guard: {
+      kind: entry.guard.kind,
+      text: entry.guard.text,
+      normalized: entry.guard.normalized ?? null,
+      var: entry.guard.var,
+      negated: Boolean(entry.guard.negated),
+      supported: Boolean(entry.guard.supported),
+    },
+    metadataPolarity: entry.metadataPolarity ?? null,
+    guardPolarity: entry.guardPolarity ?? null,
+    metadataGuardMismatch: Boolean(entry.metadataGuardMismatch),
+  };
+}
+
+export async function checkBranchExclusive({ nodes = [] } = {}) {
+  const groups = buildGroups(nodes).sort((a, b) => {
+    const aKey = `${a.source}:${a.key ?? ''}`;
+    const bKey = `${b.source}:${b.key ?? ''}`;
+    if (aKey < bKey) return -1;
+    if (aKey > bKey) return 1;
+    return 0;
+  });
+  const results = [];
+
+  for (const group of groups) {
+    if (group.positive.length === 0 && group.negative.length === 0) {
+      continue;
+    }
+
+    const result = {
+      branch: group.source === 'metadata' ? group.key : null,
+      guardVar: group.guardVars.size === 1 ? [...group.guardVars][0] : null,
+      source: group.source,
+      positive: group.positive.map(formatEntry),
+      negative: group.negative.map(formatEntry),
+      neutral: group.neutral.map(formatEntry),
+      status: 'NEUTRAL',
+      reason: null,
+      proved: null,
+      guard: null,
+      ok: true,
+      warnings: [],
+    };
+
+    const warnings = new Set();
+
+    if (group.guardVars.size > 1) {
+      warnings.add('mixed-guard-vars');
+    }
+    if (group.hasMismatch) {
+      warnings.add('metadata-guard-mismatch');
+    }
+
+    if (group.positive.length === 0 || group.negative.length === 0) {
+      result.status = 'WARN';
+      result.reason = group.positive.length === 0 ? 'missing-positive' : 'missing-negative';
+      result.ok = true;
+      results.push(result);
+      continue;
+    }
+
+    const positiveGuard = group.positive.map((entry) => entry.guard).find((guard) => guard.supported);
+    const negativeGuard = group.negative.map((entry) => entry.guard).find((guard) => guard.supported);
+
+    if (!positiveGuard || !negativeGuard) {
+      result.status = 'WARN';
+      result.reason = 'unsupported-guard';
+      result.ok = true;
+      results.push(result);
+      continue;
+    }
+
+    if (!result.guardVar) {
+      if (positiveGuard.var && negativeGuard.var && positiveGuard.var === negativeGuard.var) {
+        result.guardVar = positiveGuard.var;
+      } else {
+        result.guardVar = positiveGuard.var ?? negativeGuard.var ?? null;
+      }
+    }
+
+    result.guard = positiveGuard.normalized
+      ?? negativeGuard.normalized
+      ?? (result.guardVar ? `@${result.guardVar}` : null);
+
+    const selectWarningReason = () => {
+      if (warnings.has('metadata-guard-mismatch')) return 'metadata-guard-mismatch';
+      if (warnings.has('mixed-guard-vars')) return 'mixed-guard-vars';
+      return null;
+    };
+
+    try {
+      const proved = await proveGuardExclusive({
+        guardVar: result.guardVar,
+        positiveNegated: Boolean(positiveGuard.negated),
+        negativeNegated: Boolean(negativeGuard.negated),
+      });
+      result.proved = proved;
+      if (proved) {
+        const warningReason = selectWarningReason();
+        if (warningReason) {
+          result.status = 'WARN';
+          result.reason = warningReason;
+        } else {
+          result.status = 'PASS';
+          result.reason = null;
+        }
+      } else {
+        result.status = 'ERROR';
+        result.reason = 'overlap';
+      }
+    } catch (error) {
+      result.status = 'ERROR';
+      result.reason = 'solver-failed';
+      result.error = error?.message ?? 'solver-failed';
+    }
+
+    result.warnings = [...warnings];
+    result.ok = result.status !== 'ERROR';
+
+    results.push(result);
+  }
+
+  const ok = results.every((entry) => entry.ok !== false);
+  return { ok, results };
+}
+
+export default checkBranchExclusive;

--- a/laws/confidential_envelope.mjs
+++ b/laws/confidential_envelope.mjs
@@ -1,14 +1,4 @@
-function ensurePublishNodes({ publishNodes = [], nodes = [] }) {
-  if (Array.isArray(publishNodes) && publishNodes.length > 0) {
-    return publishNodes.map((entry) => (entry.node ? entry : { node: entry }));
-  }
-  if (!Array.isArray(nodes)) {
-    return [];
-  }
-  return nodes
-    .filter((node) => node && typeof node === 'object' && node.kind === 'Publish')
-    .map((node) => ({ node }));
-}
+import { ensurePublishNodes } from './_util.mjs';
 
 function hasProperty(object, key) {
   return Object.prototype.hasOwnProperty.call(object ?? {}, key);
@@ -41,7 +31,7 @@ export function checkConfidentialEnvelope(options = {}) {
     });
   }
 
-  const ok = results.every((entry) => entry.status !== 'ERROR');
+  const ok = results.every((entry) => entry.ok);
   return { ok, results };
 }
 

--- a/laws/confidential_envelope.mjs
+++ b/laws/confidential_envelope.mjs
@@ -1,0 +1,48 @@
+function ensurePublishNodes({ publishNodes = [], nodes = [] }) {
+  if (Array.isArray(publishNodes) && publishNodes.length > 0) {
+    return publishNodes.map((entry) => (entry.node ? entry : { node: entry }));
+  }
+  if (!Array.isArray(nodes)) {
+    return [];
+  }
+  return nodes
+    .filter((node) => node && typeof node === 'object' && node.kind === 'Publish')
+    .map((node) => ({ node }));
+}
+
+function hasProperty(object, key) {
+  return Object.prototype.hasOwnProperty.call(object ?? {}, key);
+}
+
+export function checkConfidentialEnvelope(options = {}) {
+  const publishEntries = ensurePublishNodes(options);
+  const results = [];
+
+  for (const entry of publishEntries) {
+    const node = entry.node ?? null;
+    if (!node || typeof node !== 'object') {
+      continue;
+    }
+    const payload = node.payload && typeof node.payload === 'object' ? node.payload : null;
+    const envelope = payload && typeof payload.envelope === 'object' ? payload.envelope : null;
+    if (!envelope || !hasProperty(envelope, 'ciphertext')) {
+      continue;
+    }
+    const hasPlaintext = payload ? hasProperty(payload, 'plaintext') : false;
+    const satisfied = !hasPlaintext;
+    const status = satisfied ? 'PASS' : 'WARN';
+    results.push({
+      id: node.id ?? null,
+      channel: typeof node.channel === 'string' ? node.channel : null,
+      status,
+      ok: status !== 'ERROR',
+      satisfied,
+      reason: satisfied ? null : 'plaintext-present',
+    });
+  }
+
+  const ok = results.every((entry) => entry.status !== 'ERROR');
+  return { ok, results };
+}
+
+export default checkConfidentialEnvelope;

--- a/laws/monotonic_log.mjs
+++ b/laws/monotonic_log.mjs
@@ -1,0 +1,43 @@
+function ensurePublishNodes({ publishNodes = [], nodes = [] }) {
+  if (Array.isArray(publishNodes) && publishNodes.length > 0) {
+    return publishNodes.map((entry) => (entry.node ? entry : { node: entry }));
+  }
+  if (!Array.isArray(nodes)) {
+    return [];
+  }
+  return nodes
+    .filter((node) => node && typeof node === 'object' && node.kind === 'Publish')
+    .map((node) => ({ node }));
+}
+
+export function checkMonotonicLog(options = {}) {
+  const publishEntries = ensurePublishNodes(options);
+  const results = [];
+
+  for (const entry of publishEntries) {
+    const node = entry.node ?? null;
+    if (!node || typeof node !== 'object') {
+      continue;
+    }
+    const channel = typeof node.channel === 'string' ? node.channel : null;
+    if (channel !== 'policy:record') {
+      continue;
+    }
+    results.push({
+      id: node.id ?? null,
+      channel,
+      status: 'PASS',
+      ok: true,
+      reason: null,
+      assumption: 'consumer-append-only',
+    });
+  }
+
+  const ok = results.every((entry) => entry.status !== 'ERROR');
+  return {
+    ok,
+    results,
+  };
+}
+
+export default checkMonotonicLog;

--- a/laws/monotonic_log.mjs
+++ b/laws/monotonic_log.mjs
@@ -1,14 +1,4 @@
-function ensurePublishNodes({ publishNodes = [], nodes = [] }) {
-  if (Array.isArray(publishNodes) && publishNodes.length > 0) {
-    return publishNodes.map((entry) => (entry.node ? entry : { node: entry }));
-  }
-  if (!Array.isArray(nodes)) {
-    return [];
-  }
-  return nodes
-    .filter((node) => node && typeof node === 'object' && node.kind === 'Publish')
-    .map((node) => ({ node }));
-}
+import { ensurePublishNodes } from './_util.mjs';
 
 export function checkMonotonicLog(options = {}) {
   const publishEntries = ensurePublishNodes(options);
@@ -33,7 +23,7 @@ export function checkMonotonicLog(options = {}) {
     });
   }
 
-  const ok = results.every((entry) => entry.status !== 'ERROR');
+  const ok = results.every((entry) => entry.ok);
   return {
     ok,
     results,

--- a/packages/prover/counterexample.mjs
+++ b/packages/prover/counterexample.mjs
@@ -1,0 +1,115 @@
+function normalizeVariables(input) {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const seen = new Set();
+  const vars = [];
+  for (const name of input) {
+    if (typeof name !== 'string') {
+      continue;
+    }
+    const trimmed = name.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    vars.push(trimmed);
+  }
+  return vars.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function collectTriggered(entries = [], assignment = {}) {
+  const triggered = [];
+  for (const entry of entries) {
+    const guard = entry?.guard;
+    if (!guard || guard.kind !== 'var' || typeof guard.var !== 'string') {
+      continue;
+    }
+    const value = Boolean(assignment[guard.var]);
+    const active = guard.negated ? !value : value;
+    if (active) {
+      if (typeof entry.id === 'string') {
+        triggered.push(entry.id);
+      } else if (entry.id !== null && entry.id !== undefined) {
+        triggered.push(String(entry.id));
+      }
+    }
+  }
+  return triggered.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function makePayload({
+  goal,
+  guard,
+  reason,
+  assignment,
+  positive,
+  negative,
+}) {
+  const payload = {
+    goal: goal ?? 'branch-exclusive',
+    guard: guard ?? null,
+    reason,
+    assignment: assignment ?? null,
+    triggered: {
+      positive: collectTriggered(positive, assignment),
+      negative: collectTriggered(negative, assignment),
+    },
+  };
+  return payload;
+}
+
+export function findCounterexample({
+  goal = 'branch-exclusive',
+  guard = null,
+  reason = 'overlap',
+  variables = [],
+  predicate,
+  positive = [],
+  negative = [],
+  maxBools = 8,
+} = {}) {
+  const uniqueVars = normalizeVariables(variables);
+  const sanitizedMax = Number.isInteger(maxBools) ? maxBools : 8;
+  const cappedMax = Math.min(Math.max(sanitizedMax, 1), 8);
+
+  if (sanitizedMax > 8 || uniqueVars.length > cappedMax) {
+    return makePayload({
+      goal,
+      guard: guard ?? (uniqueVars.length === 1 ? `@${uniqueVars[0]}` : guard),
+      reason: 'max-bools-exceeded',
+      assignment: null,
+      positive,
+      negative,
+    });
+  }
+
+  if (uniqueVars.length === 0) {
+    return null;
+  }
+
+  if (reason !== 'overlap') {
+    return makePayload({ goal, guard, reason, assignment: null, positive, negative });
+  }
+
+  if (typeof predicate !== 'function') {
+    throw new Error('predicate-required');
+  }
+
+  const total = 1 << uniqueVars.length;
+  for (let mask = 0; mask < total; mask += 1) {
+    const assignment = {};
+    for (let index = 0; index < uniqueVars.length; index += 1) {
+      assignment[uniqueVars[index]] = Boolean((mask >> index) & 1);
+    }
+    const holds = Boolean(predicate(assignment));
+    if (!holds) {
+      return makePayload({ goal, guard, reason: 'overlap', assignment, positive, negative });
+    }
+  }
+  return null;
+}
+
+export default {
+  findCounterexample,
+};

--- a/packages/prover/counterexample.mjs
+++ b/packages/prover/counterexample.mjs
@@ -46,15 +46,21 @@ function makePayload({
   positive,
   negative,
 }) {
+  const hasAssignment = assignment && typeof assignment === 'object';
+  const normalizedAssignment = hasAssignment ? assignment : {};
+  const triggered = hasAssignment
+    ? {
+        positive: collectTriggered(positive, normalizedAssignment),
+        negative: collectTriggered(negative, normalizedAssignment),
+      }
+    : { positive: [], negative: [] };
+
   const payload = {
     goal: goal ?? 'branch-exclusive',
     guard: guard ?? null,
     reason,
-    assignment: assignment ?? null,
-    triggered: {
-      positive: collectTriggered(positive, assignment),
-      negative: collectTriggered(negative, assignment),
-    },
+    assignment: normalizedAssignment,
+    triggered,
   };
   return payload;
 }

--- a/prover/lean/README.md
+++ b/prover/lean/README.md
@@ -1,12 +1,61 @@
-# Lean 4 Prover Roadmap
+# TF-Lang · Lean 4 Prover Skeleton
 
-The SMT shim uses Z3 today for lightweight implication checks. This folder will
-hold a future Lean 4 setup once we move beyond the stub harness:
+This document sketches how the TF-Lang kernel can map into Lean 4. The goal is to
+model the immutable L0 DAG directly in a proof assistant so that law checks and
+future proofs share a common foundation.
 
-- `lakefile.toml` to pin Lean/Mathlib versions.
-- `lake exe cache get` bootstrap scripts for CI.
-- Skeleton proofs for the idempotency and CRDT merge laws, kept in sync with the
-  Node harness.
+## Kernel model
 
-Nothing is wired yet; the README simply stakes out the structure so we can land
-Lean when the math library dependencies settle.
+We can treat the four kernel primitives as an inductive data type. Each node
+contains its identifier, inputs, and outputs. Guards (`when`) and metadata are
+modeled explicitly so that branch proofs can reason about exclusivity.
+
+```lean
+inductive Node
+  | transform (id : String) (spec : TransformSpec) (inputs : Inputs) (output : Var)
+  | publish   (id : String) (channel : Channel) (payload : Payload) (guard : Guard)
+  | subscribe (id : String) (channel : Channel) (filter : Filter) (output : Var)
+  | keypair   (id : String) (algorithm : Algorithm) (output : Var)
+
+def Dag := List Node
+```
+
+Supporting structures (`TransformSpec`, `Inputs`, `Guard`, etc.) stay minimal at
+first—enough to encode the JSON L0 payload. Later passes can refine them to use
+stronger types (e.g., enumerations for QoS, dependent pairs for payload shapes).
+
+Determinism facts ("pure transforms are stable"), effect ordering, and policy
+membership all become lemmas about the constructed `Dag` value.
+
+## Sample theorem skeleton — CRDT idempotence
+
+The idempotence proof for CRDT publishes can be phrased as a Lean theorem that
+assumes a stable correlation identifier and shows replay safety.
+
+```lean
+theorem crdt_idempotent
+  (dag : Dag)
+  (p : Node)
+  (h_publish : p ∈ dag)
+  (h_channel : p.channel = Channel.rpc "rpc:req:claims/crdt")
+  (h_corr : stable_corr p.payload.corr)
+  : idempotent dag p := by
+  -- Future work:
+  -- 1. Unpack the guard and correlation witnesses from `h_corr`.
+  -- 2. Use the SMT-style reasoning library to show that two executions with the
+  --    same corr collapse to a single state update.
+  admit
+```
+
+`admit` marks unfinished proof steps. The initial milestone is a type-correct
+statement with clear hypotheses. Later iterations can replace `admit` with real
+proof terms or calls into Lean's automation. Along the way, the same theorem can
+export assumptions that today’s JavaScript law (`laws/idempotency.mjs`) records
+manually.
+
+## Next steps
+
+1. Define parsers that lift JSON L0 pipelines into the Lean `Dag` type.
+2. Rephrase existing JavaScript law checks as Lean lemmas over `Dag`.
+3. Integrate Lean proof artifacts into the CI pipeline once the skeleton passes
+   basic elaboration.

--- a/tests/checker/laws-branch-exclusive.normalize.test.mjs
+++ b/tests/checker/laws-branch-exclusive.normalize.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import checkBranchExclusive from '../../laws/branch_exclusive.mjs';
+
+test('branch exclusivity normalizes guard strings and objects', async () => {
+  const nodes = [
+    {
+      id: 'P_then',
+      kind: 'Publish',
+      channel: 'metric:then',
+      when: '@decision',
+      metadata: { branch: { id: 'decision', path: 'then' } },
+    },
+    {
+      id: 'P_else',
+      kind: 'Publish',
+      channel: 'metric:else',
+      when: '!( @decision )',
+      metadata: { branch: { id: 'decision', path: 'else' } },
+    },
+    {
+      id: 'P_else_object',
+      kind: 'Publish',
+      channel: 'metric:else',
+      when: { op: 'not', var: '@decision' },
+      metadata: { branch: { id: 'decision', path: 'else' } },
+    },
+  ];
+
+  const report = await checkBranchExclusive({ nodes });
+  assert.equal(report.ok, true);
+  const [entry] = report.results;
+  assert.equal(entry.status, 'PASS');
+  assert.equal(entry.guardVar, 'decision');
+  assert.equal(entry.guard, '@decision');
+  assert.equal(entry.ok, true);
+  assert.equal(entry.proved, true);
+});
+
+test('metadata polarity mismatches surface as warnings', async () => {
+  const nodes = [
+    {
+      id: 'P_then',
+      kind: 'Publish',
+      channel: 'metric:then',
+      when: 'not @decision',
+      metadata: { branch: { id: 'decision', path: 'then' } },
+    },
+    {
+      id: 'P_else',
+      kind: 'Publish',
+      channel: 'metric:else',
+      when: '@decision',
+      metadata: { branch: { id: 'decision', path: 'else' } },
+    },
+  ];
+
+  const report = await checkBranchExclusive({ nodes });
+  assert.equal(report.ok, true);
+  const [entry] = report.results;
+  assert.equal(entry.status, 'WARN');
+  assert.equal(entry.reason, 'metadata-guard-mismatch');
+  assert.equal(entry.ok, true);
+  assert.equal(entry.proved, true);
+  assert.equal(entry.guard, '@decision');
+});

--- a/tests/checker/laws-branch-exclusive.test.mjs
+++ b/tests/checker/laws-branch-exclusive.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import checkBranchExclusive from '../../laws/branch_exclusive.mjs';
+
+function buildNodes({ elseGuard }) {
+  return [
+    {
+      id: 'P_then',
+      kind: 'Publish',
+      channel: 'metric:then',
+      qos: 'at_least_once',
+      payload: { value: 1 },
+      when: '@decision',
+      metadata: { branch: { id: 'decision_branch', path: 'then' } },
+    },
+    {
+      id: 'P_else',
+      kind: 'Publish',
+      channel: 'metric:else',
+      qos: 'at_least_once',
+      payload: { value: 1 },
+      when: elseGuard,
+      metadata: { branch: { id: 'decision_branch', path: 'else' } },
+    },
+  ];
+}
+
+test('branch exclusivity succeeds when guards are complementary', async () => {
+  const nodes = buildNodes({ elseGuard: { op: 'not', var: 'decision' } });
+  const report = await checkBranchExclusive({ nodes });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.results.length, 1);
+  const [entry] = report.results;
+  assert.equal(entry.status, 'PASS');
+  assert.equal(entry.reason, null);
+  assert.equal(entry.ok, true);
+  assert.equal(entry.proved, true);
+  assert.equal(entry.guardVar, 'decision');
+  assert.equal(entry.guard, '@decision');
+});
+
+test('branch exclusivity detects non-exclusive guards', async () => {
+  const nodes = buildNodes({ elseGuard: '@decision' });
+  const report = await checkBranchExclusive({ nodes });
+
+  assert.equal(report.ok, false);
+  const [entry] = report.results;
+  assert.equal(entry.status, 'ERROR');
+  assert.equal(entry.reason, 'overlap');
+  assert.equal(entry.proved, false);
+  assert.equal(entry.ok, false);
+});

--- a/tests/checker/laws-confidential-envelope.test.mjs
+++ b/tests/checker/laws-confidential-envelope.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkConfidentialEnvelope } from '../../laws/confidential_envelope.mjs';
+
+test('confidential envelope law marks payloads without plaintext as pass and warns otherwise', () => {
+  const nodes = [
+    {
+      id: 'P_secure',
+      kind: 'Publish',
+      channel: 'policy:secure',
+      qos: 'at_least_once',
+      payload: {
+        envelope: { ciphertext: 'ABC123' },
+      },
+    },
+    {
+      id: 'P_warn',
+      kind: 'Publish',
+      channel: 'policy:secure',
+      qos: 'at_least_once',
+      payload: {
+        envelope: { ciphertext: 'XYZ' },
+        plaintext: { hint: true },
+      },
+    },
+  ];
+
+  const report = checkConfidentialEnvelope({ nodes });
+  assert.equal(report.ok, true);
+  assert.equal(report.results.length, 2);
+
+  const secure = report.results.find((entry) => entry.id === 'P_secure');
+  assert(secure);
+  assert.equal(secure.status, 'PASS');
+  assert.equal(secure.reason, null);
+  assert.equal(secure.satisfied, true);
+  assert.equal(secure.ok, true);
+
+  const warn = report.results.find((entry) => entry.id === 'P_warn');
+  assert(warn);
+  assert.equal(warn.status, 'WARN');
+  assert.equal(warn.reason, 'plaintext-present');
+  assert.equal(warn.satisfied, false);
+  assert.equal(warn.ok, true);
+});

--- a/tests/checker/laws-monotonic-log.test.mjs
+++ b/tests/checker/laws-monotonic-log.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkMonotonicLog } from '../../laws/monotonic_log.mjs';
+
+test('monotonic log law records append-only assumption for policy:record channel', () => {
+  const nodes = [
+    {
+      id: 'P_record',
+      kind: 'Publish',
+      channel: 'policy:record',
+      qos: 'at_least_once',
+      payload: { entry: { id: 'abc' } },
+    },
+    {
+      id: 'P_metric',
+      kind: 'Publish',
+      channel: 'metric:noop',
+      qos: 'at_least_once',
+      payload: { value: 1 },
+    },
+  ];
+
+  const report = checkMonotonicLog({ nodes });
+  assert.equal(report.ok, true);
+  assert.equal(report.results.length, 1);
+  const [entry] = report.results;
+  assert.equal(entry.id, 'P_record');
+  assert.equal(entry.channel, 'policy:record');
+  assert.equal(entry.status, 'PASS');
+  assert.equal(entry.ok, true);
+  assert.equal(entry.reason, null);
+  assert.equal(entry.assumption, 'consumer-append-only');
+});

--- a/tests/prover/counterexample.bounds.test.mjs
+++ b/tests/prover/counterexample.bounds.test.mjs
@@ -15,7 +15,7 @@ test('counterexample search returns structured payload when max bools exceeded',
   });
 
   assert.equal(result.reason, 'max-bools-exceeded');
-  assert.equal(result.assignment, null);
+  assert.deepEqual(result.assignment, {});
   assert.deepEqual(result.triggered, { positive: [], negative: [] });
 });
 

--- a/tests/prover/counterexample.bounds.test.mjs
+++ b/tests/prover/counterexample.bounds.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { findCounterexample } from '../../packages/prover/counterexample.mjs';
+
+test('counterexample search returns structured payload when max bools exceeded', () => {
+  const result = findCounterexample({
+    goal: 'branch-exclusive',
+    guard: '@decision',
+    variables: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+    predicate: () => true,
+    positive: [],
+    negative: [],
+    maxBools: 9,
+  });
+
+  assert.equal(result.reason, 'max-bools-exceeded');
+  assert.equal(result.assignment, null);
+  assert.deepEqual(result.triggered, { positive: [], negative: [] });
+});
+
+test('counterexample search returns sorted assignment keys and triggered sets', () => {
+  const result = findCounterexample({
+    goal: 'branch-exclusive',
+    guard: '@decision',
+    variables: ['b', 'a'],
+    predicate: (candidate) => candidate.a,
+    positive: [
+      { id: 'P_b', guard: { kind: 'var', var: 'b', negated: false } },
+    ],
+    negative: [
+      { id: 'N_a', guard: { kind: 'var', var: 'a', negated: true } },
+    ],
+    maxBools: 2,
+  });
+
+  assert.equal(result.reason, 'overlap');
+  assert.deepEqual(Object.keys(result.assignment), ['a', 'b']);
+  assert.deepEqual(result.triggered.positive, []);
+  assert.deepEqual(result.triggered.negative, ['N_a']);
+});

--- a/tools/tf-lang-cli/index.mjs
+++ b/tools/tf-lang-cli/index.mjs
@@ -288,6 +288,22 @@ function sortNodeResults(entries = []) {
   });
 }
 
+function consumeFlagWithValue(argv, i, long) {
+  const arg = argv[i];
+  if (arg === `--${long}`) {
+    const value = argv[i + 1];
+    if (value === undefined) {
+      console.error(`missing value for --${long}`);
+      return { i, err: 2 };
+    }
+    return { i: i + 1, value };
+  }
+  if (typeof arg === 'string' && arg.startsWith(`--${long}=`)) {
+    return { i, value: arg.slice(long.length + 3) };
+  }
+  return null;
+}
+
 function evaluateGuard(guard, assignment) {
   if (!guard || guard.kind !== 'var' || typeof guard.var !== 'string') {
     return false;
@@ -323,64 +339,36 @@ async function runLawsCommand(rawArgs) {
     if (!arg) {
       continue;
     }
-    if (arg === '--goal') {
-      const value = argv[i + 1];
-      if (value === undefined) {
-        console.error('missing value for --goal');
-        return 2;
-      }
-      goal = value;
-      i += 1;
+    const goalHit = consumeFlagWithValue(argv, i, 'goal');
+    if (goalHit) {
+      if (goalHit.err) return goalHit.err;
+      goal = goalHit.value;
+      i = goalHit.i;
       continue;
     }
-    if (arg.startsWith('--goal=')) {
-      goal = arg.slice('--goal='.length);
-      continue;
-    }
-    if (arg === '--max-bools') {
-      const value = argv[i + 1];
-      if (value === undefined) {
-        console.error('missing value for --max-bools');
-        return 2;
-      }
-      maxBools = Number(value);
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith('--max-bools=')) {
-      maxBools = Number(arg.slice('--max-bools='.length));
+    const maxBoolsHit = consumeFlagWithValue(argv, i, 'max-bools');
+    if (maxBoolsHit) {
+      if (maxBoolsHit.err) return maxBoolsHit.err;
+      maxBools = Number(maxBoolsHit.value);
+      i = maxBoolsHit.i;
       continue;
     }
     if (arg === '--json') {
       jsonMode = true;
       continue;
     }
-    if (arg === '--policy') {
-      const value = argv[i + 1];
-      if (value === undefined) {
-        console.error('missing value for --policy');
-        return 2;
-      }
-      policyPath = value;
-      i += 1;
+    const policyHit = consumeFlagWithValue(argv, i, 'policy');
+    if (policyHit) {
+      if (policyHit.err) return policyHit.err;
+      policyPath = policyHit.value;
+      i = policyHit.i;
       continue;
     }
-    if (arg.startsWith('--policy=')) {
-      policyPath = arg.slice('--policy='.length);
-      continue;
-    }
-    if (arg === '--caps') {
-      const value = argv[i + 1];
-      if (value === undefined) {
-        console.error('missing value for --caps');
-        return 2;
-      }
-      capsPath = value;
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith('--caps=')) {
-      capsPath = arg.slice('--caps='.length);
+    const capsHit = consumeFlagWithValue(argv, i, 'caps');
+    if (capsHit) {
+      if (capsHit.err) return capsHit.err;
+      capsPath = capsHit.value;
+      i = capsHit.i;
       continue;
     }
     console.error(`unknown option: ${arg}`);

--- a/tools/tf-lang-cli/tests/laws.cli.test.mjs
+++ b/tools/tf-lang-cli/tests/laws.cli.test.mjs
@@ -1,0 +1,111 @@
+// @tf-test kind=infra area=tools speed=fast deps=node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+
+function writePipeline(tmpDir, fileName, nodes) {
+  const pipeline = {
+    pipeline_id: "cli.laws.test",
+    effects: "Outbound",
+    nodes,
+  };
+  const target = join(tmpDir, fileName);
+  writeFileSync(target, JSON.stringify(pipeline, null, 2));
+  return target;
+}
+
+test("tf laws reports PASS without counterexamples when exclusivity holds", () => {
+  const tmp = mkdtempSync(join(os.tmpdir(), "tf-laws-pass-"));
+  const file = writePipeline(tmp, "pass.l0.json", [
+    {
+      id: "P_then",
+      kind: "Publish",
+      channel: "metric:then",
+      qos: "at_least_once",
+      payload: { value: 1 },
+      when: "@decision",
+      metadata: { branch: { id: "decision", path: "then" } },
+    },
+    {
+      id: "P_else",
+      kind: "Publish",
+      channel: "metric:else",
+      qos: "at_least_once",
+      payload: { value: 1 },
+      when: { op: "not", var: "decision" },
+      metadata: { branch: { id: "decision", path: "else" } },
+    },
+    {
+      id: "P_record",
+      kind: "Publish",
+      channel: "policy:record",
+      qos: "at_least_once",
+      payload: { entry: { id: "1" } },
+    },
+    {
+      id: "P_secure",
+      kind: "Publish",
+      channel: "policy:secure",
+      qos: "at_least_once",
+      payload: { envelope: { ciphertext: "ABC" } },
+    },
+  ]);
+
+  const result = spawnSync("node", ["tools/tf-lang-cli/index.mjs", "laws", "--check", file, "--goal", "branch-exclusive"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}\n${result.stdout}`);
+  assert.match(result.stdout, /status: GREEN/);
+  assert.match(result.stdout, /branch_exclusive: PASS/);
+  assert.match(result.stdout, /monotonic_log: PASS/);
+  assert.match(result.stdout, /confidential_envelope: PASS/);
+  assert.doesNotMatch(result.stdout, /Counterexample:/);
+});
+
+test("tf laws reports RED with counterexample when exclusivity fails", () => {
+  const tmp = mkdtempSync(join(os.tmpdir(), "tf-laws-fail-"));
+  const file = writePipeline(tmp, "fail.l0.json", [
+    {
+      id: "P_then",
+      kind: "Publish",
+      channel: "metric:then",
+      qos: "at_least_once",
+      payload: { value: 1 },
+      when: "@decision",
+      metadata: { branch: { id: "decision", path: "then" } },
+    },
+    {
+      id: "P_else",
+      kind: "Publish",
+      channel: "metric:else",
+      qos: "at_least_once",
+      payload: { value: 1 },
+      when: "@decision",
+      metadata: { branch: { id: "decision", path: "else" } },
+    },
+  ]);
+
+  const result = spawnSync("node", [
+    "tools/tf-lang-cli/index.mjs",
+    "laws",
+    "--check",
+    file,
+    "--goal",
+    "branch-exclusive",
+    "--max-bools",
+    "3",
+  ], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stdout}`);
+  assert.match(result.stdout, /branch_exclusive: RED/);
+  assert.match(result.stdout, /Counterexample: .*reason=overlap.*guard=@decision/);
+});

--- a/tools/tf-lang-cli/tests/laws.json-mode.test.mjs
+++ b/tools/tf-lang-cli/tests/laws.json-mode.test.mjs
@@ -1,0 +1,129 @@
+// @tf-test kind=infra area=tools speed=fast deps=node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+
+function writePipeline(tmpDir, fileName, nodes) {
+  const pipeline = {
+    pipeline_id: "cli.laws.json.test",
+    effects: "Outbound",
+    nodes,
+  };
+  const target = join(tmpDir, fileName);
+  writeFileSync(target, JSON.stringify(pipeline, null, 2));
+  return target;
+}
+
+function writeCaps(tmpDir, fileName, data) {
+  const target = join(tmpDir, fileName);
+  writeFileSync(target, JSON.stringify(data, null, 2));
+  return target;
+}
+
+const defaultPolicy = join(process.cwd(), "policy", "policy.allow.json");
+
+test("tf laws --json emits deterministic keys and GREEN status", () => {
+  const tmp = mkdtempSync(join(os.tmpdir(), "tf-laws-json-pass-"));
+  const file = writePipeline(tmp, "pass.l0.json", [
+    {
+      id: "P_then",
+      kind: "Publish",
+      channel: "metric:then",
+      when: "@decision",
+      metadata: { branch: { id: "decision", path: "then" } },
+    },
+    {
+      id: "P_else",
+      kind: "Publish",
+      channel: "metric:else",
+      when: { op: "not", var: "decision" },
+      metadata: { branch: { id: "decision", path: "else" } },
+    },
+  ]);
+  const capsPath = writeCaps(tmp, "caps.json", []);
+
+  const result = spawnSync(
+    "node",
+    [
+      "tools/tf-lang-cli/index.mjs",
+      "laws",
+      "--check",
+      file,
+      "--goal",
+      "branch-exclusive",
+      "--json",
+      "--policy",
+      defaultPolicy,
+      "--caps",
+      capsPath,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.status, "GREEN");
+  assert.deepEqual(Object.keys(payload.laws), [
+    "branch_exclusive",
+    "monotonic_log",
+    "confidential_envelope",
+  ]);
+  assert.ok(!("counterexample" in payload));
+});
+
+test("tf laws --json reports RED status and counterexample payload", () => {
+  const tmp = mkdtempSync(join(os.tmpdir(), "tf-laws-json-fail-"));
+  const file = writePipeline(tmp, "fail.l0.json", [
+    {
+      id: "P_then",
+      kind: "Publish",
+      channel: "metric:then",
+      when: "@decision",
+      metadata: { branch: { id: "decision", path: "then" } },
+    },
+    {
+      id: "P_else",
+      kind: "Publish",
+      channel: "metric:else",
+      when: "@decision",
+      metadata: { branch: { id: "decision", path: "else" } },
+    },
+  ]);
+  const capsPath = writeCaps(tmp, "caps.json", []);
+
+  const result = spawnSync(
+    "node",
+    [
+      "tools/tf-lang-cli/index.mjs",
+      "laws",
+      "--check",
+      file,
+      "--goal",
+      "branch-exclusive",
+      "--json",
+      "--policy",
+      defaultPolicy,
+      "--caps",
+      capsPath,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.status, "RED");
+  assert.equal(payload.counterexample.goal, "branch-exclusive");
+  assert.equal(payload.counterexample.reason, "overlap");
+  assert.equal(payload.counterexample.guard, "@decision");
+  assert.deepEqual(Object.keys(payload.counterexample.assignment), ["decision"]);
+});


### PR DESCRIPTION
## Summary
- tighten branch exclusivity normalization, metadata handling, and solver inputs while aligning monotonic and confidentiality law statuses
- return structured counterexample payloads and extend `tf laws` with JSON reporting, policy/caps flags, and deterministic summaries
- document law check usage and add regression coverage for normalization, counterexample bounds, and CLI JSON mode

## Testing
- node --test tests/checker/laws-branch-exclusive.test.mjs tests/checker/laws-branch-exclusive.normalize.test.mjs
- node --test tests/checker/laws-monotonic-log.test.mjs tests/checker/laws-confidential-envelope.test.mjs
- node --test tests/prover/counterexample.bounds.test.mjs
- node --test tools/tf-lang-cli/tests/laws.cli.test.mjs
- node --test tools/tf-lang-cli/tests/laws.json-mode.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dc6fe20ed48320a8ea5fb4c7fd3080